### PR TITLE
Say what an instant share is doing, fade screens through, link the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,19 @@ Everything merged since 1.0.0, plus what is open in review.
   means editing a field that is still open. A link shared in from another app never passes
   through that screen, so it keeps its warning on the home screen, and a link shared to
   Hazel Direct is never interrupted at all.
+- **An instant share says what it is doing while it reads.** The instant target asks nothing
+  and opens nothing, so the seconds between the share and the first byte were spent on an
+  empty screen that looked like a share which had gone nowhere. A stand-in card now stands
+  there, named after the app the link was shared from, or after the site when Android does
+  not say which app that was.
+- **Screens fade through each other instead of sliding.** Home, Downloads and More are
+  peers, and the vertical slide between them read as a short panel moving about in the
+  middle of the screen rather than one screen replacing another. The outgoing screen fades,
+  then the incoming one fades up into place; nothing translates.
+- **The battery card no longer appears a moment after the settings do.** It was drawn on an
+  assumed answer and corrected once the screen resumed, so it arrived late and pushed
+  everything under it down. The answer is read before the first frame.
+- **Source, at the end of More**, opening the project on GitHub.
 - **A download keeps going once the app is left.** It ran inside the screen that started
   it, so the system suspended it shortly after the app stopped being visible and killed it
   outright when the task was swiped away. It runs behind a foreground service now, on a

--- a/app/src/main/java/com/hazel/android/MainActivity.kt
+++ b/app/src/main/java/com/hazel/android/MainActivity.kt
@@ -41,7 +41,12 @@ class MainActivity : ComponentActivity() {
      */
     val pendingShares = mutableStateListOf<SharedLink>()
 
-    data class SharedLink(val url: String, val direct: Boolean)
+    data class SharedLink(
+        val url: String,
+        val direct: Boolean,
+        /** Where it came from, for the line shown while it is being read. */
+        val source: String = ""
+    )
 
     /** A failure the user tapped a notification to come back to, or null. */
     var pendingFailure by mutableStateOf<String?>(null)
@@ -120,13 +125,40 @@ class MainActivity : ComponentActivity() {
                     // component name.
                     val direct =
                         intent.component?.className?.endsWith("DirectShareActivity") == true
-                    pendingShares.add(SharedLink(link, direct))
+                    pendingShares.add(SharedLink(link, direct, sourceLabelFor(link)))
                 }
         }
 
         intent?.getStringExtra(DownloadNotificationHelper.EXTRA_FAILURE_MESSAGE)
             ?.takeIf { it.isNotBlank() }
             ?.let { pendingFailure = it }
+    }
+
+    /**
+     * What to call where a shared link came from, for the line shown while it is being read.
+     *
+     * The app that did the sharing is the honest answer and the one the user will recognise,
+     * so it is asked for first. Android does not always say, and a share forwarded through
+     * another app can name the wrong one, so the link's own site stands in: for the purpose
+     * of "this is what is being read", the site is just as good.
+     */
+    private fun sourceLabelFor(link: String): String {
+        val referrerPackage = referrer
+            ?.takeIf { it.scheme == "android-app" }
+            ?.host
+            ?.takeIf { it != packageName }
+
+        if (referrerPackage != null) {
+            runCatching {
+                val info = packageManager.getApplicationInfo(referrerPackage, 0)
+                packageManager.getApplicationLabel(info).toString()
+            }.getOrNull()?.takeIf { it.isNotBlank() }?.let { return it }
+        }
+
+        return runCatching { java.net.URI(link).host.orEmpty() }
+            .getOrDefault("")
+            .removePrefix("www.")
+            .ifBlank { "the link" }
     }
 }
 

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -96,7 +96,16 @@ data class DownloadState(
     val errorLog: String? = null,
     val isComplete: Boolean = false,
     /** Per-link state while several links download one after another. */
-    val batch: List<BatchItem> = emptyList()
+    val batch: List<BatchItem> = emptyList(),
+    /**
+     * Where an instant share is being read from, or blank when none is.
+     *
+     * The instant target asks nothing and opens nothing, so between the share and the first
+     * byte there was a stretch of seconds with an empty screen behind it. This is what the
+     * screen says during it, and it names the source because "reading a link" is less
+     * reassuring than naming the one the user just came from.
+     */
+    val instantSource: String = ""
 ) {
     /** True once more than one link resolved, which is what turns the screen into a list. */
     val isMultiple: Boolean get() = results.size > 1
@@ -228,8 +237,11 @@ class DownloadViewModel : ViewModel() {
 
     // ── Instant share ──
 
+    /** One link shared to the instant target, with where it was shared from. */
+    private data class DirectShare(val url: String, val source: String)
+
     /** Links shared to the instant target, waiting to be read. */
-    private val directQueue = ArrayDeque<String>()
+    private val directQueue = ArrayDeque<DirectShare>()
 
     @Volatile private var directRunning = false
 
@@ -245,21 +257,31 @@ class DownloadViewModel : ViewModel() {
      * The screen is shown whichever link is being read at the time, so a user who does open
      * the app mid-run sees where it has got to rather than the first link frozen in place.
      */
-    fun startDirect(context: Context, url: String) {
+    fun startDirect(context: Context, url: String, source: String = "") {
         val link = url.trim()
         if (link.isBlank()) return
 
-        synchronized(directQueue) { directQueue.addLast(link) }
+        synchronized(directQueue) { directQueue.addLast(DirectShare(link, source)) }
         if (directRunning) return
         directRunning = true
 
         val app = context.applicationContext
         downloadScope.launch {
             while (true) {
-                val next = synchronized(directQueue) { directQueue.removeFirstOrNull() } ?: break
+                val share = synchronized(directQueue) { directQueue.removeFirstOrNull() } ?: break
+                val next = share.url
+
+                // Said while the link is being read, which is the stretch this target used
+                // to spend showing nothing at all: it asks no questions and opens no sheet,
+                // so without this the seconds before the first byte look like a share that
+                // went nowhere.
+                _state.value = _state.value.copy(
+                    instantSource = share.source.ifBlank { "the link" }
+                )
 
                 val info = runCatching { readOne(next) }.getOrNull()
                 if (info == null) {
+                    _state.value = _state.value.copy(instantSource = "")
                     DownloadNotificationHelper.showError(app, "Could not read this link")
                     continue
                 }
@@ -268,6 +290,7 @@ class DownloadViewModel : ViewModel() {
                 val maxHeight = SettingsRepository.getQuickMaxHeight(app).first()
                 val format = info.autoPick(isVideo, maxHeight)
                 if (format == null) {
+                    _state.value = _state.value.copy(instantSource = "")
                     DownloadNotificationHelper.showError(app, "Nothing to download from this link")
                     continue
                 }
@@ -280,7 +303,9 @@ class DownloadViewModel : ViewModel() {
                     info = info,
                     results = listOf(info) + _state.value.results.filterNot { it.url == info.url },
                     error = null,
-                    errorLog = null
+                    errorLog = null,
+                    // The card is there now, so it says what is happening from here on.
+                    instantSource = ""
                 )
                 markAutoOpened(info.url)
 
@@ -291,6 +316,7 @@ class DownloadViewModel : ViewModel() {
                     treeUri = SettingsRepository.getDownloadTreeUri(app).first()
                 )
             }
+            _state.value = _state.value.copy(instantSource = "")
             directRunning = false
         }
     }

--- a/app/src/main/java/com/hazel/android/ui/motion/M3Motion.kt
+++ b/app/src/main/java/com/hazel/android/ui/motion/M3Motion.kt
@@ -32,63 +32,59 @@ object M3Motion {
     private const val ENTER_SCALE = 0.92f
 
     // ============================================================================
-    // FORWARD NAVIGATION 
+    // SCREEN TRANSITIONS — fade through
     // ============================================================================
+    //
+    // The screens behind the navigation bar are peers: nothing goes forward or back
+    // between Home, Downloads and More, so nothing should look as though it does. They
+    // used to slide vertically past each other by a twelfth of the height, and because a
+    // screen is drawn inside the bars rather than under them, that read as a short panel
+    // sliding about in the middle instead of one screen replacing another.
+    //
+    // A fade through is what Material uses when there is no relationship to express: the
+    // outgoing screen fades quickly, and once it is gone the incoming one fades up while
+    // growing the last of the way to full size. Nothing translates, so nothing looks like
+    // it is arriving from somewhere.
 
-    fun forwardEnter(): EnterTransition {
+    /** How long the outgoing screen takes to clear. */
+    private const val FADE_OUT_DURATION = 90
+
+    /** How long the incoming screen takes, once the outgoing one has cleared. */
+    private const val FADE_IN_DURATION = 210
+
+    private fun fadeThroughEnter(): EnterTransition {
         return fadeIn(
             animationSpec = tween(
-                durationMillis = ENTER_DURATION,
+                durationMillis = FADE_IN_DURATION,
+                delayMillis = FADE_OUT_DURATION,
                 easing = EmphasizedDecelerate
             )
         ) + scaleIn(
             initialScale = ENTER_SCALE,
             animationSpec = tween(
-                durationMillis = ENTER_DURATION,
-                easing = EmphasizedDecelerate
-            )
-        ) + slideInVertically(
-            initialOffsetY = { fullHeight -> -fullHeight / 12 },
-            animationSpec = tween(
-                durationMillis = ENTER_DURATION,
+                durationMillis = FADE_IN_DURATION,
+                delayMillis = FADE_OUT_DURATION,
                 easing = EmphasizedDecelerate
             )
         )
     }
 
-    fun forwardExit(): ExitTransition {
+    private fun fadeThroughExit(): ExitTransition {
         return fadeOut(
             animationSpec = tween(
-                durationMillis = EXIT_DURATION,
+                durationMillis = FADE_OUT_DURATION,
                 easing = EmphasizedAccelerate
             )
         )
     }
 
-    
-    fun backEnter(): EnterTransition {
-        return fadeIn(
-            animationSpec = tween(
-                durationMillis = ENTER_DURATION,
-                easing = EmphasizedDecelerate
-            )
-        )
-    }
+    fun forwardEnter(): EnterTransition = fadeThroughEnter()
 
-    fun backExit(): ExitTransition {
-        return fadeOut(
-            animationSpec = tween(
-                durationMillis = EXIT_DURATION,
-                easing = EmphasizedAccelerate
-            )
-        ) + slideOutVertically(
-            targetOffsetY = { fullHeight -> fullHeight / 12 },
-            animationSpec = tween(
-                durationMillis = EXIT_DURATION,
-                easing = EmphasizedAccelerate
-            )
-        )
-    }
+    fun forwardExit(): ExitTransition = fadeThroughExit()
+
+    fun backEnter(): EnterTransition = fadeThroughEnter()
+
+    fun backExit(): ExitTransition = fadeThroughExit()
 
     // ============================================================================
     // CONTENT TRANSITIONS (elements appearing inside a screen)

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -273,7 +273,7 @@ fun DownloadScreen(
         val direct = shares.filter { it.direct }
         val asked = shares.filterNot { it.direct }
 
-        direct.forEach { downloadViewModel.startDirect(context, it.url) }
+        direct.forEach { downloadViewModel.startDirect(context, it.url, it.source) }
 
         // The ordinary target opens the sheet, so those go through the usual read, which
         // already takes several links at once.
@@ -424,6 +424,28 @@ fun DownloadScreen(
                                 color = MaterialTheme.colorScheme.error,
                                 modifier = Modifier.padding(top = 10.dp, start = 4.dp)
                             )
+                        }
+                    }
+                }
+
+                // An instant share reads with nothing on screen to show for it, so the
+                // same skeleton stands in, named after where the link came from.
+                item(key = "instant") {
+                    AnimatedVisibility(
+                        visible = state.instantSource.isNotBlank(),
+                        enter = M3Motion.contentEnter(),
+                        exit = M3Motion.contentExit()
+                    ) {
+                        Column {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                "Instant \u00b7 reading from ${state.instantSource}",
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            MediaCardShimmer()
                         }
                     }
                 }

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -3,7 +3,6 @@ package com.hazel.android.ui.screens.more
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.material.icons.filled.Code
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -356,20 +355,14 @@ fun MoreScreen(
                 color = MaterialTheme.colorScheme.surfaceVariant
             )
 
-            // Leaves the app rather than opening a screen, so it is marked with the icon
-            // for that and sits at the end, under everything the app can do for itself.
+            // Sits at the end, under everything the app can do for itself. No mark on the
+            // right: the line under it already says where it goes, and the chevrons above
+            // mean "another screen in here", which this is not.
             ListItem(
                 headlineContent = { Text("Source") },
                 supportingContent = { Text("View the project on GitHub") },
                 leadingContent = {
                     Icon(Icons.Filled.Code, null, tint = MaterialTheme.colorScheme.primary)
-                },
-                trailingContent = {
-                    Icon(
-                        Icons.AutoMirrored.Filled.OpenInNew, null,
-                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                        modifier = Modifier.size(16.dp)
-                    )
                 },
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                 modifier = Modifier.clickable { openSourceRepository(context) }

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -1,5 +1,9 @@
 package com.hazel.android.ui.screens.more
 
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -73,10 +77,17 @@ fun MoreScreen(
     var tempBytes by remember { mutableStateOf(0L) }
     LaunchedEffect(Unit) { tempBytes = TempStorage.totalBytes(context) }
 
-    // Re-read on every return to the screen, so coming back from the system settings shows
-    // the answer that was just given rather than the one from before leaving.
+    // Read once as the screen is built, then again on every return to it, so coming back
+    // from the system settings shows the answer that was just given.
+    //
+    // The first read happens here rather than being left to the resume below. Inside a
+    // navigation destination the lifecycle is the back stack entry's own, so it resumes on
+    // every visit to this tab, which meant the screen drew once on an assumed answer and
+    // corrected itself a moment later: the card appeared out of nowhere and pushed
+    // everything under it down. The call is a single lookup, cheap enough to make before
+    // the first frame instead of guessing.
     val lifecycleOwner = LocalLifecycleOwner.current
-    var batteryExempt by remember { mutableStateOf(true) }
+    var batteryExempt by remember { mutableStateOf(isIgnoringBatteryOptimizations(context)) }
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
@@ -138,8 +149,9 @@ fun MoreScreen(
                         )
                         Spacer(modifier = Modifier.height(2.dp))
                         Text(
-                            "Android stops a download when you leave the app. Allow " +
-                                    "unrestricted battery use to let it finish.",
+                            "Downloads keep running in the background on their own. Some " +
+                                    "phones still cut them short to save battery. Allow " +
+                                    "unrestricted use to rule that out.",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onPrimaryContainer
                                 .copy(alpha = 0.8f)
@@ -338,6 +350,47 @@ fun MoreScreen(
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                 modifier = Modifier.clickable { onNavigateToUpdate() }
             )
+
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant
+            )
+
+            // Leaves the app rather than opening a screen, so it is marked with the icon
+            // for that and sits at the end, under everything the app can do for itself.
+            ListItem(
+                headlineContent = { Text("Source") },
+                supportingContent = { Text("View the project on GitHub") },
+                leadingContent = {
+                    Icon(Icons.Filled.Code, null, tint = MaterialTheme.colorScheme.primary)
+                },
+                trailingContent = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.OpenInNew, null,
+                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        modifier = Modifier.size(16.dp)
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                modifier = Modifier.clickable { openSourceRepository(context) }
+            )
         }
     }
 }
+
+/**
+ * Opens the project's page in whatever the user browses with.
+ *
+ * Failure is swallowed: a device with no browser at all cannot be helped by a crash, and
+ * this is the least important thing on the screen.
+ */
+private fun openSourceRepository(context: android.content.Context) {
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(SOURCE_URL))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+    }
+}
+
+private const val SOURCE_URL = "https://github.com/SibtainOcn/Hazel"


### PR DESCRIPTION
Follow-up to the last merge. Verified on a device.

**An instant share now says what it is doing.** The target asks nothing and opens nothing, so the seconds between the share and the first byte were spent on an empty screen that looked like a share which had gone nowhere. A stand-in card stands there instead, named after the app the link came from — taken from the activity referrer, falling back to the link's own site when Android does not say which app it was.

**Screens fade through each other.** Home, Downloads and More are peers with no forward or back between them, but they slid vertically past each other by a twelfth of the height. Because a screen is drawn inside the bars rather than under them, that read as a short panel moving about in the middle. Outgoing fades, then incoming fades up while growing the last of the way to full size; nothing translates.

**The battery card stops arriving late.** It was drawn on an assumed answer and corrected once the destination resumed, which happens on every visit to the tab, so it appeared out of nowhere and pushed everything under it down. The answer is read before the first frame now. Its wording is also corrected: downloads survive the background on their own since the foreground service landed, and the exemption is now about phones that cut them short anyway.

**Source**, at the end of More, opening the project on GitHub.
