### PR TITLE
Warn before downloading the same link twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,4 +131,5 @@ as it now stands rather than how it got here.
 - **Independent yt-dlp updates.** The engine updates separately from the app, on a Stable,
   Nightly or Master channel, so extractor fixes can be picked up the day they ship.
 
-[1.0.0]: https://github.com/SibtainOcn/HAZEL-DLP/releases/tag/v1.0.0
+[Unreleased]: https://github.com/SibtainOcn/Hazel/compare/v1.0.0...main
+[1.0.0]: https://github.com/SibtainOcn/Hazel/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to Hazel are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Everything merged since 1.0.0, plus what is open in review.
+
+### Added
+- **Downloads tab.** Everything that has finished, backed by a flow so an entry appears the
+  moment a download completes. Search, sort by date, title or size, and filter by audio or
+  video. Tapping a row opens the file in the device's default player; the row menu removes
+  the entry or deletes the file.
+- **Already downloaded warning.** Resolving a link that has been downloaded before raises
+  it before the sheet opens, offering to go ahead or leave it. Only a copy still present on
+  the device counts, so an entry whose file was deleted elsewhere does not block anything.
+  Links inside a multi-link set carry a Downloaded tag instead.
+- **Missing files read as missing.** A history row whose file has gone shows its artwork
+  drained of colour and dimmed, alongside the tag saying so.
+- One placeholder per link while a set of links is being read, rather than a single card
+  standing in for the whole set.
+
+### Fixed
+- **File sizes quoted well above the finished file**, 30.1 MB shown against a 12.6 MB
+  result. The probe passed `--compat-options manifest-filesize-approx`, which makes yt-dlp
+  drop the exact size it would otherwise report and substitute bitrate times duration. That
+  product is an upper bound, so anything that compressed well came out far under the quote.
+  An exact size is now used whenever the source reports one; where none is reported the
+  estimate is computed knowingly and shown as `~ 30.1 MB` rather than passed off as
+  measured.
+
+### Changed
+- Home, Downloads and More use stroked marks in one style, instead of Home and Downloads
+  sharing an icon.
+- README rewritten around what the app does.
+
 ## [1.0.0] - 2026-08-29
 
 First release. The app was rebuilt around a single idea: paste one link or several, see

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -40,6 +41,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -59,6 +61,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
+import com.hazel.android.data.DownloadHistoryRepository
+import com.hazel.android.data.HistoryEntry
 import com.hazel.android.data.SearchHistoryRepository
 import com.hazel.android.data.SettingsRepository
 import com.hazel.android.download.BatchItem
@@ -144,6 +148,11 @@ fun DownloadScreen(
         }
     }
 
+    // Links already downloaded, so a repeat can be pointed out before it is started again.
+    val history by DownloadHistoryRepository.getHistory(context)
+        .collectAsState(initial = emptyList())
+    var alreadyHave by remember { mutableStateOf<HistoryEntry?>(null) }
+
     // A single link goes straight to its sheet. A set of links does not, because the list
     // itself is the thing to look at first.
     var autoOpenedFor by remember { mutableStateOf<String?>(null) }
@@ -155,7 +164,15 @@ fun DownloadScreen(
             resolved != autoOpenedFor && !state.isMultiple &&
                     !state.isDownloading && !state.isComplete -> {
                 autoOpenedFor = resolved
-                sheetVisible = true
+
+                // Downloading the same thing twice is usually a mistake rather than a
+                // choice, so it is raised before the sheet opens. Only a copy that is
+                // still on the device counts: an entry whose file has since been deleted
+                // is not a reason to stop anyone downloading it again.
+                val existing = history.firstOrNull { it.url == resolved }
+                    ?.takeIf { DownloadHistoryRepository.fileExists(context, it) }
+
+                if (existing != null) alreadyHave = existing else sheetVisible = true
             }
         }
     }
@@ -240,6 +257,8 @@ fun DownloadScreen(
                     isComplete = batchItem?.state == BatchState.DONE ||
                             (!state.isMultiple && state.isComplete),
                     batchItem = batchItem,
+                    alreadyDownloaded = state.isMultiple &&
+                            history.any { it.url == info.url },
                     onOpenSheet = {
                         downloadViewModel.selectResult(info)
                         sheetVisible = true
@@ -287,6 +306,33 @@ fun DownloadScreen(
                 downloadViewModel.fetchAll(queries)
             },
             onDismiss = { searchOpen = false }
+        )
+    }
+
+    alreadyHave?.let { existing ->
+        AlertDialog(
+            onDismissRequest = { alreadyHave = null },
+            title = { Text("Already downloaded", fontWeight = FontWeight.Bold) },
+            text = {
+                Column {
+                    Text(existing.fileName, style = MaterialTheme.typography.bodyMedium)
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        "Saved to ${existing.savedPath}. Download it again anyway?",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    alreadyHave = null
+                    sheetVisible = true
+                }) { Text("Download again") }
+            },
+            dismissButton = {
+                TextButton(onClick = { alreadyHave = null }) { Text("Leave it") }
+            }
         )
     }
 
@@ -492,6 +538,7 @@ private fun MediaCard(
     totalBytes: Long,
     isComplete: Boolean,
     batchItem: BatchItem?,
+    alreadyDownloaded: Boolean = false,
     onOpenSheet: () -> Unit,
     onCancel: () -> Unit,
     onRemove: (() -> Unit)? = null
@@ -638,6 +685,9 @@ private fun MediaCard(
                                 foreground = MaterialTheme.colorScheme.onPrimary
                             )
                             batchItem?.state == BatchState.QUEUED -> CornerTag(text = "Queued")
+                            // Marks a link in a set that has been downloaded before, where
+                            // there is no dialog to raise it.
+                            alreadyDownloaded -> CornerTag(text = "Downloaded")
                         }
                     }
                 }

--- a/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -332,10 +334,17 @@ private fun HistoryCard(
                 .clickable(enabled = present, onClick = onOpen)
         ) {
             if (entry.thumbnail != null) {
+                // A row whose file has been deleted elsewhere keeps its place in the list,
+                // but the artwork is drained of colour and dimmed so the difference is
+                // visible at a glance rather than only on the tag.
                 AsyncImage(
                     model = entry.thumbnail,
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
+                    alpha = if (present) 1f else 0.7f,
+                    colorFilter = if (present) null else ColorFilter.colorMatrix(
+                        ColorMatrix().apply { setToSaturation(0f) }
+                    ),
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/res/drawable/more_tab.xml
+++ b/app/src/main/res/drawable/more_tab.xml
@@ -2,8 +2,8 @@
 <!--
   More mark for the bottom navigation.
 
-  A gear drawn as an open stroked ring with a broken outer arc, so it sits with the home
-  and downloads marks rather than reading as a solid filled settings glyph next to them.
+  Two sliders, stroked at the same weight as the home and downloads marks so the bar reads
+  as one set.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
@@ -12,23 +12,45 @@
     android:viewportHeight="24"
     android:tint="?attr/colorControlNormal">
 
-    <!-- Inner ring -->
     <path
-        android:pathData="M15,12C15,13.66 13.66,15 12,15C10.34,15 9,13.66 9,12C9,10.34 10.34,9 12,9C13.66,9 15,10.34 15,12Z"
+        android:pathData="M22,6.5H16"
         android:strokeWidth="1.5"
         android:strokeColor="#FFFFFF"
-        android:strokeLineCap="round" />
-
-    <!-- Outer body, left open at the lower right in the same way as the home mark -->
-    <path
-        android:pathData="M12.79,3.29C12.53,3.19 12.2,3.19 11.53,3.19C10.86,3.19 10.53,3.19 10.27,3.29C9.72,3.5 9.3,3.95 9.14,4.51L9.05,4.83C8.83,5.58 8.06,6.02 7.3,5.83L6.98,5.75C6.42,5.61 5.82,5.75 5.38,6.13C5.17,6.31 5.01,6.6 4.67,7.17C4.34,7.74 4.17,8.03 4.13,8.3C4.05,8.87 4.26,9.44 4.68,9.83L4.93,10.06C5.49,10.58 5.49,11.47 4.93,11.99L4.68,12.22C4.26,12.61 4.05,13.18 4.13,13.75C4.17,14.02 4.34,14.31 4.67,14.88C5.01,15.45 5.17,15.74 5.38,15.92C5.82,16.3 6.42,16.44 6.98,16.3L7.3,16.22C8.06,16.03 8.83,16.47 9.05,17.22L9.14,17.54C9.3,18.1 9.72,18.55 10.27,18.76C10.53,18.86 10.86,18.86 11.53,18.86"
-        android:strokeWidth="1.5"
-        android:strokeColor="#FFFFFF"
-        android:strokeLineCap="round" />
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
 
     <path
-        android:pathData="M14.7,18.76C15.25,18.55 15.67,18.1 15.83,17.54L15.92,17.22C16.14,16.47 16.91,16.03 17.67,16.22L17.99,16.3C18.55,16.44 19.15,16.3 19.59,15.92C19.8,15.74 19.96,15.45 20.3,14.88C20.63,14.31 20.8,14.02 20.84,13.75C20.92,13.18 20.71,12.61 20.29,12.22L20.04,11.99C19.48,11.47 19.48,10.58 20.04,10.06L20.29,9.83C20.71,9.44 20.92,8.87 20.84,8.3"
+        android:pathData="M6,6.5H2"
         android:strokeWidth="1.5"
         android:strokeColor="#FFFFFF"
-        android:strokeLineCap="round" />
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:pathData="M10,10C11.93,10 13.5,8.43 13.5,6.5C13.5,4.57 11.93,3 10,3C8.07,3 6.5,4.57 6.5,6.5C6.5,8.43 8.07,10 10,10Z"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:pathData="M22,17.5H18"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:pathData="M8,17.5H2"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:pathData="M14,21C15.93,21 17.5,19.43 17.5,17.5C17.5,15.57 15.93,14 14,14C12.07,14 10.5,15.57 10.5,17.5C10.5,19.43 12.07,21 14,21Z"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
 </vector>


### PR DESCRIPTION
## Already downloaded

Resolving a link that is already in the history raises it before the sheet opens:

> **Already downloaded**
> When Autocorrect Saves Beluga's Life....mp4
> Saved to Download/Hazel. Download it again anyway?
> `Leave it` · `Download again`

Only a copy that is **still on the device** counts. An entry whose file has since been deleted elsewhere is not a reason to stop anyone downloading it again, so the check opens the file rather than trusting the record.

Links inside a multi-link set carry a `Downloaded` corner tag instead, since there is no single sheet to interrupt.

## Missing files read as missing

A history row whose file has gone now shows its artwork drained of colour and dimmed to 70%, alongside the existing `File missing` tag, so the state is visible at a glance.

## Icon

Replaces the More tab icon with the supplied sliders mark. The previous one was hand-built and drew badly at 22dp.

## Note on the size fix from #2

Nothing in it is per-site. The probe reads whatever the extractor provides and falls back in the same order for every source: exact `filesize`, then `filesize_approx`, then `tbr x duration` computed locally and labelled `~`. There is no site list and no special-casing anywhere in that path.

## Testing

Verified on device: re-resolving a previously downloaded link raises the dialog with the right filename and path; `Download again` opens the sheet; `Leave it` dismisses without opening it. All three tab icons render correctly.