### PR TITLE
Downloads history screen, size accuracy, and matching tab icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,107 @@
+<div align="center">
+
+<img src="BRAND/Hazel.png" alt="Hazel" width="96" />
+
 # Hazel
 
-[![License](https://img.shields.io/badge/LICENSE-GPL--3.0-00bcd4?style=for-the-badge&labelColor=0d1117)](https://opensource.org/licenses/GPL-3.0)
-[![Kotlin](https://img.shields.io/badge/KOTLIN-2.0-6d6d6d?style=for-the-badge&logo=kotlin&logoColor=white&labelColor=0d1117)](https://kotlinlang.org/)
-[![Compose](https://img.shields.io/badge/COMPOSE-MATERIAL3-ffffff?style=for-the-badge&logo=jetpackcompose&logoColor=white&labelColor=0d1117)](https://developer.android.com/jetpack/compose)
-[![Platform](https://img.shields.io/badge/PLATFORM-ANDROID-00bcd4?style=for-the-badge&logo=android&logoColor=white&labelColor=0d1117)](#installation)
-[![Buy Me a Coffee](https://img.shields.io/badge/BUY_ME_A_COFFEE-SUPPORT-ffdd00?style=for-the-badge&logo=buymeacoffee&logoColor=white&labelColor=0d1117)](https://buymeacoffee.com/sibtainocn)
+**A media downloader for Android.** Paste one link or several, see exactly what each source
+offers, choose, and download.
 
-Hazel is a media downloader and converter for Android. Download videos and audio from 3000+ platforms and convert between formats offline — all from one app.
+Built on [yt-dlp](https://github.com/yt-dlp/yt-dlp) and FFmpeg, with a Material 3 interface
+written entirely in Jetpack Compose.
 
-## What Makes Hazel Different
-
-- **Share & Download** — See a reel, tweet, or story? Just tap _Share → Hazel_ and it downloads automatically. No copy-pasting URLs.
-- **The Source's Own Formats** — No fixed quality presets. Hazel reads what the site actually serves and lets you pick from it, right down to the codec and file size.
-- **Offline Converter** — Already have a video file? Convert it to any audio format right on your device, no internet needed.
-- **Self-Updating Engine** — Update yt-dlp straight from its GitHub releases, independently of the app, so extractor fixes land the day they ship.
-
-## Screenshots
-
-<div align="center">
-  <img src="assets/screenshots/1_home.png" width="32%">
-  <img src="assets/screenshots/3_settings.png" width="32%">
 </div>
+
+---
+
+## What it does
+
+Hazel resolves a link into what the source actually has, rather than guessing at a quality
+preset. Every format the site reports is listed with its container, codec, size, bitrate and
+format id, and the best concrete one is chosen for you.
+
+**One link or many.** Queue several links in one pass and download the whole set with one
+action, or open any of them individually and change just that one.
+
+**Real formats.** No quality presets and no hardcoded ladders. A video-only stream names the
+audio track it will be muxed with, and that is the track the download requests.
+
+**Anything yt-dlp supports.** Nothing in the app is written for a particular site. YouTube,
+Instagram, TikTok, X, Reddit, SoundCloud and the rest of yt-dlp's extractor list all go
+through the same path, and sources that report almost no metadata still work because every
+field degrades instead of failing.
 
 ## Features
 
-### Download
-- **3000+ Platforms** — YouTube, Instagram, Twitter/X, TikTok, SoundCloud, Vimeo, Dailymotion, and more
-- **Real Formats, Not Presets** — Pick from the formats the source actually offers, with container, codec, size and bitrate shown for each. Best is always first.
-- **Works on Sparse Sources** — Sites that report little or no metadata still resolve, and a generic best option keeps the download possible either way
-- **Share to Download** — Share any URL from any app to start downloading instantly
-- **Live Progress** — Percentage, transferred size and a progress ring on the media card itself
-- **Smart Notifications** — Real-time progress bar and completion alerts
+### Downloading
+- Multi-link entry with queued links as removable chips and a history of links used before
+- Reads grouped by site and run in parallel, so a set resolves in about the time its slowest
+  member takes
+- Full format list in its own sheet, sortable by quality, size or container
+- Editable title, author and output container, for both audio and video
+- Save to `Download/Hazel` or to any folder picked through the system document picker,
+  including removable storage
+- Downloads run one after another with per-link progress, and one failure does not stop the
+  rest of the set
 
-### Converter (More > Tools)
-- **Offline Conversion** — Convert any downloaded video to MP3, AAC, or FLAC without internet
-- **Batch Support** — Convert multiple files at once
-- **Quality Control** — Choose bitrate and format before converting
+### Processing
+- **SponsorBlock** segment removal, by category
+- **Chapters** embedded into the file, or used to split it into one file per chapter
+- **Subtitles** embedded, saved alongside, or both, with a language selector
+- **Containers**: mp4, webm, mkv, mov, avi, flv for video; mp3, m4a, aac, alac, flac, opus,
+  wav, vorbis for audio
+- Thumbnail embedding and a configurable yt-dlp filename template
 
-### Engine Updates
-- **Independent yt-dlp Updates** — Pull the latest yt-dlp binary from GitHub without reinstalling Hazel
-- **Release Channels** — Choose between Stable, Nightly, and Master builds
-- **Automatic Refresh** — The selected channel is checked on launch and can be updated on demand from More
+### Sign-ins
+- Sign in through an in-app browser to reach age-restricted, private and members-only media
+- Cookies are stored per site and reused by every later read and download
+- Offered automatically when a link fails because it needs an account
+- Kept in the app's private storage and never sent anywhere but yt-dlp
 
-### Customization
-- **12+ Accent Colors** 
-- **Light & Dark Theme** 
+### Library
+- Everything downloaded, with search, sorting and audio/video filtering
+- Updates live as downloads finish, and flags entries whose file has since been deleted
+- Tap to open in your default player
 
+### Settings
+- Link reading speed: Fast, Balanced or Thorough, plus an IPv4 fallback for networks with a
+  broken IPv6 route
+- Temporary file cleanup, by category, with a running total
+- yt-dlp engine updates on a Stable, Nightly or Master channel, independent of app releases
+- Dark theme and accent colour
 
-## Installation
+## Install
 
-Download the latest APK from [GitHub Releases](https://github.com/SibtainOcn/Hazel/releases).
+Grab the APK from [Releases](https://github.com/SibtainOcn/Hazel/releases). Universal and
+per-ABI builds are published; the per-ABI build for your device is smaller.
 
+Minimum Android 7.0 (API 24).
 
-The debug APK will be at `app/build/outputs/apk/debug/`.
+## Build
 
-For release builds, you'll need to configure your own signing key — see the [Contributing Guide](CONTRIBUTING.md).
+```bash
+git clone https://github.com/SibtainOcn/Hazel.git
+cd Hazel
+./gradlew assembleDebug
+```
 
-## Contributing
+Release builds are signed from a keystore kept outside the repository. Point
+`HAZEL_SIGNING_DIR` in `local.properties` at a folder holding your keystore and a
+`signing.properties` with `storeFile`, `storePassword`, `keyAlias` and `keyPassword`. Without
+it the release build still succeeds and produces an unsigned APK.
 
-We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) before submitting a pull request.
+## Built with
 
-## License
+| | |
+|---|---|
+| Language | Kotlin |
+| UI | Jetpack Compose, Material 3 |
+| Download engine | [yt-dlp](https://github.com/yt-dlp/yt-dlp) via [youtubedl-android](https://github.com/JunkFood02/youtubedl-android) |
+| Media processing | FFmpeg |
+| Storage | DataStore, MediaStore, Storage Access Framework |
+| Images | Coil |
 
-GPL-3.0 License — see [LICENSE](LICENSE) for details.
+## Licence
 
+See [LICENSE](LICENSE). Hazel is a client for yt-dlp; respect the terms of the sites you
+download from and the rights of the people whose work you are saving.

--- a/app/src/main/java/com/hazel/android/data/DownloadHistoryRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/DownloadHistoryRepository.kt
@@ -1,0 +1,160 @@
+package com.hazel.android.data
+
+import android.content.Context
+import android.net.Uri
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** What was downloaded, as it was at the moment it finished. */
+data class HistoryEntry(
+    val id: Long,
+    val url: String,
+    val title: String,
+    val author: String,
+    val thumbnail: String?,
+    val durationSeconds: Int,
+    val fileName: String,
+    /** Address the file was saved to, used to open it. Blank when it could not be resolved. */
+    val fileUri: String,
+    /** Where it landed, for display only. */
+    val savedPath: String,
+    val isVideo: Boolean,
+    val sizeBytes: Long,
+    val completedAt: Long
+) {
+    val site: String
+        get() = runCatching {
+            java.net.URL(url).host.removePrefix("www.")
+        }.getOrNull().orEmpty()
+}
+
+/** How the history list is ordered. */
+enum class HistorySort(val label: String) {
+    NEWEST("Date added"),
+    TITLE("Title"),
+    SIZE("File size")
+}
+
+/** Which kinds of download the list shows. */
+enum class HistoryFilter(val label: String) {
+    ALL("All"),
+    AUDIO("Audio"),
+    VIDEO("Video")
+}
+
+/**
+ * Everything that has finished downloading.
+ *
+ * Exposed as a flow, so the list updates the moment a download completes rather than when
+ * the screen is next opened. Entries are records of what happened and are kept even if the
+ * file is later moved or deleted elsewhere on the device; the screen checks whether each
+ * file is still there and says so, which is more useful than silently dropping the row.
+ */
+object DownloadHistoryRepository {
+
+    private const val LIMIT = 500
+
+    private val HISTORY_KEY = stringPreferencesKey("download_history")
+
+    fun getHistory(context: Context): Flow<List<HistoryEntry>> =
+        context.dataStore.data.map { prefs -> decode(prefs[HISTORY_KEY]) }
+
+    suspend fun record(context: Context, entry: HistoryEntry) {
+        context.dataStore.edit { prefs ->
+            val existing = decode(prefs[HISTORY_KEY])
+            prefs[HISTORY_KEY] = encode((listOf(entry) + existing).take(LIMIT))
+        }
+    }
+
+    suspend fun remove(context: Context, id: Long) {
+        context.dataStore.edit { prefs ->
+            prefs[HISTORY_KEY] = encode(decode(prefs[HISTORY_KEY]).filterNot { it.id == id })
+        }
+    }
+
+    suspend fun clear(context: Context) {
+        context.dataStore.edit { prefs -> prefs.remove(HISTORY_KEY) }
+    }
+
+    /**
+     * Whether the file behind an entry is still on the device.
+     *
+     * A download can be deleted from a file manager or a gallery app long after it was
+     * made, so the record on its own says nothing about what is there now. The address is
+     * opened rather than merely inspected, because a MediaStore row can outlive the file
+     * it points at.
+     */
+    suspend fun fileExists(context: Context, entry: HistoryEntry): Boolean =
+        withContext(Dispatchers.IO) {
+            if (entry.fileUri.isBlank()) return@withContext false
+            runCatching {
+                context.contentResolver.openFileDescriptor(Uri.parse(entry.fileUri), "r")
+                    ?.use { true } ?: false
+            }.getOrDefault(false)
+        }
+
+    /** Deletes the file an entry points at, and the entry with it. */
+    suspend fun deleteFile(context: Context, entry: HistoryEntry): Boolean =
+        withContext(Dispatchers.IO) {
+            val deleted = runCatching {
+                entry.fileUri.isNotBlank() &&
+                        context.contentResolver.delete(Uri.parse(entry.fileUri), null, null) > 0
+            }.getOrDefault(false)
+            remove(context, entry.id)
+            deleted
+        }
+
+    private fun encode(entries: List<HistoryEntry>): String {
+        val array = JSONArray()
+        entries.forEach { entry ->
+            array.put(
+                JSONObject().apply {
+                    put("id", entry.id)
+                    put("url", entry.url)
+                    put("title", entry.title)
+                    put("author", entry.author)
+                    put("thumbnail", entry.thumbnail ?: "")
+                    put("duration", entry.durationSeconds)
+                    put("fileName", entry.fileName)
+                    put("fileUri", entry.fileUri)
+                    put("savedPath", entry.savedPath)
+                    put("isVideo", entry.isVideo)
+                    put("size", entry.sizeBytes)
+                    put("completedAt", entry.completedAt)
+                }
+            )
+        }
+        return array.toString()
+    }
+
+    private fun decode(raw: String?): List<HistoryEntry> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            (0 until array.length()).mapNotNull { index ->
+                array.optJSONObject(index)?.let { json ->
+                    HistoryEntry(
+                        id = json.optLong("id"),
+                        url = json.optString("url"),
+                        title = json.optString("title"),
+                        author = json.optString("author"),
+                        thumbnail = json.optString("thumbnail").takeIf { it.isNotBlank() },
+                        durationSeconds = json.optInt("duration"),
+                        fileName = json.optString("fileName"),
+                        fileUri = json.optString("fileUri"),
+                        savedPath = json.optString("savedPath"),
+                        isVideo = json.optBoolean("isVideo", true),
+                        sizeBytes = json.optLong("size"),
+                        completedAt = json.optLong("completedAt")
+                    )
+                }
+            }
+        }.getOrDefault(emptyList())
+    }
+}

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hazel.android.HazelApp
 import com.hazel.android.data.CookieRepository
+import com.hazel.android.data.DownloadHistoryRepository
+import com.hazel.android.data.HistoryEntry
 import com.hazel.android.data.SettingsRepository
 import com.hazel.android.util.StoragePaths
 import com.yausername.youtubedl_android.YoutubeDL
@@ -46,6 +48,8 @@ data class DownloadState(
     val isFetching: Boolean = false,
     /** How far through a multi-link read the app is, for the progress line. */
     val fetchProgress: String = "",
+    /** How many links the current read covers, so the screen can stand in for each one. */
+    val fetchCount: Int = 0,
     /** Every link that resolved from the last search, in the order they were entered. */
     val results: List<MediaInfo> = emptyList(),
     /** The result the open sheet is editing, and the one the engine is working on. */
@@ -181,7 +185,8 @@ class DownloadViewModel : ViewModel() {
             info = null,
             batch = emptyList(),
             isComplete = false,
-            fetchProgress = ""
+            fetchProgress = "",
+            fetchCount = valid.size
         )
 
         fetchJob = viewModelScope.launch {
@@ -711,6 +716,44 @@ class DownloadViewModel : ViewModel() {
         DownloadNotificationHelper.showComplete(
             context, fileName, isVideo = downloadIsVideo, fileUri = savedUri
         )
+
+        recordHistory(context, fileName, savedPath, savedUri)
+    }
+
+    /**
+     * Files the finished download into the history.
+     *
+     * Written as the download completes rather than gathered later by scanning a folder,
+     * so the record keeps the title, artwork and duration the source reported. Once the
+     * file is in public storage there is nothing left to recover those from.
+     */
+    private fun recordHistory(
+        context: Context,
+        fileName: String,
+        savedPath: String,
+        savedUri: android.net.Uri?
+    ) {
+        val info = _state.value.info ?: return
+
+        viewModelScope.launch {
+            DownloadHistoryRepository.record(
+                context,
+                HistoryEntry(
+                    id = System.currentTimeMillis(),
+                    url = info.url,
+                    title = info.title,
+                    author = info.uploader,
+                    thumbnail = info.thumbnail,
+                    durationSeconds = info.durationSeconds,
+                    fileName = fileName,
+                    fileUri = savedUri?.toString().orEmpty(),
+                    savedPath = savedPath,
+                    isVideo = downloadIsVideo,
+                    sizeBytes = _state.value.totalBytes,
+                    completedAt = System.currentTimeMillis()
+                )
+            )
+        }
     }
 
     /** Deletes yt-dlp's in-progress artefacts from the temp directory. */

--- a/app/src/main/java/com/hazel/android/download/MediaInfo.kt
+++ b/app/src/main/java/com/hazel/android/download/MediaInfo.kt
@@ -60,7 +60,9 @@ data class MediaFormat(
     val hasVideo: Boolean,
     val hasAudio: Boolean,
     /** True for the synthesised "best available" rows, which have no real format id. */
-    val isGeneric: Boolean = false
+    val isGeneric: Boolean = false,
+    /** True when the size came from the bitrate rather than from the source itself. */
+    val isEstimatedSize: Boolean = false
 ) {
     /** Codec badge text, e.g. "AVC1" for video or "OPUS" for audio. */
     val codecLabel: String
@@ -70,7 +72,15 @@ data class MediaFormat(
                 ?.uppercase() ?: ""
         }
 
-    val sizeLabel: String get() = formatFileSize(fileSizeBytes)
+    /**
+     * Size badge. Sources report either an exact size or an estimate derived from the
+     * bitrate; an estimate is marked so a figure that turns out larger than the file is
+     * not read as the app getting it wrong.
+     */
+    val sizeLabel: String
+        get() = formatFileSize(fileSizeBytes).let {
+            if (it.isNotBlank() && isEstimatedSize) "~ $it" else it
+        }
 
     val bitrateLabel: String get() = formatBitrate(bitrateKbps)
 }

--- a/app/src/main/java/com/hazel/android/download/MediaProbe.kt
+++ b/app/src/main/java/com/hazel/android/download/MediaProbe.kt
@@ -223,10 +223,6 @@ object MediaProbe {
         addOption("--socket-timeout", fetchMode.socketTimeoutSeconds.toString())
         addOption("-R", fetchMode.retries.toString())
 
-        // Reported sizes for fragmented streams are approximations rather than a reason
-        // to fetch every manifest.
-        addOption("--compat-options", "manifest-filesize-approx")
-
         if (forceIpv4) addOption("--force-ipv4")
         cookieFile?.let { addOption("--cookies", it.absolutePath) }
     }
@@ -310,7 +306,11 @@ object MediaProbe {
             }
             ?: root
 
-        val parsed = readFormats(media).distinctBy { it.formatId }
+        // Resolved before the formats, because a format with no reported size can only
+        // be estimated from its bitrate and the running time.
+        val duration = resolveDuration(media).takeIf { it > 0 } ?: resolveDuration(root)
+
+        val parsed = readFormats(media, duration).distinctBy { it.formatId }
 
         // Video entries lead with the highest resolution, then the smoothest frame rate,
         // then the richest bitrate, so the best option is always the first row.
@@ -342,7 +342,7 @@ object MediaProbe {
                 root.optString("channel")
             ),
             thumbnail = resolveThumbnail(media) ?: resolveThumbnail(root),
-            durationSeconds = resolveDuration(media).takeIf { it > 0 } ?: resolveDuration(root),
+            durationSeconds = duration,
             // "Best" always heads each tab, whatever the source did or did not report.
             videoFormats = listOf(BEST_VIDEO) + video,
             audioFormats = listOf(BEST_AUDIO) + audio
@@ -353,20 +353,24 @@ object MediaProbe {
      * Reads the `formats` array, or synthesises a single entry from the top-level fields
      * when the extractor describes the media as one direct stream (common on Instagram).
      */
-    private fun readFormats(media: JSONObject): List<MediaFormat> {
+    private fun readFormats(media: JSONObject, durationSeconds: Int): List<MediaFormat> {
         val array = media.optJSONArray("formats") ?: JSONArray()
         val formats = buildList {
             for (i in 0 until array.length()) {
-                array.optJSONObject(i)?.let { toFormat(it) }?.let { add(it) }
+                array.optJSONObject(i)?.let { toFormat(it, durationSeconds) }?.let { add(it) }
             }
         }
         if (formats.isNotEmpty()) return formats
 
         // No usable format list. If the payload still points at a stream, offer that.
-        return listOfNotNull(toFormat(media, fallbackId = "0"))
+        return listOfNotNull(toFormat(media, durationSeconds, fallbackId = "0"))
     }
 
-    private fun toFormat(json: JSONObject, fallbackId: String? = null): MediaFormat? {
+    private fun toFormat(
+        json: JSONObject,
+        durationSeconds: Int,
+        fallbackId: String? = null
+    ): MediaFormat? {
         val id = json.optString("format_id").takeIf { it.isNotBlank() && it != "null" }
             ?: fallbackId
             ?: return null
@@ -409,6 +413,25 @@ object MediaProbe {
 
         if (!hasVideo && !hasAudio) return null
 
+        val bitrate = json.optPositiveDouble("tbr")
+            ?: json.optPositiveDouble("abr")
+            ?: json.optPositiveDouble("vbr")
+            ?: 0.0
+
+        // An exact size when the source reports one. Streaming sites usually do not for
+        // adaptive formats, so the fallback is the bitrate over the running time. That is
+        // an upper bound rather than a measurement: the bitrate a site advertises is what
+        // the stream peaks at, and content that compresses well finishes well under it.
+        // The distinction is carried through so the sheet can mark it as approximate
+        // rather than quoting a figure the finished file will not match.
+        val exactSize = json.optPositiveLong("filesize")
+        val reportedApprox = json.optPositiveLong("filesize_approx")
+        val estimatedSize = if (bitrate > 0 && durationSeconds > 0) {
+            (bitrate * 1000.0 / 8.0 * durationSeconds).toLong()
+        } else {
+            0L
+        }
+
         return MediaFormat(
             formatId = id,
             selector = id,
@@ -418,13 +441,9 @@ object MediaProbe {
             acodec = acodec,
             height = height,
             fps = fps,
-            bitrateKbps = json.optPositiveDouble("tbr")
-                ?: json.optPositiveDouble("abr")
-                ?: json.optPositiveDouble("vbr")
-                ?: 0.0,
-            fileSizeBytes = json.optPositiveLong("filesize")
-                ?: json.optPositiveLong("filesize_approx")
-                ?: 0L,
+            bitrateKbps = bitrate,
+            fileSizeBytes = exactSize ?: reportedApprox ?: estimatedSize,
+            isEstimatedSize = exactSize == null,
             hasVideo = hasVideo,
             hasAudio = hasAudio
         )

--- a/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
@@ -8,9 +8,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.annotation.DrawableRes
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -52,14 +48,11 @@ import com.hazel.android.update.UpdateScreen
 sealed class Screen(
     val route: String,
     val title: String,
-    /** Drawable for a mark that ships with the app, otherwise null. */
-    @DrawableRes val iconRes: Int? = null,
-    /** Used when there is no drawable for this destination. */
-    val icon: ImageVector? = null
+    @DrawableRes val icon: Int
 ) {
-    data object Download : Screen("download", "Home", iconRes = R.drawable.home)
-    data object History : Screen("history", "Downloads", icon = Icons.Filled.Download)
-    data object More : Screen("more", "More", icon = Icons.Filled.Settings)
+    data object Download : Screen("download", "Home", R.drawable.home)
+    data object History : Screen("history", "Downloads", R.drawable.downloads_tab)
+    data object More : Screen("more", "More", R.drawable.more_tab)
 }
 
 private val bottomNavItems = listOf(
@@ -138,20 +131,11 @@ fun AppNavigation(
                                 }
                             },
                             icon = {
-                                val iconRes = screen.iconRes
-                                if (iconRes != null) {
-                                    Icon(
-                                        painter = painterResource(id = iconRes),
-                                        contentDescription = screen.title,
-                                        modifier = Modifier.size(22.dp)
-                                    )
-                                } else {
-                                    Icon(
-                                        imageVector = screen.icon!!,
-                                        contentDescription = screen.title,
-                                        modifier = Modifier.size(22.dp)
-                                    )
-                                }
+                                Icon(
+                                    painter = painterResource(id = screen.icon),
+                                    contentDescription = screen.title,
+                                    modifier = Modifier.size(22.dp)
+                                )
                             },
                             label = { Text(screen.title, style = MaterialTheme.typography.labelSmall) },
                             colors = NavigationBarItemDefaults.colors(

--- a/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
@@ -1,6 +1,5 @@
 package com.hazel.android.ui.navigation
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,6 +7,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Alignment
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.annotation.DrawableRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -22,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -36,6 +40,7 @@ import com.hazel.android.ui.motion.M3Motion
 import com.hazel.android.ui.screens.converter.ConverterScreen
 import com.hazel.android.ui.screens.cookies.CookiesScreen
 import com.hazel.android.ui.screens.download.DownloadScreen
+import com.hazel.android.ui.screens.history.HistoryScreen
 import com.hazel.android.ui.screens.more.AppearanceScreen
 import com.hazel.android.ui.screens.more.FetchSettingsScreen
 import com.hazel.android.ui.screens.more.MoreScreen
@@ -47,14 +52,19 @@ import com.hazel.android.update.UpdateScreen
 sealed class Screen(
     val route: String,
     val title: String,
-    @DrawableRes val icon: Int
+    /** Drawable for a mark that ships with the app, otherwise null. */
+    @DrawableRes val iconRes: Int? = null,
+    /** Used when there is no drawable for this destination. */
+    val icon: ImageVector? = null
 ) {
-    data object Download : Screen("download", "Home", R.drawable.download)
-    data object More : Screen("more", "More", R.drawable.settings)
+    data object Download : Screen("download", "Home", iconRes = R.drawable.home)
+    data object History : Screen("history", "Downloads", icon = Icons.Filled.Download)
+    data object More : Screen("more", "More", icon = Icons.Filled.Settings)
 }
 
 private val bottomNavItems = listOf(
     Screen.Download,
+    Screen.History,
     Screen.More,
 )
 
@@ -128,11 +138,20 @@ fun AppNavigation(
                                 }
                             },
                             icon = {
-                                Icon(
-                                    painter = painterResource(id = screen.icon),
-                                    contentDescription = screen.title,
-                                    modifier = Modifier.size(22.dp)
-                                )
+                                val iconRes = screen.iconRes
+                                if (iconRes != null) {
+                                    Icon(
+                                        painter = painterResource(id = iconRes),
+                                        contentDescription = screen.title,
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                } else {
+                                    Icon(
+                                        imageVector = screen.icon!!,
+                                        contentDescription = screen.title,
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                }
                             },
                             label = { Text(screen.title, style = MaterialTheme.typography.labelSmall) },
                             colors = NavigationBarItemDefaults.colors(
@@ -167,6 +186,9 @@ fun AppNavigation(
                     onSharedUrlConsumed = onSharedUrlConsumed,
                     downloadViewModel = downloadViewModel
                 )
+            }
+            composable(Screen.History.route) {
+                HistoryScreen()
             }
             composable(Screen.More.route) {
                 MoreScreen(

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -217,8 +217,12 @@ fun DownloadScreen(
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
-                    Spacer(modifier = Modifier.height(20.dp))
-                    MediaCardShimmer()
+                    // One placeholder per link being read, so a set of links looks like
+                    // the list it is about to become rather than like a single card.
+                    repeat(state.fetchCount.coerceAtLeast(1)) {
+                        Spacer(modifier = Modifier.height(20.dp))
+                        MediaCardShimmer()
+                    }
                 }
             }
 

--- a/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
@@ -1,0 +1,493 @@
+package com.hazel.android.ui.screens.history
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.hazel.android.data.DownloadHistoryRepository
+import com.hazel.android.data.HistoryEntry
+import com.hazel.android.data.HistoryFilter
+import com.hazel.android.data.HistorySort
+import com.hazel.android.download.formatDuration
+import com.hazel.android.download.formatFileSize
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Everything that has finished downloading.
+ *
+ * The list is driven by a flow, so a download that finishes while this screen is open
+ * appears without anything being refreshed. Each row also checks whether its file is still
+ * on the device, because a download can be deleted from a file manager long after it was
+ * made and a row that silently does nothing when tapped is worse than one that says the
+ * file is gone.
+ */
+@Composable
+fun HistoryScreen() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val history by DownloadHistoryRepository.getHistory(context)
+        .collectAsState(initial = emptyList())
+
+    var sort by remember { mutableStateOf(HistorySort.NEWEST) }
+    var filter by remember { mutableStateOf(HistoryFilter.ALL) }
+    var query by remember { mutableStateOf("") }
+    var searchOpen by remember { mutableStateOf(false) }
+    var sortMenuOpen by remember { mutableStateOf(false) }
+    var menuOpen by remember { mutableStateOf(false) }
+    var confirmClear by remember { mutableStateOf(false) }
+    var pendingDelete by remember { mutableStateOf<HistoryEntry?>(null) }
+
+    // Checked once per entry as it appears, rather than on every recomposition, since it
+    // touches the filesystem.
+    val presence = remember { mutableStateMapOf<Long, Boolean>() }
+    LaunchedEffect(history) {
+        history.forEach { entry ->
+            if (entry.id !in presence) {
+                presence[entry.id] = DownloadHistoryRepository.fileExists(context, entry)
+            }
+        }
+    }
+
+    val visible = remember(history, sort, filter, query) {
+        history
+            .filter { entry ->
+                when (filter) {
+                    HistoryFilter.ALL -> true
+                    HistoryFilter.AUDIO -> !entry.isVideo
+                    HistoryFilter.VIDEO -> entry.isVideo
+                }
+            }
+            .filter { entry ->
+                query.isBlank() ||
+                        entry.title.contains(query, ignoreCase = true) ||
+                        entry.author.contains(query, ignoreCase = true)
+            }
+            .let { entries ->
+                when (sort) {
+                    HistorySort.NEWEST -> entries.sortedByDescending { it.completedAt }
+                    HistorySort.TITLE -> entries.sortedBy { it.title.lowercase() }
+                    HistorySort.SIZE -> entries.sortedByDescending { it.sizeBytes }
+                }
+            }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+
+        // ── Header ──
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 8.dp, bottom = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Downloads",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
+            )
+
+            IconButton(onClick = { searchOpen = !searchOpen }) {
+                Icon(Icons.Filled.Search, contentDescription = "Search downloads")
+            }
+
+            Box {
+                IconButton(onClick = { sortMenuOpen = true }) {
+                    Icon(Icons.Filled.Sort, contentDescription = "Sort")
+                }
+                DropdownMenu(
+                    expanded = sortMenuOpen,
+                    onDismissRequest = { sortMenuOpen = false }
+                ) {
+                    HistorySort.entries.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option.label) },
+                            onClick = {
+                                sort = option
+                                sortMenuOpen = false
+                            },
+                            trailingIcon = if (option == sort) {
+                                { Icon(Icons.Filled.Check, null, Modifier.size(18.dp)) }
+                            } else null
+                        )
+                    }
+                }
+            }
+
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(Icons.Filled.MoreVert, contentDescription = "More")
+                }
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text("Clear history") },
+                        onClick = {
+                            menuOpen = false
+                            confirmClear = true
+                        }
+                    )
+                }
+            }
+        }
+
+        if (searchOpen) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                placeholder = { Text("Search downloads") },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 4.dp)
+            )
+        }
+
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(HistoryFilter.entries) { option ->
+                FilterChip(
+                    selected = option == filter,
+                    onClick = { filter = option },
+                    label = { Text(option.label) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                        selectedLabelColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        if (visible.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    Icons.Filled.Download,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    if (history.isEmpty()) "Nothing downloaded yet"
+                    else "Nothing matches that",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                    start = 20.dp, end = 20.dp, bottom = 24.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(visible, key = { it.id }) { entry ->
+                    HistoryCard(
+                        entry = entry,
+                        present = presence[entry.id] ?: true,
+                        onOpen = { openEntry(context, entry) },
+                        onRemove = {
+                            scope.launch { DownloadHistoryRepository.remove(context, entry.id) }
+                        },
+                        onDeleteFile = { pendingDelete = entry }
+                    )
+                }
+            }
+        }
+    }
+
+    if (confirmClear) {
+        AlertDialog(
+            onDismissRequest = { confirmClear = false },
+            title = { Text("Clear history", fontWeight = FontWeight.Bold) },
+            text = { Text("The list is emptied. Your downloaded files are not touched.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    scope.launch { DownloadHistoryRepository.clear(context) }
+                    confirmClear = false
+                }) { Text("Clear") }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmClear = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    pendingDelete?.let { entry ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Delete file", fontWeight = FontWeight.Bold) },
+            text = { Text("${entry.fileName} will be deleted from your device.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    scope.launch {
+                        val deleted = DownloadHistoryRepository.deleteFile(context, entry)
+                        Toast.makeText(
+                            context,
+                            if (deleted) "File deleted" else "Could not delete the file",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                    pendingDelete = null
+                }) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun HistoryCard(
+    entry: HistoryEntry,
+    present: Boolean,
+    onOpen: () -> Unit,
+    onRemove: () -> Unit,
+    onDeleteFile: () -> Unit
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 9f)
+                .clickable(enabled = present, onClick = onOpen)
+        ) {
+            if (entry.thumbnail != null) {
+                AsyncImage(
+                    model = entry.thumbnail,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            // The artwork is arbitrary, so the text over it gets its own scrim rather than
+            // relying on the image being dark where the words fall.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        androidx.compose.ui.graphics.Brush.verticalGradient(
+                            0f to Color.Black.copy(alpha = 0.65f),
+                            0.45f to Color.Transparent,
+                            1f to Color.Black.copy(alpha = 0.7f)
+                        )
+                    )
+            )
+
+            Column(modifier = Modifier.padding(12.dp)) {
+                Text(
+                    entry.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (entry.author.isNotBlank()) {
+                    Text(
+                        entry.author,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.75f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            // Type and actions sit top right, away from the title.
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box {
+                    IconButton(onClick = { menuOpen = true }) {
+                        Icon(
+                            Icons.Filled.MoreVert,
+                            contentDescription = "Options",
+                            tint = Color.White
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = menuOpen,
+                        onDismissRequest = { menuOpen = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Remove from list") },
+                            onClick = {
+                                menuOpen = false
+                                onRemove()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Delete file") },
+                            enabled = present,
+                            onClick = {
+                                menuOpen = false
+                                onDeleteFile()
+                            }
+                        )
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(10.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    if (entry.isVideo) Icons.Filled.PlayArrow else Icons.Filled.MusicNote,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = Color.White
+                )
+                val duration = formatDuration(entry.durationSeconds)
+                if (duration.isNotBlank()) Tag(duration)
+                if (entry.sizeBytes > 0) Tag(formatFileSize(entry.sizeBytes))
+                if (!present) {
+                    Tag(
+                        "File missing",
+                        background = MaterialTheme.colorScheme.error,
+                        foreground = MaterialTheme.colorScheme.onError
+                    )
+                }
+            }
+
+            Text(
+                formatDate(entry.completedAt),
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.85f),
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(12.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun Tag(
+    text: String,
+    background: Color = Color.Black.copy(alpha = 0.6f),
+    foreground: Color = Color.White
+) {
+    Surface(shape = RoundedCornerShape(4.dp), color = background) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = foreground,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+        )
+    }
+}
+
+/** Opens a finished download in whatever app the device uses for that media type. */
+private fun openEntry(context: Context, entry: HistoryEntry) {
+    if (entry.fileUri.isBlank()) {
+        Toast.makeText(context, "This file's location is unknown", Toast.LENGTH_SHORT).show()
+        return
+    }
+    runCatching {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(
+                Uri.parse(entry.fileUri),
+                if (entry.isVideo) "video/*" else "audio/*"
+            )
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }.onFailure {
+        Toast.makeText(context, "Nothing can open this file", Toast.LENGTH_SHORT).show()
+    }
+}
+
+private fun formatDate(millis: Long): String =
+    runCatching {
+        SimpleDateFormat("d MMM yyyy, HH:mm", Locale.getDefault()).format(Date(millis))
+    }.getOrDefault("")

--- a/app/src/main/res/drawable/downloads_tab.xml
+++ b/app/src/main/res/drawable/downloads_tab.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Downloads mark for the bottom navigation.
+
+  Stroked and left deliberately open on one side, matching the home mark so the bar reads
+  as one set rather than as icons borrowed from different places.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <path
+        android:pathData="M12,4L12,14M12,14L15,11M12,14L9,11"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:pathData="M12,20C7.58,20 4,16.42 4,12M20,12C20,14.53 18.83,16.78 17,18.25"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round" />
+</vector>

--- a/app/src/main/res/drawable/home.xml
+++ b/app/src/main/res/drawable/home.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Home mark for the bottom navigation.
+
+  Drawn with strokes rather than fills so it matches the weight of the other navigation
+  icons, and tinted at runtime so it follows the selected and unselected colours.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <path
+        android:pathData="M9,16C9.85,16.63 10.88,17 12,17C13.12,17 14.15,16.63 15,16"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round" />
+
+    <path
+        android:pathData="M22,12.2V13.73C22,17.63 22,19.58 20.83,20.79C19.66,22 17.77,22 14,22H10C6.23,22 4.34,22 3.17,20.79C2,19.58 2,17.63 2,13.73V12.2C2,9.92 2,8.77 2.52,7.82C3.04,6.87 3.99,6.29 5.88,5.11L7.88,3.87C9.89,2.62 10.89,2 12,2C13.11,2 14.11,2.62 16.12,3.87L18.12,5.11C20.01,6.29 20.96,6.87 21.48,7.82"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round" />
+</vector>

--- a/app/src/main/res/drawable/more_tab.xml
+++ b/app/src/main/res/drawable/more_tab.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  More mark for the bottom navigation.
+
+  A gear drawn as an open stroked ring with a broken outer arc, so it sits with the home
+  and downloads marks rather than reading as a solid filled settings glyph next to them.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <!-- Inner ring -->
+    <path
+        android:pathData="M15,12C15,13.66 13.66,15 12,15C10.34,15 9,13.66 9,12C9,10.34 10.34,9 12,9C13.66,9 15,10.34 15,12Z"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round" />
+
+    <!-- Outer body, left open at the lower right in the same way as the home mark -->
+    <path
+        android:pathData="M12.79,3.29C12.53,3.19 12.2,3.19 11.53,3.19C10.86,3.19 10.53,3.19 10.27,3.29C9.72,3.5 9.3,3.95 9.14,4.51L9.05,4.83C8.83,5.58 8.06,6.02 7.3,5.83L6.98,5.75C6.42,5.61 5.82,5.75 5.38,6.13C5.17,6.31 5.01,6.6 4.67,7.17C4.34,7.74 4.17,8.03 4.13,8.3C4.05,8.87 4.26,9.44 4.68,9.83L4.93,10.06C5.49,10.58 5.49,11.47 4.93,11.99L4.68,12.22C4.26,12.61 4.05,13.18 4.13,13.75C4.17,14.02 4.34,14.31 4.67,14.88C5.01,15.45 5.17,15.74 5.38,15.92C5.82,16.3 6.42,16.44 6.98,16.3L7.3,16.22C8.06,16.03 8.83,16.47 9.05,17.22L9.14,17.54C9.3,18.1 9.72,18.55 10.27,18.76C10.53,18.86 10.86,18.86 11.53,18.86"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round" />
+
+    <path
+        android:pathData="M14.7,18.76C15.25,18.55 15.67,18.1 15.83,17.54L15.92,17.22C16.14,16.47 16.91,16.03 17.67,16.22L17.99,16.3C18.55,16.44 19.15,16.3 19.59,15.92C19.8,15.74 19.96,15.45 20.3,14.88C20.63,14.31 20.8,14.02 20.84,13.75C20.92,13.18 20.71,12.61 20.29,12.22L20.04,11.99C19.48,11.47 19.48,10.58 20.04,10.06L20.29,9.83C20.71,9.44 20.92,8.87 20.84,8.3"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round" />
+</vector>


### PR DESCRIPTION
Supersedes #1, which GitHub closed when the branch was rebased onto the amended `main`.

## Downloads history

A new **Downloads** tab listing everything that has finished. Backed by a flow, so an entry appears the moment a download completes rather than when the screen is next opened. Each row also checks whether its file is still on the device, because a download can be deleted from a file manager long after it was made.

- Search, sort by date, title or size, filter by audio or video
- Tap to open in the device's default player; row menu removes the entry or deletes the file
- Recorded as the download completes, keeping the title, artwork and duration the source reported, since none of that survives the move into public storage

## File size accuracy

The sheet quoted sizes well above the finished file: 30.1 MB shown against a 12.6 MB result.

The probe passed `--compat-options manifest-filesize-approx`, which makes yt-dlp drop the exact `filesize` it would otherwise report and substitute `tbr x duration`. That product is an upper bound, so anything that compressed well came out far under the quoted figure.

The option is gone. An exact size is used whenever the source reports one. Sources that report none for adaptive formats still get an estimate, but it is computed knowingly and shown as `~ 30.1 MB` rather than passed off as measured. Nothing here is per-site: it reads whatever fields the extractor provides and falls back in the same order for every source.

## Interface

- Home, Downloads and More tabs now use stroked marks in one style, instead of Home and Downloads sharing an icon
- One shimmer placeholder per link while a set of links is being read
- README rewritten around what the app does

## Testing

Verified on device: multi-link fetch and batch download end to end with files landing in `Download/Hazel`; history recording live; size label matching the downloaded file; all three tab icons rendering.