### PR TITLE
Warm the light theme and tighten the download feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Everything merged since 1.0.0, plus what is open in review.
   drained of colour and dimmed, alongside the tag saying so.
 - One placeholder per link while a set of links is being read, rather than a single card
   standing in for the whole set.
+- **Processing is shown as its own stage.** Once every byte is in and yt-dlp moves on to
+  merging, converting or tagging, a sharp sweep crosses the artwork, the corner reads
+  Processing, and the line along the bottom edge runs on its own. The band carries a dark
+  shoulder either side of its bright core, so it stands out over pale and dark artwork
+  alike.
 
 ### Fixed
 - **File sizes quoted well above the finished file**, 30.1 MB shown against a 12.6 MB
@@ -31,8 +36,30 @@ Everything merged since 1.0.0, plus what is open in review.
   An exact size is now used whenever the source reports one; where none is reported the
   estimate is computed knowingly and shown as `~ 30.1 MB` rather than passed off as
   measured.
+- **Cancel offered after there was anything left to cancel.** The cancel control stayed on
+  the card through merging and tagging, where the transfer is already over and stopping it
+  does nothing. It now goes as soon as that stage begins.
+- **The download sheet opened half height** for a single link, so reaching the format rows
+  and the fields under them took a drag before anything could be done. It opens at full
+  height, as the sheet for a set of links already did.
+- **The progress notification lagged behind the download.** It was redrawn on every second
+  percentage point, and a large transfer holds one percentage for seconds at a time, so the
+  speed and ETA on it were routinely stale. It is redrawn on a timer instead.
 
 ### Changed
+- **The light theme is warm rather than white.** Background, surfaces and every container
+  tone are mixed towards paper, replacing a near-white ground that read as glare under a
+  full-bleed thumbnail. The container tones are now named outright, which also takes the
+  violet tint out of the search field and the navigation bar, where Material's own light
+  defaults had put it. The dark theme is untouched.
+- **The notification says less.** The progress line is the source's own output with its
+  stage prefix stripped, giving percentage, size, speed and ETA, and it no longer carries
+  destination paths. Titles are shortened to one line, and a finished download is headed by
+  the media's title rather than the generated file name. Tapping it still opens the file in
+  the device's default player.
+- **The log line under the cards is gone.** The card's own header already shows the
+  percentage and the transferred size, the notification carries the full status line, and a
+  failure offers its log to copy, so a truncated third copy on the screen said nothing new.
 - Home, Downloads and More use stroked marks in one style, instead of Home and Downloads
   sharing an icon.
 - README rewritten around what the app does.

--- a/app/src/main/java/com/hazel/android/download/DownloadNotificationHelper.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadNotificationHelper.kt
@@ -27,6 +27,22 @@ object DownloadNotificationHelper {
     private const val PROGRESS_NOTIFICATION_ID = 1001
     private const val COMPLETE_NOTIFICATION_ID = 1002
 
+    /**
+     * Longest title the notification shows. A title past this length wraps onto a second
+     * line and pushes the progress figures off the collapsed notification, which are the
+     * part worth reading while a download runs.
+     */
+    private const val TITLE_LIMIT = 48
+
+    /** Shortens a title to one line, ending on a word wherever that is possible. */
+    private fun shortTitle(title: String): String {
+        val clean = title.trim()
+        if (clean.length <= TITLE_LIMIT) return clean
+        val cut = clean.take(TITLE_LIMIT)
+        val lastSpace = cut.lastIndexOf(' ')
+        return (if (lastSpace > TITLE_LIMIT / 2) cut.take(lastSpace) else cut).trimEnd() + "\u2026"
+    }
+
     /** Create notification channels (safe to call multiple times) */
     fun createChannels(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -99,9 +115,10 @@ object DownloadNotificationHelper {
      * Shows or updates the progress notification. Always silent, never a popup.
      *
      * The media's own title heads the notification and the live yt-dlp line sits under it,
-     * so the notification says what is being downloaded and how far along it is. No file
-     * path is shown: it is long, wraps over several lines, and tells the user nothing they
-     * can act on.
+     * so the notification says what is being downloaded and how far along it is. Both are
+     * kept to one line each: the title is shortened here, and the status line arrives with
+     * its stage prefix and any file path already stripped out, because a path fills the
+     * notification on its own and tells the reader nothing they can act on.
      *
      * @param progress percent complete, or a negative value while that is not yet known.
      */
@@ -114,7 +131,7 @@ object DownloadNotificationHelper {
         createChannels(context)
         val builder = NotificationCompat.Builder(context, CHANNEL_PROGRESS)
             .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(mediaTitle.ifBlank { "Hazel" })
+            .setContentTitle(shortTitle(mediaTitle).ifBlank { "Hazel" })
             .setContentText(statusLine.ifBlank { "Downloading" })
             .setProgress(100, progress.coerceIn(0, 100), progress < 0)
             .setOngoing(true)
@@ -146,7 +163,7 @@ object DownloadNotificationHelper {
      */
     fun showComplete(
         context: Context,
-        fileName: String,
+        title: String,
         isVideo: Boolean,
         fileUri: Uri? = null
     ) {
@@ -158,7 +175,7 @@ object DownloadNotificationHelper {
 
         val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(fileName)
+            .setContentTitle(shortTitle(title).ifBlank { "Hazel" })
             .setContentText(if (fileUri != null) "Tap to open" else "Saved")
             .setAutoCancel(true)
             .setColorized(true)

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -59,6 +59,12 @@ data class DownloadState(
     /** Total transfer size reported by yt-dlp, 0 until its first progress line. */
     val totalBytes: Long = 0L,
     val status: String = "",
+    /**
+     * True once the transfer is done and yt-dlp has moved on to merging, converting or
+     * tagging. There is nothing left to cancel at that point, so the screen swaps the
+     * cancel control for a processing treatment.
+     */
+    val isProcessing: Boolean = false,
     val fileName: String = "",
     val savedPath: String = "",
     val error: String? = null,
@@ -87,6 +93,9 @@ class DownloadViewModel : ViewModel() {
     private var downloadJob: Job? = null
     private val processId = "hazel_download"
     @Volatile private var isCancelled = false
+
+    /** When the progress notification was last redrawn, so updates stay evenly paced. */
+    @Volatile private var lastNotifiedAt = 0L
 
     private var downloadContext: Context? = null
     private var downloadIsVideo: Boolean = true
@@ -337,6 +346,7 @@ class DownloadViewModel : ViewModel() {
             progress = 0f,
             totalBytes = 0L,
             status = "Starting download",
+            isProcessing = false,
             error = null,
             batch = plans.map { BatchItem(url = it.info.url, title = it.title) }
         )
@@ -362,7 +372,8 @@ class DownloadViewModel : ViewModel() {
                     info = plan.info,
                     progress = 0f,
                     totalBytes = 0L,
-                    status = "Starting download"
+                    status = "Starting download",
+                    isProcessing = false
                 )
                 DownloadNotificationHelper.showProgress(context, 0, "Starting download", plan.title)
 
@@ -432,6 +443,7 @@ class DownloadViewModel : ViewModel() {
             isDownloading = false,
             isComplete = done > 0,
             status = "",
+            isProcessing = false,
             error = when {
                 done == 0 && failed > 0 ->
                     current.batch.firstOrNull { it.error != null }?.error ?: "Download failed"
@@ -638,15 +650,25 @@ class DownloadViewModel : ViewModel() {
             .ifBlank { "download" }
 
     private fun executeYtDlp(request: YoutubeDLRequest) {
+        lastNotifiedAt = 0L
         YoutubeDL.getInstance().execute(request, processId) { progress, _, line ->
             val percent = progress.coerceIn(0f, 100f)
             val status = cleanProgressLine(line) ?: _state.value.status
+            val processing = _state.value.isProcessing || isPostProcessing(line)
             _state.value = _state.value.copy(
                 progress = percent / 100f,
                 totalBytes = parseTotalBytes(line) ?: _state.value.totalBytes,
-                status = status
+                status = status,
+                isProcessing = processing
             )
-            if (percent.toInt() % 2 == 0) {
+
+            // Updates are paced by the clock rather than by the percentage. yt-dlp reports
+            // the same percentage for seconds at a time on a large transfer while the speed
+            // and ETA behind it keep moving, so pacing on the percentage left the
+            // notification showing figures that were already out of date.
+            val now = System.currentTimeMillis()
+            if (now - lastNotifiedAt >= NOTIFICATION_INTERVAL_MS) {
+                lastNotifiedAt = now
                 downloadContext?.let {
                     DownloadNotificationHelper.showProgress(
                         it, percent.toInt(), status, _state.value.info?.title.orEmpty()
@@ -671,7 +693,7 @@ class DownloadViewModel : ViewModel() {
             ?.maxByOrNull { it.lastModified() }
         val fileName = latestFile?.name ?: "File saved"
 
-        _state.value = _state.value.copy(status = "Saving")
+        _state.value = _state.value.copy(status = "Saving", isProcessing = true)
 
         val tree = downloadTreeUri.takeIf { it.isNotBlank() }?.let(android.net.Uri::parse)
 
@@ -709,12 +731,18 @@ class DownloadViewModel : ViewModel() {
         _state.value = _state.value.copy(
             progress = 1f,
             status = "",
+            isProcessing = false,
             fileName = fileName,
             savedPath = savedPath
         )
 
+        // The media's own title heads the completion notification rather than the file
+        // name, which carries the template's separators and the container extension.
         DownloadNotificationHelper.showComplete(
-            context, fileName, isVideo = downloadIsVideo, fileUri = savedUri
+            context,
+            title = _state.value.info?.title.orEmpty().ifBlank { fileName },
+            isVideo = downloadIsVideo,
+            fileUri = savedUri
         )
 
         recordHistory(context, fileName, savedPath, savedUri)
@@ -777,6 +805,7 @@ class DownloadViewModel : ViewModel() {
             isDownloading = false,
             progress = 0f,
             status = "",
+            isProcessing = false,
             error = message
         )
         DownloadNotificationHelper.showError(context, message)
@@ -788,11 +817,24 @@ class DownloadViewModel : ViewModel() {
      * Every line is prefixed with the stage that produced it, such as `[download]` or
      * `[youtube]`. The prefix repeats on every line and says nothing the progress bar does
      * not already show, so it is dropped and the rest of the line is kept as written.
+     *
+     * Lines whose content is a file path are dropped rather than shown. A destination path
+     * fills a notification on its own, pushes the transfer figures out of view, and is not
+     * something anyone can act on while the download is still running.
      */
     private fun cleanProgressLine(line: String): String? =
         line.replace(LEADING_TAG_PATTERN, "")
             .trim()
-            .takeIf { it.isNotEmpty() }
+            .takeIf { it.isNotEmpty() && !PATH_LINE_PATTERN.containsMatchIn(it) }
+
+    /**
+     * Whether a line comes from a stage that runs after every byte is in: merging the video
+     * and audio streams, converting the container, or writing tags and artwork.
+     */
+    private fun isPostProcessing(line: String): Boolean {
+        val lower = line.lowercase()
+        return POST_PROCESS_MARKERS.any { it in lower }
+    }
 
     /**
      * Reads the transfer size out of a yt-dlp progress line, which looks like
@@ -891,6 +933,22 @@ class DownloadViewModel : ViewModel() {
 
         /** Leading `[stage]` markers yt-dlp puts at the front of every output line. */
         val LEADING_TAG_PATTERN = Regex("""^(\s*\[[^\]]*]\s*)+""")
+
+        /** Lines whose content is a file path, which the notification leaves out. */
+        val PATH_LINE_PATTERN = Regex(
+            """^(destination|merging formats into|writing)|/storage/|/data/|/files/""",
+            RegexOption.IGNORE_CASE
+        )
+
+        /** How often the progress notification is redrawn while a transfer runs. */
+        const val NOTIFICATION_INTERVAL_MS = 600L
+
+        /** Stages that run once the transfer itself has finished. */
+        val POST_PROCESS_MARKERS = listOf(
+            "[merger]", "merging formats", "[ffmpeg]", "[extractaudio]",
+            "[videoconvertor]", "[videoremuxer]", "[metadata]", "[embedthumbnail]",
+            "[fixup", "deleting original file", "correcting container"
+        )
 
         val TERMINAL_MARKERS = listOf(
             "unsupported url", "is not a valid url", "no suitable infoextractor",

--- a/app/src/main/java/com/hazel/android/ui/components/Shimmer.kt
+++ b/app/src/main/java/com/hazel/android/ui/components/Shimmer.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -58,6 +59,10 @@ private const val SWEEP_DURATION_MS = 1200
 
 /** Width of the moving highlight, as a fraction of the host's width. */
 private const val BAND_WIDTH = 0.45f
+
+/** The processing sweep is narrower and quicker, so it reads as a glint, not a wash. */
+private const val SHARP_BAND_WIDTH = 0.20f
+private const val SHARP_SWEEP_DURATION_MS = 900
 
 /** Position of the band and the geometry it is measured against. */
 private data class ShimmerSweep(
@@ -228,6 +233,58 @@ fun FormatListShimmer(rows: Int = 5, modifier: Modifier = Modifier) {
             repeat(rows) { FormatRowShimmer() }
         }
     }
+}
+
+/**
+ * A single bright band sweeping across whatever this is laid over.
+ *
+ * Unlike the skeleton blocks this paints no resting fill, so the artwork underneath stays
+ * visible and only the band moves over it. The band is narrow and its highlight rises and
+ * falls sharply, which reads as a surface catching the light rather than as a placeholder
+ * waiting to be filled — the download is finished at this point, and what is left is the
+ * work the app is doing to the file.
+ *
+ * The bright core is flanked by a darker shoulder on both sides. A single white band
+ * disappears over pale artwork, and a single dark one disappears over dark artwork; the
+ * pair always leaves one half of it standing out. That is also what makes this readable in
+ * either theme, since what the band crosses is the artwork rather than any app surface.
+ */
+@Composable
+fun ProcessingShimmer(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "processing")
+    val progress by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = SHARP_SWEEP_DURATION_MS, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "processingSweep"
+    )
+
+    Box(
+        modifier = modifier.drawBehind {
+            val bandWidth = size.width * SHARP_BAND_WIDTH
+            val travel = size.width + bandWidth * 2f
+            val start = -bandWidth + travel * progress
+
+            drawRect(
+                brush = Brush.linearGradient(
+                    colorStops = arrayOf(
+                        0f to Color.Transparent,
+                        0.30f to Color.Black.copy(alpha = 0.28f),
+                        0.44f to Color.White.copy(alpha = 0.10f),
+                        0.50f to Color.White.copy(alpha = 0.60f),
+                        0.56f to Color.White.copy(alpha = 0.10f),
+                        0.70f to Color.Black.copy(alpha = 0.28f),
+                        1f to Color.Transparent
+                    ),
+                    start = Offset(start, 0f),
+                    end = Offset(start + bandWidth, size.height)
+                )
+            )
+        }
+    )
 }
 
 /** Single placeholder line, for a field whose value has not arrived yet. */

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -73,6 +73,7 @@ import com.hazel.android.download.MediaInfo
 import com.hazel.android.download.formatDuration
 import com.hazel.android.download.formatFileSize
 import com.hazel.android.ui.components.MediaCardShimmer
+import com.hazel.android.ui.components.ProcessingShimmer
 import com.hazel.android.ui.motion.M3Motion
 import com.hazel.android.ui.screens.cookies.CookieWebViewActivity
 import com.hazel.android.util.FolderUtil
@@ -252,6 +253,7 @@ fun DownloadScreen(
                 MediaCard(
                     info = info,
                     isDownloading = isActive,
+                    isProcessing = isActive && state.isProcessing,
                     progress = state.progress,
                     totalBytes = state.totalBytes,
                     isComplete = batchItem?.state == BatchState.DONE ||
@@ -267,17 +269,6 @@ fun DownloadScreen(
                     onRemove = if (state.isMultiple && !state.isDownloading) {
                         { downloadViewModel.removeResult(info) }
                     } else null
-                )
-            }
-
-            if (state.isDownloading && state.status.isNotBlank()) {
-                Spacer(modifier = Modifier.height(16.dp))
-                Text(
-                    state.status,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
                 )
             }
 
@@ -529,11 +520,17 @@ private fun DownloadAllButton(onClick: () -> Unit, modifier: Modifier = Modifier
  * The whole card is the download control: tapping anywhere on it opens the format sheet,
  * so there is no separate button competing with it. While this card's download runs it
  * carries the progress readout, and its centre becomes the cancel control.
+ *
+ * Once the transfer finishes and the streams are being merged and tagged, the cancel
+ * control goes: there is no transfer left to stop, and offering to stop one would only
+ * invite a tap that cannot do what it says. A sweep across the artwork takes its place, so
+ * the card still reads as busy while that work runs.
  */
 @Composable
 private fun MediaCard(
     info: MediaInfo,
     isDownloading: Boolean,
+    isProcessing: Boolean = false,
     progress: Float,
     totalBytes: Long,
     isComplete: Boolean,
@@ -591,7 +588,8 @@ private fun MediaCard(
                     )
 
                     // Percentage readout, with the transferred size beside it once
-                    // yt-dlp has reported a total.
+                    // yt-dlp has reported a total. Both are about the transfer, so once
+                    // that is done the corner just names the stage that follows.
                     Row(
                         modifier = Modifier
                             .align(Alignment.TopStart)
@@ -599,42 +597,51 @@ private fun MediaCard(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        OverlayChip(
-                            text = "%.1f %%".format(animatedProgress * 100),
-                            bold = true
-                        )
-                        if (totalBytes > 0) {
-                            val done = (totalBytes * animatedProgress).toLong()
+                        if (isProcessing) {
+                            OverlayChip(text = "Processing", bold = true)
+                        } else {
                             OverlayChip(
-                                text = "${formatFileSize(done)} / ${formatFileSize(totalBytes)}"
+                                text = "%.1f %%".format(animatedProgress * 100),
+                                bold = true
                             )
+                            if (totalBytes > 0) {
+                                val done = (totalBytes * animatedProgress).toLong()
+                                OverlayChip(
+                                    text = "${formatFileSize(done)} / ${formatFileSize(totalBytes)}"
+                                )
+                            }
                         }
                     }
 
-                    // A progress ring wrapping the cancel control. It is the only tappable
-                    // area while a download runs, so a stray tap cannot reopen the sheet.
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .size(60.dp)
-                            .clip(CircleShape)
-                            .background(Color.Black.copy(alpha = 0.55f))
-                            .clickable(onClick = onCancel),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(
-                            progress = { animatedProgress },
-                            modifier = Modifier.size(60.dp),
-                            color = Color.White,
-                            trackColor = Color.Transparent,
-                            strokeWidth = 3.dp
-                        )
-                        Icon(
-                            Icons.Filled.Close,
-                            contentDescription = "Cancel download",
-                            modifier = Modifier.size(22.dp),
-                            tint = Color.White
-                        )
+                    if (isProcessing) {
+                        ProcessingShimmer(modifier = Modifier.fillMaxSize())
+                    } else {
+                        // A progress ring wrapping the cancel control. It is the only
+                        // tappable area while a download runs, so a stray tap cannot
+                        // reopen the sheet.
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .size(60.dp)
+                                .clip(CircleShape)
+                                .background(Color.Black.copy(alpha = 0.55f))
+                                .clickable(onClick = onCancel),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                progress = { animatedProgress },
+                                modifier = Modifier.size(60.dp),
+                                color = Color.White,
+                                trackColor = Color.Transparent,
+                                strokeWidth = 3.dp
+                            )
+                            Icon(
+                                Icons.Filled.Close,
+                                contentDescription = "Cancel download",
+                                modifier = Modifier.size(22.dp),
+                                tint = Color.White
+                            )
+                        }
                     }
                 }
 
@@ -692,18 +699,29 @@ private fun MediaCard(
                     }
                 }
 
-                // Filled line along the bottom edge of the thumbnail.
+                // Filled line along the bottom edge of the thumbnail. Processing has no
+                // figure to fill it with, so the line runs on its own there.
                 if (isDownloading) {
-                    LinearProgressIndicator(
-                        progress = { animatedProgress },
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .fillMaxWidth()
-                            .height(4.dp),
-                        color = MaterialTheme.colorScheme.primary,
-                        trackColor = Color.White.copy(alpha = 0.25f),
-                        drawStopIndicator = {}
-                    )
+                    val lineModifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .height(4.dp)
+
+                    if (isProcessing) {
+                        LinearProgressIndicator(
+                            modifier = lineModifier,
+                            color = MaterialTheme.colorScheme.primary,
+                            trackColor = Color.White.copy(alpha = 0.25f)
+                        )
+                    } else {
+                        LinearProgressIndicator(
+                            progress = { animatedProgress },
+                            modifier = lineModifier,
+                            color = MaterialTheme.colorScheme.primary,
+                            trackColor = Color.White.copy(alpha = 0.25f),
+                            drawStopIndicator = {}
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/hazel/android/ui/screens/download/FormatSelectionSheet.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/FormatSelectionSheet.kt
@@ -69,8 +69,8 @@ fun FormatSelectionSheet(
     onConfirm: (MediaFormat) -> Unit,
     onDismiss: () -> Unit
 ) {
-    // Partially expanded on open, draggable up to full height.
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    // Full height on open, to match the sheet it is opened from.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var sort by remember { mutableStateOf(FormatSort.QUALITY) }
     var sortMenuOpen by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/hazel/android/ui/screens/download/FormatSheet.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/FormatSheet.kt
@@ -87,7 +87,10 @@ fun FormatSheet(
     onDownload: (format: MediaFormat, title: String, author: String) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    // Opened at full height. The sheet's own content is a full screen of format rows and
+    // fields, so a half-height first stop showed only the header and made an extra drag a
+    // condition of using it. The set-of-links sheet already opens this way.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     // Open on whichever tab the source actually has formats for.
     var videoTab by remember(info.url) { mutableStateOf(info.videoFormats.isNotEmpty()) }

--- a/app/src/main/java/com/hazel/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/hazel/android/ui/theme/Color.kt
@@ -9,12 +9,33 @@ val DarkSurfaceVariant = Color(0xFF1E1E1E)
 val DarkOnBackground = Color(0xFFE0E0E0)
 val DarkOnSurface = Color(0xFFCCCCCC)
 
-// Light Theme
-val LightBackground = Color(0xFFFAFAFA)
-val LightSurface = Color(0xFFFFFFFF)
-val LightSurfaceVariant = Color(0xFFF0F0F0)
-val LightOnBackground = Color(0xFF1C1C1C)
-val LightOnSurface = Color(0xFF333333)
+// Light Theme — a warm paper ground rather than a neutral white.
+//
+// A pure white background under a full-bleed thumbnail reads as glare, and Material's own
+// light defaults tint their container tones violet, which fought the accent in the search
+// field and the navigation bar. Every tone here is mixed towards paper instead, so the
+// surfaces stay quiet and the accent is the only colour on the screen.
+val LightBackground = Color(0xFFF6F4EF)
+val LightSurface = Color(0xFFFCFAF5)
+val LightSurfaceVariant = Color(0xFFE9E5DB)
+val LightOnBackground = Color(0xFF201D18)
+val LightOnSurface = Color(0xFF43403A)
+val LightOnSurfaceVariant = Color(0xFF5C574E)
+val LightOutline = Color(0xFF8C867A)
+val LightOutlineVariant = Color(0xFFDCD6C9)
+
+// Container tones, lightest to darkest. Cards sit on the lower ones; the search field and
+// the navigation bar take the higher ones, which is what gives them an edge against the
+// background without needing a border to carry it.
+val LightSurfaceContainerLowest = Color(0xFFFFFDF8)
+val LightSurfaceContainerLow = Color(0xFFF9F6F0)
+val LightSurfaceContainer = Color(0xFFF3EFE7)
+val LightSurfaceContainerHigh = Color(0xFFEDE9DF)
+val LightSurfaceContainerHighest = Color(0xFFE7E2D6)
+val LightSurfaceBright = Color(0xFFFCFAF5)
+val LightSurfaceDim = Color(0xFFDFDACE)
+val LightInverseSurface = Color(0xFF35322C)
+val LightInverseOnSurface = Color(0xFFF7F3EB)
 
 // Default Brand — Hazel Cyan
 val HazelCyan = Color(0xFF00BCD4)

--- a/app/src/main/java/com/hazel/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hazel/android/ui/theme/Theme.kt
@@ -48,8 +48,23 @@ fun HazelTheme(
             surface = LightSurface,
             onSurface = LightOnSurface,
             surfaceVariant = LightSurfaceVariant,
+            onSurfaceVariant = LightOnSurfaceVariant,
+            outline = LightOutline,
+            outlineVariant = LightOutlineVariant,
+            // Named one by one rather than left to Material's defaults, which derive their
+            // light container tones from a violet neutral and pulled the search field and
+            // the navigation bar away from the rest of the screen.
+            surfaceContainerLowest = LightSurfaceContainerLowest,
+            surfaceContainerLow = LightSurfaceContainerLow,
+            surfaceContainer = LightSurfaceContainer,
+            surfaceContainerHigh = LightSurfaceContainerHigh,
+            surfaceContainerHighest = LightSurfaceContainerHighest,
+            surfaceBright = LightSurfaceBright,
+            surfaceDim = LightSurfaceDim,
+            inverseSurface = LightInverseSurface,
+            inverseOnSurface = LightInverseOnSurface,
             error = ErrorRedLight,
-            onError = LightBackground,
+            onError = Color.White,
         )
     }
 


### PR DESCRIPTION
Five changes to how a download looks while it runs, and a light theme that stops competing with the artwork.

## Light theme

The light theme was a near-white ground with Material's default container tones on top, which derive from a violet neutral. Two things came out of that: under a full-bleed thumbnail the background read as glare, and the search field and the navigation bar carried a tint that fought the accent.

Every light tone is now mixed towards paper, and the container tones are named outright rather than left to be derived. **The dark theme is untouched.**

## Feedback while a download runs

The same information was in three places: the card header, the notification, and a truncated log line under the cards. The log line is gone. The header carries the percentage and the transferred size, the notification carries the full status line, and a failure still offers its log to copy.

The notification keeps the source's own progress line with its stage prefix stripped, so it reads `100.0% of ~ 24.08MiB at 4.22MiB/s ETA 00:00 (frag 35/36)`. Destination paths are dropped: one fills the notification on its own and cannot be acted on. It is redrawn on a timer rather than on every second percentage point, because a large transfer holds one percentage for seconds at a time and the speed and ETA on it were routinely stale. Titles are shortened to one line, and a finished download is headed by the media's title rather than the generated file name. Tapping it still opens the file in the device's default player.

## Processing as its own stage

Merging, converting and tagging now read as a stage of their own. The cancel control goes once the transfer is over, since there is nothing left for it to stop, and a sweep across the artwork takes its place, with the corner reading Processing and the line along the bottom edge running on its own. The band has a dark shoulder either side of its bright core, so it stands out over pale and dark artwork alike.

## Sheet height

The single-link download sheet opens at full height, as the sheet for a set of links already did. Opening half height put a drag between the user and the format rows.

## Checks

`:app:compileDebugKotlin` passes.
