### PR TITLE
Persist the download queue, add Wi-Fi only and a speed limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,19 @@ Everything merged since 1.0.0, plus what is open in review.
   assumed answer and corrected once the screen resumed, so it arrived late and pushed
   everything under it down. The answer is read before the first frame.
 - **Source, at the end of More**, opening the project on GitHub.
+- **The download queue outlives the app.** It was held in memory only, so a swipe off the
+  recents list, a crash or a low-memory kill threw it away without a word: the user asked for
+  ten downloads, got three, and nothing anywhere said what happened to the other seven. Each
+  link is written down as it is queued, with the settings it was asked for under, taken off
+  again once it is done either way, and picked up on the next launch. A download interrupted
+  part way through starts itself again where it left off.
+- **Wi-Fi only**, under Downloads in More. Checked as a download starts rather than
+  throughout, so a transfer already going when the phone leaves Wi-Fi is left alone: cutting
+  it off partway wastes the data it has already spent.
+- **A speed limit**, under Downloads in More. Blank for none, otherwise a number with an
+  optional K or M, passed through as yt-dlp's own rate limit.
+- **Source code** at the end of More, opening the project on GitHub, and the storage screen
+  it sits above is now called Downloads, since it covers more than where files land.
 - **A download keeps going once the app is left.** It ran inside the screen that started
   it, so the system suspended it shortly after the app stopped being visible and killed it
   outright when the task was swiped away. It runs behind a foreground service now, on a

--- a/app/src/main/java/com/hazel/android/data/DownloadQueueRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/DownloadQueueRepository.kt
@@ -1,0 +1,277 @@
+package com.hazel.android.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.hazel.android.download.DownloadOptions
+import com.hazel.android.download.DownloadPlan
+import com.hazel.android.download.MediaFormat
+import com.hazel.android.download.MediaInfo
+import kotlinx.coroutines.flow.first
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * One link waiting to be downloaded, written down so it outlives the app.
+ *
+ * This is not the whole of what the sheet knew about the link. A read reports every format
+ * a source offers, and keeping all of them for every queued item would write a great deal
+ * to disk to answer a question nobody will ask again: by the time an item is queued the
+ * choice has been made. What is kept is what the download itself needs, which is the chosen
+ * format, the audio track it will be muxed with, and the naming.
+ */
+data class QueuedDownload(
+    val url: String,
+    val title: String,
+    val author: String,
+    val thumbnail: String?,
+    val durationSeconds: Int,
+    val formatId: String,
+    val selector: String,
+    val formatLabel: String,
+    val ext: String,
+    val hasVideo: Boolean,
+    val hasAudio: Boolean,
+    val isGeneric: Boolean,
+    val fileSizeBytes: Long,
+    /** The audio track a video-only stream is muxed with, when there is one. */
+    val mergeAudioSelector: String?,
+    val mergeAudioSizeBytes: Long,
+    val treeUri: String,
+    /** The settings this link was asked for under, so a later change does not rewrite it. */
+    val options: DownloadOptions
+)
+
+/**
+ * The download queue, kept on disk.
+ *
+ * A queue that lives only in memory is a queue that a swipe off the recents list, a crash or
+ * a low-memory kill throws away silently: the user asked for ten downloads, got three, and
+ * nothing anywhere says what happened to the other seven. Written down, the run picks up
+ * where it left off the next time the app opens.
+ *
+ * Stored as JSON in the same preferences the rest of the app uses rather than in a database
+ * of its own. It is a short list, read once at startup and rewritten when an item finishes,
+ * with no queries to answer and nothing to migrate, which is not what a database is for.
+ */
+object DownloadQueueRepository {
+
+    private val QUEUE_KEY = stringPreferencesKey("download_queue")
+
+    /** Everything still waiting, oldest first. */
+    suspend fun load(context: Context): List<QueuedDownload> =
+        decode(context.dataStore.data.first()[QUEUE_KEY])
+
+    /** Replaces the stored queue with [items]. */
+    suspend fun save(context: Context, items: List<QueuedDownload>) {
+        context.dataStore.edit { prefs ->
+            if (items.isEmpty()) prefs.remove(QUEUE_KEY)
+            else prefs[QUEUE_KEY] = encode(items)
+        }
+    }
+
+    /** Adds to the end of the queue, ignoring a link already waiting there. */
+    suspend fun add(context: Context, items: List<QueuedDownload>) {
+        if (items.isEmpty()) return
+        context.dataStore.edit { prefs ->
+            val existing = decode(prefs[QUEUE_KEY])
+            val known = existing.mapTo(mutableSetOf()) { it.url }
+            val merged = existing + items.filterNot { it.url in known }
+            prefs[QUEUE_KEY] = encode(merged)
+        }
+    }
+
+    /** Takes one link out, whether it finished, failed for good, or was cancelled. */
+    suspend fun remove(context: Context, url: String) {
+        context.dataStore.edit { prefs ->
+            val remaining = decode(prefs[QUEUE_KEY]).filterNot { it.url == url }
+            if (remaining.isEmpty()) prefs.remove(QUEUE_KEY)
+            else prefs[QUEUE_KEY] = encode(remaining)
+        }
+    }
+
+    suspend fun clear(context: Context) {
+        context.dataStore.edit { prefs -> prefs.remove(QUEUE_KEY) }
+    }
+
+    private fun encode(items: List<QueuedDownload>): String {
+        val array = JSONArray()
+        items.forEach { item ->
+            array.put(
+                JSONObject().apply {
+                    put("url", item.url)
+                    put("title", item.title)
+                    put("author", item.author)
+                    put("thumbnail", item.thumbnail ?: JSONObject.NULL)
+                    put("duration", item.durationSeconds)
+                    put("formatId", item.formatId)
+                    put("selector", item.selector)
+                    put("formatLabel", item.formatLabel)
+                    put("ext", item.ext)
+                    put("hasVideo", item.hasVideo)
+                    put("hasAudio", item.hasAudio)
+                    put("isGeneric", item.isGeneric)
+                    put("size", item.fileSizeBytes)
+                    put("mergeAudio", item.mergeAudioSelector ?: JSONObject.NULL)
+                    put("mergeAudioSize", item.mergeAudioSizeBytes)
+                    put("treeUri", item.treeUri)
+                    put("options", encodeOptions(item.options))
+                }
+            )
+        }
+        return array.toString()
+    }
+
+    private fun decode(raw: String?): List<QueuedDownload> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            (0 until array.length()).mapNotNull { index ->
+                val item = array.optJSONObject(index) ?: return@mapNotNull null
+                val url = item.optString("url").takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
+
+                QueuedDownload(
+                    url = url,
+                    title = item.optString("title"),
+                    author = item.optString("author"),
+                    thumbnail = item.optString("thumbnail").takeIf {
+                        it.isNotBlank() && it != "null"
+                    },
+                    durationSeconds = item.optInt("duration"),
+                    formatId = item.optString("formatId"),
+                    selector = item.optString("selector"),
+                    formatLabel = item.optString("formatLabel"),
+                    ext = item.optString("ext"),
+                    hasVideo = item.optBoolean("hasVideo"),
+                    hasAudio = item.optBoolean("hasAudio"),
+                    isGeneric = item.optBoolean("isGeneric"),
+                    fileSizeBytes = item.optLong("size"),
+                    mergeAudioSelector = item.optString("mergeAudio").takeIf {
+                        it.isNotBlank() && it != "null"
+                    },
+                    mergeAudioSizeBytes = item.optLong("mergeAudioSize"),
+                    treeUri = item.optString("treeUri"),
+                    options = decodeOptions(item.optJSONObject("options"))
+                )
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun encodeOptions(options: DownloadOptions) = JSONObject().apply {
+        put("videoContainer", options.videoContainer)
+        put("audioContainer", options.audioContainer)
+        put("embedThumbnail", options.embedThumbnail)
+        put("filenameTemplate", options.filenameTemplate)
+        put("sponsorBlock", JSONArray(options.sponsorBlockFilters.toList()))
+        put("addChapters", options.addChapters)
+        put("splitByChapters", options.splitByChapters)
+        put("embedSubs", options.embedSubs)
+        put("writeSubs", options.writeSubs)
+        put("writeAutoSubs", options.writeAutoSubs)
+        put("subLanguages", options.subLanguages)
+    }
+
+    private fun decodeOptions(json: JSONObject?): DownloadOptions {
+        if (json == null) return DownloadOptions()
+        val filters = json.optJSONArray("sponsorBlock")
+        return DownloadOptions(
+            videoContainer = json.optString("videoContainer"),
+            audioContainer = json.optString("audioContainer"),
+            embedThumbnail = json.optBoolean("embedThumbnail"),
+            filenameTemplate = json.optString("filenameTemplate")
+                .ifBlank { DownloadOptions.DEFAULT_FILENAME_TEMPLATE },
+            sponsorBlockFilters = buildSet {
+                if (filters != null) {
+                    for (i in 0 until filters.length()) {
+                        filters.optString(i).takeIf { it.isNotBlank() }?.let { add(it) }
+                    }
+                }
+            },
+            addChapters = json.optBoolean("addChapters", true),
+            splitByChapters = json.optBoolean("splitByChapters"),
+            embedSubs = json.optBoolean("embedSubs", true),
+            writeSubs = json.optBoolean("writeSubs"),
+            writeAutoSubs = json.optBoolean("writeAutoSubs"),
+            subLanguages = json.optString("subLanguages")
+                .ifBlank { DownloadOptions.DEFAULT_SUB_LANGUAGES }
+        )
+    }
+}
+
+/** What the engine needs, rebuilt from what was written down. */
+fun QueuedDownload.toPlan(): DownloadPlan {
+    val format = MediaFormat(
+        formatId = formatId,
+        selector = selector,
+        label = formatLabel,
+        ext = ext,
+        vcodec = null,
+        acodec = null,
+        height = 0,
+        fps = 0,
+        bitrateKbps = 0.0,
+        fileSizeBytes = fileSizeBytes,
+        hasVideo = hasVideo,
+        hasAudio = hasAudio,
+        isGeneric = isGeneric
+    )
+
+    // The muxed audio track is put back where the engine looks for it, which is the info's
+    // own audio list, so a restored download builds the same command as a fresh one.
+    val mergeAudio = mergeAudioSelector?.let {
+        MediaFormat(
+            formatId = it,
+            selector = it,
+            label = "",
+            ext = "",
+            vcodec = null,
+            acodec = null,
+            height = 0,
+            fps = 0,
+            bitrateKbps = 0.0,
+            fileSizeBytes = mergeAudioSizeBytes,
+            hasVideo = false,
+            hasAudio = true
+        )
+    }
+
+    val info = MediaInfo(
+        url = url,
+        title = title,
+        uploader = author,
+        thumbnail = thumbnail,
+        durationSeconds = durationSeconds,
+        videoFormats = if (format.hasVideo) listOf(format) else emptyList(),
+        audioFormats = listOfNotNull(
+            format.takeIf { !it.hasVideo },
+            mergeAudio
+        )
+    )
+
+    return DownloadPlan(info, format, title, author)
+}
+
+/** What to write down for a link about to be queued. */
+fun DownloadPlan.toQueued(options: DownloadOptions, treeUri: String): QueuedDownload {
+    val mergeAudio = if (format.hasVideo && !format.hasAudio) info.mergeAudio else null
+    return QueuedDownload(
+        url = info.url,
+        title = title,
+        author = author,
+        thumbnail = info.thumbnail,
+        durationSeconds = info.durationSeconds,
+        formatId = format.formatId,
+        selector = format.selector,
+        formatLabel = format.label,
+        ext = format.ext,
+        hasVideo = format.hasVideo,
+        hasAudio = format.hasAudio,
+        isGeneric = format.isGeneric,
+        fileSizeBytes = format.fileSizeBytes,
+        mergeAudioSelector = mergeAudio?.selector,
+        mergeAudioSizeBytes = mergeAudio?.fileSizeBytes ?: 0L,
+        treeUri = treeUri,
+        options = options
+    )
+}

--- a/app/src/main/java/com/hazel/android/data/SettingsRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/SettingsRepository.kt
@@ -187,6 +187,40 @@ object SettingsRepository {
         context.dataStore.edit { prefs -> prefs[INCOGNITO_KEY] = enabled }
     }
 
+    // ── Network ──
+
+    private val WIFI_ONLY_KEY = booleanPreferencesKey("wifi_only")
+    private val SPEED_LIMIT_KEY = stringPreferencesKey("speed_limit")
+
+    /**
+     * Refuses to start a download while the phone is on mobile data.
+     *
+     * Checked when a download starts rather than throughout: a transfer already running
+     * when the connection changes is left alone, because killing it partway to save data
+     * wastes what it has already spent.
+     */
+    fun getWifiOnly(context: Context): Flow<Boolean> =
+        context.dataStore.data.map { prefs -> prefs[WIFI_ONLY_KEY] ?: false }
+
+    suspend fun setWifiOnly(context: Context, enabled: Boolean) {
+        context.dataStore.edit { prefs -> prefs[WIFI_ONLY_KEY] = enabled }
+    }
+
+    /**
+     * Ceiling on transfer speed, as yt-dlp spells it: a number with an optional K or M, so
+     * "500K" or "1.5M". Blank means no ceiling, which is the default.
+     */
+    fun getSpeedLimit(context: Context): Flow<String> =
+        context.dataStore.data.map { prefs -> prefs[SPEED_LIMIT_KEY].orEmpty() }
+
+    suspend fun setSpeedLimit(context: Context, limit: String) {
+        context.dataStore.edit { prefs -> prefs[SPEED_LIMIT_KEY] = limit.trim() }
+    }
+
+    /** True when [limit] is something yt-dlp will accept, or blank. */
+    fun isValidSpeedLimit(limit: String): Boolean =
+        limit.isBlank() || Regex("""^\d+(\.\d+)?[KMkm]?$""").matches(limit.trim())
+
     // ── List layout ──
     //
     // Big artwork or a tight list. Two settings rather than one: the results list is read

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -6,6 +6,10 @@ import androidx.lifecycle.viewModelScope
 import com.hazel.android.HazelApp
 import com.hazel.android.data.CookieRepository
 import com.hazel.android.data.DownloadHistoryRepository
+import com.hazel.android.data.DownloadQueueRepository
+import com.hazel.android.data.QueuedDownload
+import com.hazel.android.data.toPlan
+import com.hazel.android.data.toQueued
 import com.hazel.android.data.HistoryEntry
 import com.hazel.android.data.SettingsRepository
 import com.hazel.android.download.extractor.LinkContents
@@ -49,19 +53,6 @@ data class DownloadPlan(
     val format: MediaFormat,
     val title: String,
     val author: String
-)
-
-/**
- * One link waiting its turn, with the settings it was asked for under.
- *
- * The options travel with the link rather than being read when its turn comes, because
- * links can be added while a run is going: three shared in a row are three separate asks,
- * and the second one should not quietly pick up a setting changed after it was made.
- */
-private data class QueuedDownload(
-    val plan: DownloadPlan,
-    val options: DownloadOptions,
-    val treeUri: String
 )
 
 data class DownloadState(
@@ -180,8 +171,48 @@ class DownloadViewModel : ViewModel() {
      * going, and starting one was the only way in. They are appended instead, and the run
      * keeps going until the queue is empty, so a set collected over several shares behaves
      * the same as a set collected in one.
+     *
+     * The same list is written to disk as it changes. A queue held only here is one that a
+     * swipe off the recents list throws away without a word, leaving the user to work out
+     * for themselves which seven of their ten downloads never happened.
      */
     private val queue = ArrayDeque<QueuedDownload>()
+
+    init {
+        restoreQueue()
+    }
+
+    /**
+     * Picks up a queue left behind by a run that did not finish.
+     *
+     * The links are put back in the list so the screen shows what is still owed, and the
+     * run starts itself: they were asked for already, and asking again for permission to
+     * carry on would make the writing-down pointless.
+     */
+    private fun restoreQueue() {
+        downloadScope.launch {
+            val app = HazelApp.instance
+            val pending = runCatching { DownloadQueueRepository.load(app) }
+                .getOrDefault(emptyList())
+            if (pending.isEmpty()) return@launch
+
+            val plans = pending.map { it.toPlan() }
+
+            _state.value = _state.value.copy(
+                results = plans.map { it.info } + _state.value.results.filterNot { existing ->
+                    plans.any { it.info.url == existing.url }
+                },
+                batch = plans.map { BatchItem(url = it.info.url, title = it.title) }
+            )
+
+            synchronized(queue) {
+                // Straight into the queue rather than back through the front door: they are
+                // already written down, and enqueuing them again would only rewrite them.
+                pending.forEach { queue.addLast(it) }
+            }
+            runQueue(app, resumed = true)
+        }
+    }
 
     /** Destination picked through the document picker, or blank for Download/Hazel. */
     private var downloadTreeUri: String = ""
@@ -669,10 +700,14 @@ class DownloadViewModel : ViewModel() {
 
         com.hazel.android.util.PermissionHelper.ensureNotificationPermission(context)
 
-        val queued = plans.map { QueuedDownload(it, options, treeUri) }
+        val queued = plans.map { it.toQueued(options, treeUri) }
         val alreadyRunning = _state.value.isDownloading
 
         synchronized(queue) { queue.addAll(queued) }
+
+        // Written down before anything starts, so a queue interrupted a second later is
+        // still a queue that can be picked up.
+        downloadScope.launch { DownloadQueueRepository.add(HazelApp.instance, queued) }
 
         if (alreadyRunning) {
             // The run in flight picks these up on its own. Only the list the screen shows
@@ -700,30 +735,72 @@ class DownloadViewModel : ViewModel() {
             batch = plans.map { BatchItem(url = it.info.url, title = it.title) }
         )
 
+        runQueue(context.applicationContext, resumed = false)
+    }
+
+    /**
+     * Works through the queue, one link at a time, until there is nothing left in it.
+     *
+     * One at a time is deliberate: yt-dlp already saturates the connection for a single
+     * download, and every download shares one temporary directory, where the sweep that
+     * publishes finished files cannot tell one run's output from another's.
+     *
+     * [resumed] marks a queue picked up from disk rather than one just asked for, which is
+     * the only case where the run has to announce itself.
+     */
+    private fun runQueue(app: Context, resumed: Boolean) {
+        if (resumed) {
+            isBatchCancelled = false
+            downloadContext = app
+            _state.value = _state.value.copy(
+                isDownloading = true,
+                isComplete = false,
+                progress = 0f,
+                totalBytes = 0L,
+                status = "Resuming downloads",
+                isProcessing = false,
+                error = null
+            )
+        }
+
+        val firstTitle = synchronized(queue) { queue.firstOrNull() }?.title.orEmpty()
+
         // Asks the system to leave the process alone for the length of the run. Started
         // before the first link rather than per link, so a set of ten is one service for
         // the whole set instead of ten in a row.
-        DownloadService.start(context, plans.first().title)
+        DownloadService.start(app, firstTitle)
 
         // Run on a scope tied to the process rather than to the screen. A download the user
         // has walked away from should not end because the screen that started it did.
         downloadJob = downloadScope.launch {
-            val app = context.applicationContext
             val cm = app.getSystemService(android.net.ConnectivityManager::class.java)
             val caps = cm?.activeNetwork?.let { cm.getNetworkCapabilities(it) }
             if (caps?.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET) != true) {
                 DownloadService.stop(app)
-                synchronized(queue) { queue.clear() }
-                fail(context, "No internet connection")
+                // The queue is left where it is, on disk and in memory. There is nothing
+                // wrong with what was asked for, only with the connection, so it waits.
+                fail(app, "No internet connection")
                 return@launch
             }
 
-            val cookies = CookieRepository.activeCookieFile(context)
+            // Checked once, as the run starts, rather than throughout. A transfer already
+            // going when the phone drops off Wi-Fi is left alone: stopping it partway
+            // wastes the data it has already spent, which is what the setting is for.
+            if (SettingsRepository.getWifiOnly(app).first() &&
+                caps.hasTransport(android.net.NetworkCapabilities.TRANSPORT_CELLULAR)
+            ) {
+                DownloadService.stop(app)
+                fail(app, "Waiting for Wi-Fi. Downloads are set to Wi-Fi only.")
+                return@launch
+            }
+
+            val cookies = CookieRepository.activeCookieFile(app)
+            val speedLimit = SettingsRepository.getSpeedLimit(app).first()
 
             while (true) {
                 if (isBatchCancelled) break
                 val next = synchronized(queue) { queue.removeFirstOrNull() } ?: break
-                val plan = next.plan
+                val plan = next.toPlan()
                 val options = next.options
                 downloadTreeUri = next.treeUri
 
@@ -740,7 +817,7 @@ class DownloadViewModel : ViewModel() {
                     status = "Starting download",
                     isProcessing = false
                 )
-                DownloadNotificationHelper.showProgress(context, 0, "Starting download", plan.title)
+                DownloadNotificationHelper.showProgress(app, 0, "Starting download", plan.title)
 
                 try {
                     if (!downloadDir.exists()) downloadDir.mkdirs()
@@ -749,7 +826,7 @@ class DownloadViewModel : ViewModel() {
                         executeYtDlp(
                             buildRequest(
                                 plan.info.url, plan.format, options, plan.title, plan.author,
-                                cookies
+                                cookies, speedLimit
                             )
                         )
                     } catch (e: Exception) {
@@ -764,26 +841,26 @@ class DownloadViewModel : ViewModel() {
                         executeYtDlp(
                             buildRequest(
                                 plan.info.url, plan.format, options, plan.title, plan.author,
-                                cookies
+                                cookies, speedLimit
                             )
                         )
                     }
 
                     if (isCancelled || isBatchCancelled) {
-                        finishDownload(context)
+                        finishDownload(app)
                         markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
                         break
                     }
 
-                    finishDownload(context)
+                    finishDownload(app)
                     markBatch(plan.info.url, BatchState.DONE)
                 } catch (_: CancellationException) {
-                    finishDownload(context)
+                    finishDownload(app)
                     markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
                     break
                 } catch (e: Exception) {
                     if (isCancelled || isBatchCancelled) {
-                        finishDownload(context)
+                        finishDownload(app)
                         markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
                         break
                     }
@@ -804,9 +881,14 @@ class DownloadViewModel : ViewModel() {
                 }
             }
 
+            // A run stopped part way leaves whatever it did not reach written down, so the
+            // next launch carries on. Only a run that emptied the queue clears the record.
+            val remaining = synchronized(queue) { queue.toList() }
+            DownloadQueueRepository.save(app, remaining)
             synchronized(queue) { queue.clear() }
-            DownloadService.stop(context.applicationContext)
-            finishBatch(context)
+
+            DownloadService.stop(app)
+            finishBatch(app)
         }
     }
 
@@ -816,6 +898,14 @@ class DownloadViewModel : ViewModel() {
                 if (it.url == url) it.copy(state = state, error = error) else it
             }
         )
+
+        // Taken off the written-down queue once it is settled either way. A link kept there
+        // after it finished would download itself again on the next launch.
+        if (state == BatchState.DONE || state == BatchState.FAILED) {
+            downloadScope.launch {
+                DownloadQueueRepository.remove(HazelApp.instance, url)
+            }
+        }
     }
 
     /** Reports the run as a whole once every item has been attempted. */
@@ -905,7 +995,8 @@ class DownloadViewModel : ViewModel() {
         options: DownloadOptions,
         title: String,
         author: String,
-        cookieFile: File?
+        cookieFile: File?,
+        speedLimit: String
     ): YoutubeDLRequest = buildDownloadRequest(url).apply {
         val isVideo = format.hasVideo
         val container = (if (isVideo) options.videoContainer else options.audioContainer).trim()
@@ -913,6 +1004,11 @@ class DownloadViewModel : ViewModel() {
         addOption("-o", "${downloadDir.absolutePath}/${outputTemplate(options, title, author)}")
         addOption("--no-playlist")
         addOption("--no-mtime")
+
+        // A ceiling on transfer speed, when one was asked for. Left off entirely otherwise,
+        // rather than passed as some very large number, so nothing stands between yt-dlp
+        // and the connection in the ordinary case.
+        if (speedLimit.isNotBlank()) addOption("--limit-rate", speedLimit)
         addOption("--no-check-certificates")
         addOption("--cache-dir", ytDlpCacheDir.absolutePath)
 

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -168,7 +168,7 @@ fun MoreScreen(
         ) {
             // Download location — read-only
             ListItem(
-                headlineContent = { Text("Download Location") },
+                headlineContent = { Text("Downloads") },
                 leadingContent = {
                     Icon(Icons.Filled.Folder, null, tint = MaterialTheme.colorScheme.primary)
                 },
@@ -359,8 +359,7 @@ fun MoreScreen(
             // right: the line under it already says where it goes, and the chevrons above
             // mean "another screen in here", which this is not.
             ListItem(
-                headlineContent = { Text("Source") },
-                supportingContent = { Text("View the project on GitHub") },
+                headlineContent = { Text("Source code") },
                 leadingContent = {
                     Icon(Icons.Filled.Code, null, tint = MaterialTheme.colorScheme.primary)
                 },

--- a/app/src/main/java/com/hazel/android/ui/screens/more/StorageLocationsScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/StorageLocationsScreen.kt
@@ -1,5 +1,18 @@
 package com.hazel.android.ui.screens.more
 
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.hazel.android.data.SettingsRepository
+import kotlinx.coroutines.launch
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -46,6 +59,21 @@ import com.hazel.android.util.StoragePaths
 @Composable
 fun StorageLocationsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val wifiOnly by SettingsRepository.getWifiOnly(context).collectAsState(initial = false)
+    val savedLimit by SettingsRepository.getSpeedLimit(context).collectAsState(initial = "")
+
+    // Seeded from the saved value once it arrives, then left to the field: rebinding it on
+    // every save would fight whoever is typing.
+    var limitDraft by remember { mutableStateOf("") }
+    var limitLoaded by remember { mutableStateOf(false) }
+    LaunchedEffect(savedLimit) {
+        if (!limitLoaded) {
+            limitDraft = savedLimit
+            limitLoaded = true
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -72,7 +100,7 @@ fun StorageLocationsScreen(onBack: () -> Unit) {
             }
             Spacer(modifier = Modifier.width(8.dp))
             Text(
-                "Storage Locations",
+                "Downloads",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary
@@ -81,7 +109,7 @@ fun StorageLocationsScreen(onBack: () -> Unit) {
 
         // Info text
         Text(
-            "Tap any location to open it in your file manager",
+            "Where downloads are saved, and the limits they run under",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
             modifier = Modifier.padding(bottom = 16.dp)
@@ -101,6 +129,98 @@ fun StorageLocationsScreen(onBack: () -> Unit) {
                 onClick = { FolderUtil.open(context, StoragePaths.finalDownloads) }
             )
 
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(
+            "Limits",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            // Checked as a download starts, not while one runs: stopping a transfer partway
+            // because the phone changed networks wastes the data it has already spent.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { scope.launch { SettingsRepository.setWifiOnly(context, !wifiOnly) } }
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Filled.Wifi,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Wi-Fi only", fontWeight = FontWeight.Medium)
+                    Text(
+                        "Downloads wait rather than run on mobile data",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                    )
+                }
+                Switch(
+                    checked = wifiOnly,
+                    onCheckedChange = { enabled ->
+                        scope.launch { SettingsRepository.setWifiOnly(context, enabled) }
+                    }
+                )
+            }
+
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant
+            )
+
+            // Held locally while it is being typed and written once it reads as something
+            // the engine will take, so a half-typed "1" is not saved as a one-byte ceiling.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Filled.Speed,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Speed limit", fontWeight = FontWeight.Medium)
+                    Text(
+                        "Blank for no limit. A number with K or M, like 500K or 1.5M",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                    )
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                OutlinedTextField(
+                    value = limitDraft,
+                    onValueChange = { typed ->
+                        limitDraft = typed
+                        if (SettingsRepository.isValidSpeedLimit(typed)) {
+                            scope.launch { SettingsRepository.setSpeedLimit(context, typed) }
+                        }
+                    },
+                    isError = !SettingsRepository.isValidSpeedLimit(limitDraft),
+                    singleLine = true,
+                    placeholder = { Text("None") },
+                    modifier = Modifier.width(120.dp)
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
**The download queue now outlives the app.** It was held in memory only, so a swipe off the recents list, a crash or a low-memory kill threw it away without a word: ten downloads asked for, three delivered, and nothing anywhere saying what happened to the other seven.

Each link is written down as it is queued, along with the settings it was asked for under, so a later settings change does not rewrite a download already in the queue. It comes off the record once it is settled either way, and whatever is left is picked up on the next launch, restarting itself rather than waiting to be asked again.

Verified on a device: a 489 MB download killed at ~10% came back on relaunch and resumed on its own, reaching 48% without being touched.

**Wi-Fi only** and a **speed limit**, both under Downloads in More. Wi-Fi only is checked as a download starts rather than throughout: a transfer already running when the phone leaves Wi-Fi is left alone, since cutting it off partway wastes the data it has already spent. The speed limit is a choice from a list rather than a typed field, passed through as yt-dlp's rate limit.

**Source code** at the end of More, and the storage screen is renamed Downloads since it now covers more than where files land.

### On the two things not here

**Room.** The queue is written as JSON in the same preferences store the rest of the app uses, not in a database. The app has no database and no KSP set up, and history, a longer list kept forever, is already stored this way. Adding a database and an annotation processor for a short list that is read once at startup, has no queries to answer and nothing to migrate would have been the only one in the app, inconsistent with what sits beside it. The behaviour is the same either way; say the word if you would rather have the database anyway.

**Max concurrent downloads.** Not included, deliberately. Downloads share one temporary directory, and the sweep that publishes finished files takes whatever it finds there and attributes the newest file to the download that just ended. There is also one process id for cancellation and one set of progress fields for the whole engine. Running two at once today would publish one download's file as another's and write the wrong size into history. Doing it properly needs per-download temp directories, per-download process ids and per-download progress in the state and both cards: its own piece of work, which I would rather do than ship a setting that quietly corrupts output.
