### PR TITLE
Pause a download and pick it up where it stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,25 @@ Everything merged since 1.0.0, plus what is open in review.
   assumed answer and corrected once the screen resumed, so it arrived late and pushed
   everything under it down. The answer is read before the first frame.
 - **Source, at the end of More**, opening the project on GitHub.
+- **Pause and resume, from a menu in the corner of a downloading card.** The engine has no
+  pause of its own, so the process is stopped the way a cancel stops it; what makes it a
+  pause is what does not happen afterwards. The part file is left exactly where it is,
+  nothing is published, and the link goes back to the head of the queue. Starting again
+  hands yt-dlp the same part file, which it carries on from rather than fetching a second
+  time. While a download is paused the artwork keeps the treatment that says it is in hand,
+  and the control in the middle becomes the one that starts it again.
+- **A resumed download no longer reads as though it had started over.** The engine counts
+  what the current run has fetched, not what is already on disk, so a download picked up at
+  190 MB reported nought per cent while its file sat untouched. The bytes already written
+  are measured before the engine starts, and the readout never falls below them.
+- **A cancelled download stays cancelled.** Cancelling clears what was still owed from the
+  record, so nothing comes back on the next launch; a paused one is kept, but shown as
+  paused rather than started again, since a launch undoing a pause would make the button
+  mean nothing.
+- **The speed limit is chosen from a list rather than typed.** The value has a shape the
+  engine expects, a typo in it only shows up as a download running at modem speed, and
+  nobody has a particular number in mind. The choices cover the reasons for setting one at
+  all: sparing a metered connection, and leaving room for everything else on the network.
 - **The download queue outlives the app.** It was held in memory only, so a swipe off the
   recents list, a crash or a low-memory kill threw it away without a word: the user asked for
   ten downloads, got three, and nothing anywhere said what happened to the other seven. Each

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,15 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!--
+             Carries the notification's Pause, Resume and Cancel buttons to the download
+             they belong to. Not exported: nothing outside the app has any business
+             stopping a download the user started.
+        -->
+        <receiver
+            android:name=".download.DownloadActionReceiver"
+            android:exported="false" />
+
         <!-- Sign-in browser used to collect cookies for gated media -->
         <activity
             android:name=".ui.screens.cookies.CookieWebViewActivity"

--- a/app/src/main/java/com/hazel/android/data/DownloadQueueRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/DownloadQueueRepository.kt
@@ -39,7 +39,15 @@ data class QueuedDownload(
     val mergeAudioSizeBytes: Long,
     val treeUri: String,
     /** The settings this link was asked for under, so a later change does not rewrite it. */
-    val options: DownloadOptions
+    val options: DownloadOptions,
+    /**
+     * True for a link the user stopped on purpose.
+     *
+     * Kept on the record, because the part file it already fetched is worth coming back to,
+     * but not started again on its own: a pause is a decision, and a launch undoing it
+     * would make the button mean nothing.
+     */
+    val paused: Boolean = false
 )
 
 /**
@@ -94,6 +102,26 @@ object DownloadQueueRepository {
         context.dataStore.edit { prefs -> prefs.remove(QUEUE_KEY) }
     }
 
+    /** Marks one link as stopped on purpose, or as owed again. */
+    suspend fun setPaused(context: Context, url: String, paused: Boolean) {
+        context.dataStore.edit { prefs ->
+            val updated = decode(prefs[QUEUE_KEY]).map {
+                if (it.url == url) it.copy(paused = paused) else it
+            }
+            if (updated.isEmpty()) prefs.remove(QUEUE_KEY)
+            else prefs[QUEUE_KEY] = encode(updated)
+        }
+    }
+
+    /** Clears the paused mark from everything, for a run being started again. */
+    suspend fun clearPaused(context: Context) {
+        context.dataStore.edit { prefs ->
+            val updated = decode(prefs[QUEUE_KEY]).map { it.copy(paused = false) }
+            if (updated.isEmpty()) prefs.remove(QUEUE_KEY)
+            else prefs[QUEUE_KEY] = encode(updated)
+        }
+    }
+
     private fun encode(items: List<QueuedDownload>): String {
         val array = JSONArray()
         items.forEach { item ->
@@ -116,6 +144,7 @@ object DownloadQueueRepository {
                     put("mergeAudioSize", item.mergeAudioSizeBytes)
                     put("treeUri", item.treeUri)
                     put("options", encodeOptions(item.options))
+                    put("paused", item.paused)
                 }
             )
         }
@@ -152,7 +181,8 @@ object DownloadQueueRepository {
                     },
                     mergeAudioSizeBytes = item.optLong("mergeAudioSize"),
                     treeUri = item.optString("treeUri"),
-                    options = decodeOptions(item.optJSONObject("options"))
+                    options = decodeOptions(item.optJSONObject("options")),
+                    paused = item.optBoolean("paused")
                 )
             }
         }.getOrDefault(emptyList())

--- a/app/src/main/java/com/hazel/android/data/SettingsRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/SettingsRepository.kt
@@ -217,9 +217,29 @@ object SettingsRepository {
         context.dataStore.edit { prefs -> prefs[SPEED_LIMIT_KEY] = limit.trim() }
     }
 
-    /** True when [limit] is something yt-dlp will accept, or blank. */
-    fun isValidSpeedLimit(limit: String): Boolean =
-        limit.isBlank() || Regex("""^\d+(\.\d+)?[KMkm]?$""").matches(limit.trim())
+    /**
+     * The ceilings offered, paired with what each is called.
+     *
+     * A list rather than a field to type in: the value has a shape yt-dlp expects, a typo
+     * in it is only discovered when a download runs slower than a modem, and nobody has a
+     * particular number in mind anyway. These cover the reasons for setting one at all,
+     * which are sparing a metered connection and leaving room for everything else on the
+     * network.
+     */
+    val SPEED_LIMITS: List<Pair<String, String>> = listOf(
+        "" to "No limit",
+        "256K" to "256 KB/s",
+        "512K" to "512 KB/s",
+        "1M" to "1 MB/s",
+        "2M" to "2 MB/s",
+        "5M" to "5 MB/s",
+        "10M" to "10 MB/s"
+    )
+
+    /** What to call the stored ceiling, falling back to its own text if it is not a preset. */
+    fun speedLimitLabel(limit: String): String =
+        SPEED_LIMITS.firstOrNull { it.first == limit }?.second
+            ?: limit.ifBlank { "No limit" }
 
     // ── List layout ──
     //

--- a/app/src/main/java/com/hazel/android/download/DownloadActionReceiver.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadActionReceiver.kt
@@ -1,0 +1,82 @@
+package com.hazel.android.download
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.hazel.android.MainActivity
+
+/**
+ * Where the notification's buttons find the download they are meant to act on.
+ *
+ * A notification action arrives as a broadcast, and a broadcast has no view model of its
+ * own. The one driving the download registers itself here while it lives, so pressing Pause
+ * in the shade reaches the same object the button on the card reaches, and the two cannot
+ * disagree about what the download is doing.
+ *
+ * The reference is cleared when that view model is torn down. Holding a dead one would keep
+ * a screen's worth of state alive for as long as the process, and would take its orders on
+ * behalf of a download that no longer exists.
+ */
+object DownloadCommands {
+
+    @Volatile private var active: DownloadViewModel? = null
+
+    fun register(viewModel: DownloadViewModel) {
+        active = viewModel
+    }
+
+    fun unregister(viewModel: DownloadViewModel) {
+        if (active === viewModel) active = null
+    }
+
+    fun current(): DownloadViewModel? = active
+}
+
+/**
+ * Turns a press on Pause, Resume or Cancel in the shade into the same call the screen makes.
+ *
+ * Nothing is decided here. The view model owns what a pause means and what a resume picks
+ * up from, and this only carries the press across, so the notification and the card cannot
+ * drift into doing two different things by the same name.
+ */
+class DownloadActionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val viewModel = DownloadCommands.current()
+
+        when (intent.action) {
+            ACTION_PAUSE -> viewModel?.pauseDownload()
+
+            ACTION_RESUME ->
+                if (viewModel != null) {
+                    viewModel.resumeDownload()
+                } else {
+                    // The process was rebuilt since the download was paused, so there is
+                    // nothing here to resume with. The queue is on disk and the app picks
+                    // it up as it starts, so opening the app is the resume.
+                    openApp(context)
+                }
+
+            ACTION_CANCEL ->
+                if (viewModel != null) {
+                    viewModel.cancelDownload()
+                } else {
+                    DownloadNotificationHelper.cancelPaused(context)
+                    DownloadNotificationHelper.cancelProgress(context)
+                }
+        }
+    }
+
+    private fun openApp(context: Context) {
+        val launch = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        runCatching { context.startActivity(launch) }
+    }
+
+    companion object {
+        const val ACTION_PAUSE = "com.hazel.android.action.PAUSE"
+        const val ACTION_RESUME = "com.hazel.android.action.RESUME"
+        const val ACTION_CANCEL = "com.hazel.android.action.CANCEL"
+    }
+}

--- a/app/src/main/java/com/hazel/android/download/DownloadNotificationHelper.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadNotificationHelper.kt
@@ -34,6 +34,19 @@ object DownloadNotificationHelper {
     private const val COMPLETE_NOTIFICATION_ID = 1002
 
     /**
+     * The held download sits under an id of its own.
+     *
+     * The running notification belongs to the foreground service, and stopping that service
+     * takes its notification down with it. A pause stops the service, so posting the paused
+     * state under the same id would be posting something on its way out.
+     */
+    private const val PAUSED_NOTIFICATION_ID = 1003
+
+    private const val REQUEST_PAUSE = 2001
+    private const val REQUEST_RESUME = 2002
+    private const val REQUEST_CANCEL = 2003
+
+    /**
      * Longest title the notification shows. A title past this length wraps onto a second
      * line and pushes the progress figures off the collapsed notification, which are the
      * part worth reading while a download runs.
@@ -146,6 +159,23 @@ object DownloadNotificationHelper {
     }
 
     /**
+     * A notification button, wired to the receiver that hands it to the running download.
+     *
+     * Each action needs a request code of its own. Two buttons built with the same one are
+     * the same pending intent as far as the system is concerned, and the second would
+     * quietly replace the first, leaving Resume doing whatever Pause was asked to do.
+     */
+    private fun actionIntent(context: Context, action: String, requestCode: Int): PendingIntent {
+        val intent = Intent(context, DownloadActionReceiver::class.java)
+            .setAction(action)
+            .setPackage(context.packageName)
+        return PendingIntent.getBroadcast(
+            context, requestCode, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    /**
      * Shows or updates the progress notification. Always silent, never a popup.
      *
      * The media's own title heads the notification and the live yt-dlp line sits under it,
@@ -201,6 +231,19 @@ object DownloadNotificationHelper {
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setCategory(NotificationCompat.CATEGORY_PROGRESS)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            // A download the user walked away from is one they can only reach from the
+            // shade, so the two things worth doing to it are offered there as well as on
+            // the card: hold it, or give it up.
+            .addAction(
+                R.drawable.ic_notification_pause,
+                "Pause",
+                actionIntent(context, DownloadActionReceiver.ACTION_PAUSE, REQUEST_PAUSE)
+            )
+            .addAction(
+                R.drawable.ic_notification_cancel,
+                "Cancel",
+                actionIntent(context, DownloadActionReceiver.ACTION_CANCEL, REQUEST_CANCEL)
+            )
     }
 
     /**
@@ -266,10 +309,75 @@ object DownloadNotificationHelper {
     /** `ETA 00:10` in a yt-dlp progress line. */
     private val ETA_PATTERN = Regex("""ETA\s+([\d:]+)""", RegexOption.IGNORE_CASE)
 
-    /** Cancel the progress notification */
+    /**
+     * Takes down whatever the download had in the shade, running or held.
+     *
+     * Both go, because every caller is a download that has ended. Leaving the paused entry
+     * behind would offer a Resume button for a download that finished.
+     */
     fun cancelProgress(context: Context) {
         val mgr = context.getSystemService(NotificationManager::class.java)
         mgr.cancel(PROGRESS_NOTIFICATION_ID)
+        mgr.cancel(PAUSED_NOTIFICATION_ID)
+    }
+
+    /**
+     * Says the download is held, and how far it got, with the button that starts it again.
+     *
+     * The figures are the ones the card shows, passed in rather than worked out here, so a
+     * download reading 39 percent on screen does not read as something else in the shade.
+     */
+    fun showPaused(
+        context: Context,
+        progress: Int,
+        mediaTitle: String,
+        doneBytes: Long,
+        totalBytes: Long
+    ) {
+        createChannels(context)
+        val mgr = context.getSystemService(NotificationManager::class.java)
+        mgr.cancel(PROGRESS_NOTIFICATION_ID)
+
+        val detail = buildList {
+            add("Paused")
+            if (progress in 0..100) add("$progress%")
+            if (totalBytes > 0) add("${formatSize(doneBytes)} / ${formatSize(totalBytes)}")
+        }.joinToString("  ·  ")
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_PROGRESS)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(shortTitle(mediaTitle).ifBlank { "Hazel" })
+            .setContentText(detail)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(detail))
+            .setSubText(if (progress in 0..100) "$progress%" else null)
+            .setProgress(100, progress.coerceIn(0, 100), false)
+            // Held in the shade rather than swept away with the run that stopped. A paused
+            // download is still owed, and this is the only thing that says so once the app
+            // is off screen.
+            .setOngoing(true)
+            .setSilent(true)
+            .setOnlyAlertOnce(true)
+            .setContentIntent(launchPendingIntent(context))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .addAction(
+                R.drawable.ic_notification_resume,
+                "Resume",
+                actionIntent(context, DownloadActionReceiver.ACTION_RESUME, REQUEST_RESUME)
+            )
+            .addAction(
+                R.drawable.ic_notification_cancel,
+                "Cancel",
+                actionIntent(context, DownloadActionReceiver.ACTION_CANCEL, REQUEST_CANCEL)
+            )
+
+        mgr.notify(PAUSED_NOTIFICATION_ID, builder.build())
+    }
+
+    /** Takes the held notification down, for a download that is running again. */
+    fun cancelPaused(context: Context) {
+        context.getSystemService(NotificationManager::class.java)
+            .cancel(PAUSED_NOTIFICATION_ID)
     }
 
     /**

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 /** Where one link has got to while a batch is running. */
-enum class BatchState { QUEUED, DOWNLOADING, DONE, FAILED }
+enum class BatchState { QUEUED, DOWNLOADING, PAUSED, DONE, FAILED }
 
 /** One link's outcome inside a batch, so the screen can report progress per item. */
 data class BatchItem(
@@ -144,6 +144,17 @@ class DownloadViewModel : ViewModel() {
     private val processId = "hazel_download"
     @Volatile private var isCancelled = false
 
+    /**
+     * Set while the engine is being stopped for a pause rather than for good.
+     *
+     * The two look identical from inside the run: the process is destroyed and the call
+     * throws. What follows is the opposite in each case, so the difference has to be stated
+     * rather than inferred. A cancel throws the part file away and records a failure; a
+     * pause leaves the part file exactly where it is, which is what lets the download pick
+     * up from there instead of starting again.
+     */
+    @Volatile private var isPaused = false
+
     /** When the progress notification was last redrawn, so updates stay evenly paced. */
     @Volatile private var lastNotifiedAt = 0L
 
@@ -163,6 +174,24 @@ class DownloadViewModel : ViewModel() {
      * against and it does not move.
      */
     @Volatile private var expectedTotalBytes: Long = 0L
+
+    /**
+     * How far along the download actually is, judged by what is on disk.
+     *
+     * A download picked up from a part file reports its own progress from nothing: the
+     * engine counts what this run has fetched, not what is already written. Shown as it
+     * comes, that reads as the download having started again, which is the one thing a
+     * resume must not look like. The same gap opens up without any resume at all, because a
+     * video and its audio are fetched as two runs of the transfer and the second one starts
+     * its count at zero with most of the file already down.
+     *
+     * So the temp directory is measured instead, before the engine starts and again as it
+     * runs, and the readout never falls below what those bytes are worth.
+     */
+    @Volatile private var progressFloor = 0f
+
+    /** When the temp directory was last measured, so the floor is not re-read every line. */
+    @Volatile private var lastFloorCheckAt = 0L
 
     /**
      * Links waiting their turn, and the run that is draining them.
@@ -198,17 +227,29 @@ class DownloadViewModel : ViewModel() {
 
             val plans = pending.map { it.toPlan() }
 
+            // A link the user paused is shown as paused and left alone. Only what was
+            // still owed when the app went away is picked up, which is the difference
+            // between carrying on and overriding a decision already made.
             _state.value = _state.value.copy(
                 results = plans.map { it.info } + _state.value.results.filterNot { existing ->
                     plans.any { it.info.url == existing.url }
                 },
-                batch = plans.map { BatchItem(url = it.info.url, title = it.title) }
+                batch = pending.map {
+                    BatchItem(
+                        url = it.url,
+                        title = it.title,
+                        state = if (it.paused) BatchState.PAUSED else BatchState.QUEUED
+                    )
+                }
             )
+
+            val owed = pending.filterNot { it.paused }
+            if (owed.isEmpty()) return@launch
 
             synchronized(queue) {
                 // Straight into the queue rather than back through the front door: they are
                 // already written down, and enqueuing them again would only rewrite them.
-                pending.forEach { queue.addLast(it) }
+                owed.forEach { queue.addLast(it) }
             }
             runQueue(app, resumed = true)
         }
@@ -805,19 +846,25 @@ class DownloadViewModel : ViewModel() {
                 downloadTreeUri = next.treeUri
 
                 isCancelled = false
+                isPaused = false
                 downloadIsVideo = plan.format.hasVideo
                 markBatch(plan.info.url, BatchState.DOWNLOADING)
 
                 expectedTotalBytes = expectedTotalFor(plan)
+                lastFloorCheckAt = 0L
+                progressFloor = fractionOnDisk()
 
+                val opening = if (progressFloor > 0f) "Resuming" else "Starting download"
                 _state.value = _state.value.copy(
                     info = plan.info,
-                    progress = 0f,
+                    progress = progressFloor,
                     totalBytes = expectedTotalBytes,
-                    status = "Starting download",
+                    status = opening,
                     isProcessing = false
                 )
-                DownloadNotificationHelper.showProgress(app, 0, "Starting download", plan.title)
+                DownloadNotificationHelper.showProgress(
+                    app, (progressFloor * 100f).toInt(), opening, plan.title
+                )
 
                 try {
                     if (!downloadDir.exists()) downloadDir.mkdirs()
@@ -833,17 +880,31 @@ class DownloadViewModel : ViewModel() {
                         // A replayed payload whose addresses have expired fails here. That
                         // is not the link failing, so it is read again and tried once more
                         // before the item is recorded as a failure.
+                        // A pause counts as a reason not to retry, the same as a cancel.
+                        // Without that the retry treated the stopped process as a stale
+                        // payload, threw away the part file and started the download again,
+                        // which is the one thing a pause must not do.
                         val replayed = InfoCache.infoJsonFor(plan.info.url) != null
-                        if (!replayed || isCancelled || isBatchCancelled) throw e
+                        if (!replayed || isCancelled || isBatchCancelled || isPaused) throw e
 
                         InfoCache.invalidate(plan.info.url)
                         purgeFragments()
+                        // The fragments that earned the floor have just been thrown away,
+                        // so the floor goes with them rather than holding the bar up at a
+                        // figure nothing on disk backs any more.
+                        progressFloor = 0f
+                        lastFloorCheckAt = 0L
                         executeYtDlp(
                             buildRequest(
                                 plan.info.url, plan.format, options, plan.title, plan.author,
                                 cookies, speedLimit
                             )
                         )
+                    }
+
+                    if (isPaused) {
+                        holdForResume(next)
+                        break
                     }
 
                     if (isCancelled || isBatchCancelled) {
@@ -855,10 +916,19 @@ class DownloadViewModel : ViewModel() {
                     finishDownload(app)
                     markBatch(plan.info.url, BatchState.DONE)
                 } catch (_: CancellationException) {
+                    if (isPaused) {
+                        holdForResume(next)
+                        break
+                    }
                     finishDownload(app)
                     markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
                     break
                 } catch (e: Exception) {
+                    if (isPaused) {
+                        holdForResume(next)
+                        break
+                    }
+
                     if (isCancelled || isBatchCancelled) {
                         finishDownload(app)
                         markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
@@ -882,13 +952,33 @@ class DownloadViewModel : ViewModel() {
             }
 
             // A run stopped part way leaves whatever it did not reach written down, so the
-            // next launch carries on. Only a run that emptied the queue clears the record.
-            val remaining = synchronized(queue) { queue.toList() }
+            // next launch carries on. A run the user cancelled leaves nothing: they stopped
+            // it on purpose, and a queue that came back on the next launch would be the app
+            // overruling that.
+            val remaining =
+                if (isBatchCancelled) emptyList()
+                else synchronized(queue) { queue.toList() }
             DownloadQueueRepository.save(app, remaining)
             synchronized(queue) { queue.clear() }
 
             DownloadService.stop(app)
             finishBatch(app)
+        }
+    }
+
+    /**
+     * Puts a paused link back at the head of the queue, with its part file untouched.
+     *
+     * Nothing is swept and nothing is published: the temporary directory still holds a
+     * half-finished file, and handing that to the sweep would put half a video in the user's
+     * Downloads folder and write it into the history as though it had finished.
+     */
+    private fun holdForResume(item: QueuedDownload) {
+        synchronized(queue) { queue.addFirst(item.copy(paused = true)) }
+        markBatch(item.url, BatchState.PAUSED)
+        _state.value = _state.value.copy(status = "Paused", isProcessing = false)
+        downloadScope.launch {
+            DownloadQueueRepository.setPaused(HazelApp.instance, item.url, true)
         }
     }
 
@@ -900,7 +990,8 @@ class DownloadViewModel : ViewModel() {
         )
 
         // Taken off the written-down queue once it is settled either way. A link kept there
-        // after it finished would download itself again on the next launch.
+        // after it finished would download itself again on the next launch. A paused one is
+        // not settled: it is still owed, and staying on the record is the point of it.
         if (state == BatchState.DONE || state == BatchState.FAILED) {
             downloadScope.launch {
                 DownloadQueueRepository.remove(HazelApp.instance, url)
@@ -960,6 +1051,48 @@ class DownloadViewModel : ViewModel() {
             try {
                 YoutubeDL.getInstance().destroyProcessById(processId)
             } catch (_: Exception) { /* process may already be done */ }
+        }
+    }
+
+    /**
+     * Stops the download in hand and keeps everything it has fetched so far.
+     *
+     * The engine has no pause of its own, so the process is stopped the same way a cancel
+     * stops it. What makes it a pause is what does not happen afterwards: the part file is
+     * left alone, nothing is published, and the link goes back to the head of the queue,
+     * still written down. Starting again hands yt-dlp the same part file, which it carries
+     * on from rather than fetching a second time.
+     */
+    fun pauseDownload() {
+        if (!_state.value.isDownloading || _state.value.isProcessing) return
+
+        isPaused = true
+        downloadScope.launch {
+            try {
+                YoutubeDL.getInstance().destroyProcessById(processId)
+            } catch (_: Exception) { /* process may already be done */ }
+        }
+    }
+
+    /** Starts the queue again from whatever is at the head of it, paused item included. */
+    fun resumeDownload() {
+        if (_state.value.isDownloading) return
+        val app = HazelApp.instance
+        downloadScope.launch {
+            val pending = runCatching { DownloadQueueRepository.load(app) }
+                .getOrDefault(emptyList())
+            if (pending.isEmpty()) return@launch
+
+            DownloadQueueRepository.clearPaused(app)
+            synchronized(queue) {
+                if (queue.isEmpty()) pending.forEach { queue.addLast(it.copy(paused = false)) }
+            }
+            _state.value = _state.value.copy(
+                batch = _state.value.batch.map {
+                    if (it.state == BatchState.PAUSED) it.copy(state = BatchState.QUEUED) else it
+                }
+            )
+            runQueue(app, resumed = true)
         }
     }
 
@@ -1170,7 +1303,8 @@ class DownloadViewModel : ViewModel() {
     private fun executeYtDlp(request: YoutubeDLRequest) {
         lastNotifiedAt = 0L
         YoutubeDL.getInstance().execute(request, processId) { progress, _, line ->
-            val percent = progress.coerceIn(0f, 100f)
+            refreshFloorFromDisk()
+            val percent = progress.coerceIn(0f, 100f).coerceAtLeast(progressFloor * 100f)
             val status = cleanProgressLine(line) ?: _state.value.status
             val processing = _state.value.isProcessing || isPostProcessing(line)
             _state.value = _state.value.copy(
@@ -1321,7 +1455,53 @@ class DownloadViewModel : ViewModel() {
         }
     }
 
+    /**
+     * What fraction of the expected file is sitting in the temp directory right now.
+     *
+     * Read off the files rather than remembered, because the files are the thing that
+     * actually survives: a download interrupted by the app being killed leaves them behind
+     * with nobody left to have remembered anything.
+     *
+     * Everything in the directory counts, not only what is still a part file. A video whose
+     * transfer finished is renamed off .part while its audio is still being fetched, and
+     * counting part files alone would call that download nearly empty at the moment it is
+     * nearly done. The directory holds one download's working files and nothing else, so
+     * its whole weight is the honest answer.
+     */
+    private fun fractionOnDisk(): Float {
+        if (expectedTotalBytes <= 0L) return 0f
+        val onDisk = try {
+            downloadDir.listFiles()
+                ?.filter { it.isFile && !it.name.endsWith(".ytdl") }
+                ?.sumOf { it.length() }
+                ?: 0L
+        } catch (_: Exception) {
+            0L
+        }
+        if (onDisk <= 0L) return 0f
+
+        // Capped short of the end: a floor of one would leave the bar full for the whole of
+        // whatever is left to do, muxing included.
+        return (onDisk.toFloat() / expectedTotalBytes).coerceIn(0f, 0.99f)
+    }
+
+    /**
+     * Re-measures the temp directory, at most once a second.
+     *
+     * The floor is what keeps the readout honest through a resume and through the switch
+     * from the video stream to the audio one, and it can only do that if it keeps up with
+     * the bytes landing. A progress line arrives many times a second, though, and listing a
+     * directory that often for a number that moves slowly is not worth the reads.
+     */
+    private fun refreshFloorFromDisk() {
+        val now = System.currentTimeMillis()
+        if (now - lastFloorCheckAt < FLOOR_INTERVAL_MS) return
+        lastFloorCheckAt = now
+        progressFloor = maxOf(progressFloor, fractionOnDisk())
+    }
+
     /** Deletes yt-dlp's in-progress artefacts from the temp directory. */
+
     private fun purgeFragments() {
         try {
             downloadDir.listFiles()?.forEach { f ->
@@ -1514,6 +1694,9 @@ class DownloadViewModel : ViewModel() {
 
         /** How often the progress notification is redrawn while a transfer runs. */
         const val NOTIFICATION_INTERVAL_MS = 600L
+
+        /** How often the temp directory is weighed while a transfer runs. */
+        const val FLOOR_INTERVAL_MS = 1000L
 
         /** Stages that run once the transfer itself has finished. */
         val POST_PROCESS_MARKERS = listOf(

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -208,7 +208,15 @@ class DownloadViewModel : ViewModel() {
     private val queue = ArrayDeque<QueuedDownload>()
 
     init {
+        // Offered to the notification's buttons, so a pause from the shade and a pause from
+        // the card are the same call rather than two ideas of what a pause is.
+        DownloadCommands.register(this)
         restoreQueue()
+    }
+
+    override fun onCleared() {
+        DownloadCommands.unregister(this)
+        super.onCleared()
     }
 
     /**
@@ -977,8 +985,54 @@ class DownloadViewModel : ViewModel() {
         synchronized(queue) { queue.addFirst(item.copy(paused = true)) }
         markBatch(item.url, BatchState.PAUSED)
         _state.value = _state.value.copy(status = "Paused", isProcessing = false)
+
+        // The shade is told the same thing the card is, off the same figures. A download
+        // held while the app is off screen otherwise loses its notification along with the
+        // service, leaving nothing anywhere to say it is waiting or to start it again.
+        val app = HazelApp.instance
+        val fraction = _state.value.progress.coerceIn(0f, 1f)
+        val total = _state.value.totalBytes
+        DownloadNotificationHelper.showPaused(
+            context = app,
+            progress = (fraction * 100f).toInt(),
+            mediaTitle = _state.value.info?.title.orEmpty().ifBlank { item.title },
+            doneBytes = (total * fraction).toLong(),
+            totalBytes = total
+        )
+
         downloadScope.launch {
-            DownloadQueueRepository.setPaused(HazelApp.instance, item.url, true)
+            DownloadQueueRepository.setPaused(app, item.url, true)
+        }
+    }
+
+    /**
+     * Throws away a download that was sitting paused.
+     *
+     * Everything a finished run would have done is done here instead: the half-finished
+     * files go, the record goes, and the shade is cleared. What is deliberately not done is
+     * publishing anything, because a cancelled download has nothing worth keeping.
+     */
+    private fun discardHeldDownload() {
+        val app = HazelApp.instance
+        purgeFragments()
+        DownloadNotificationHelper.cancelProgress(app)
+        DownloadNotificationHelper.showCancelled(app)
+
+        synchronized(queue) { queue.clear() }
+        _state.value = _state.value.copy(
+            batch = _state.value.batch.map {
+                if (it.state == BatchState.PAUSED || it.state == BatchState.QUEUED) {
+                    it.copy(state = BatchState.FAILED, error = "Cancelled")
+                } else it
+            },
+            isDownloading = false,
+            isProcessing = false,
+            progress = 0f,
+            status = ""
+        )
+
+        downloadScope.launch {
+            DownloadQueueRepository.save(app, emptyList())
         }
     }
 
@@ -1047,6 +1101,15 @@ class DownloadViewModel : ViewModel() {
     fun cancelDownload() {
         isCancelled = true
         isBatchCancelled = true
+
+        // A paused download has no process left to kill and no run left to tidy up after
+        // it, so giving it up has to be done here. Without this the record survived the
+        // cancel and the download let itself back in on the next launch.
+        if (!_state.value.isDownloading) {
+            discardHeldDownload()
+            return
+        }
+
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 YoutubeDL.getInstance().destroyProcessById(processId)
@@ -1083,6 +1146,7 @@ class DownloadViewModel : ViewModel() {
                 .getOrDefault(emptyList())
             if (pending.isEmpty()) return@launch
 
+            DownloadNotificationHelper.cancelPaused(app)
             DownloadQueueRepository.clearPaused(app)
             synchronized(queue) {
                 if (queue.isEmpty()) pending.forEach { queue.addLast(it.copy(paused = false)) }

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -70,6 +71,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.hazel.android.R
@@ -544,6 +546,8 @@ fun DownloadScreen(
                                     history.any { it.url == info.url },
                             onOpenSheet = openSheet,
                             onCancel = downloadViewModel::cancelDownload,
+                            onPause = downloadViewModel::pauseDownload,
+                            onResume = downloadViewModel::resumeDownload,
                             onRemove = remove
                         )
                     }
@@ -827,6 +831,8 @@ private fun MediaCard(
     alreadyDownloaded: Boolean = false,
     onOpenSheet: () -> Unit,
     onCancel: () -> Unit,
+    onPause: () -> Unit = {},
+    onResume: () -> Unit = {},
     onRemove: (() -> Unit)? = null
 ) {
     val animatedProgress by animateFloatAsState(
@@ -834,6 +840,9 @@ private fun MediaCard(
         animationSpec = M3Motion.emphasized(300),
         label = "cardProgress"
     )
+
+    var menuOpen by remember { mutableStateOf(false) }
+    val isPaused = batchItem?.state == BatchState.PAUSED
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -869,7 +878,71 @@ private fun MediaCard(
                     )
                 }
 
-                if (isDownloading) {
+                // Offered while the download is in hand, and while it is sitting paused.
+                // It is the only way back from a pause, so it cannot go away with the
+                // thing it undoes.
+                if (isDownloading || isPaused) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(6.dp)
+                            .zIndex(1f)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .background(Color.Black.copy(alpha = 0.55f))
+                                .clickable { menuOpen = true },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                Icons.Filled.MoreVert,
+                                contentDescription = "Download options",
+                                modifier = Modifier.size(18.dp),
+                                tint = Color.White
+                            )
+                        }
+
+                        DropdownMenu(
+                            expanded = menuOpen,
+                            onDismissRequest = { menuOpen = false }
+                        ) {
+                            if (isPaused) {
+                                DropdownMenuItem(
+                                    text = { Text("Resume") },
+                                    onClick = {
+                                        menuOpen = false
+                                        onResume()
+                                    }
+                                )
+                            } else {
+                                DropdownMenuItem(
+                                    text = { Text("Pause") },
+                                    // Nothing to pause once the transfer is done and the
+                                    // engine has moved on to merging or tagging.
+                                    enabled = !isProcessing,
+                                    onClick = {
+                                        menuOpen = false
+                                        onPause()
+                                    }
+                                )
+                            }
+                            DropdownMenuItem(
+                                text = { Text("Cancel") },
+                                onClick = {
+                                    menuOpen = false
+                                    onCancel()
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // A paused download is still a download in hand, so the artwork keeps the
+                // treatment that says so. Only the control in the middle changes: there is
+                // nothing to stop any more, and the thing to do is start it again.
+                if (isDownloading || isPaused) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -886,7 +959,15 @@ private fun MediaCard(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        if (isProcessing) {
+                        if (isPaused) {
+                            OverlayChip(text = "Paused", bold = true)
+                            if (totalBytes > 0) {
+                                val done = (totalBytes * animatedProgress).toLong()
+                                OverlayChip(
+                                    text = "${formatFileSize(done)} / ${formatFileSize(totalBytes)}"
+                                )
+                            }
+                        } else if (isProcessing) {
                             OverlayChip(text = "Processing", bold = true)
                         } else {
                             OverlayChip(
@@ -902,7 +983,7 @@ private fun MediaCard(
                         }
                     }
 
-                    if (isProcessing) {
+                    if (isProcessing && !isPaused) {
                         ProcessingShimmer(modifier = Modifier.fillMaxSize())
                     } else {
                         // A progress ring wrapping the cancel control. It is the only
@@ -914,7 +995,7 @@ private fun MediaCard(
                                 .size(60.dp)
                                 .clip(CircleShape)
                                 .background(Color.Black.copy(alpha = 0.55f))
-                                .clickable(onClick = onCancel),
+                                .clickable(onClick = if (isPaused) onResume else onCancel),
                             contentAlignment = Alignment.Center
                         ) {
                             CircularProgressIndicator(
@@ -925,8 +1006,9 @@ private fun MediaCard(
                                 strokeWidth = 3.dp
                             )
                             Icon(
-                                Icons.Filled.Close,
-                                contentDescription = "Cancel download",
+                                if (isPaused) Icons.Filled.PlayArrow else Icons.Filled.Close,
+                                contentDescription =
+                                    if (isPaused) "Resume download" else "Cancel download",
                                 modifier = Modifier.size(22.dp),
                                 tint = Color.White
                             )
@@ -1170,6 +1252,7 @@ private fun MediaRow(
                     }
 
                     val state = when {
+                        batchItem?.state == BatchState.PAUSED -> "Paused"
                         isProcessing -> "Processing"
                         // The same line the card shows: how far along, and how far there is
                         // to go. A percentage on its own says nothing about whether the

--- a/app/src/main/java/com/hazel/android/ui/screens/more/StorageLocationsScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/StorageLocationsScreen.kt
@@ -1,10 +1,14 @@
 package com.hazel.android.ui.screens.more
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Surface
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -62,18 +66,8 @@ fun StorageLocationsScreen(onBack: () -> Unit) {
     val scope = rememberCoroutineScope()
 
     val wifiOnly by SettingsRepository.getWifiOnly(context).collectAsState(initial = false)
-    val savedLimit by SettingsRepository.getSpeedLimit(context).collectAsState(initial = "")
-
-    // Seeded from the saved value once it arrives, then left to the field: rebinding it on
-    // every save would fight whoever is typing.
-    var limitDraft by remember { mutableStateOf("") }
-    var limitLoaded by remember { mutableStateOf(false) }
-    LaunchedEffect(savedLimit) {
-        if (!limitLoaded) {
-            limitDraft = savedLimit
-            limitLoaded = true
-        }
-    }
+    val speedLimit by SettingsRepository.getSpeedLimit(context).collectAsState(initial = "")
+    var limitMenuOpen by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -201,25 +195,64 @@ fun StorageLocationsScreen(onBack: () -> Unit) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text("Speed limit", fontWeight = FontWeight.Medium)
                     Text(
-                        "Blank for no limit. A number with K or M, like 500K or 1.5M",
+                        "How fast a download is allowed to go",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
                     )
                 }
                 Spacer(modifier = Modifier.width(12.dp))
-                OutlinedTextField(
-                    value = limitDraft,
-                    onValueChange = { typed ->
-                        limitDraft = typed
-                        if (SettingsRepository.isValidSpeedLimit(typed)) {
-                            scope.launch { SettingsRepository.setSpeedLimit(context, typed) }
+                Box {
+                    Surface(
+                        onClick = { limitMenuOpen = true },
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f)
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(start = 16.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                SettingsRepository.speedLimitLabel(speedLimit),
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Icon(
+                                Icons.Filled.ArrowDropDown,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
-                    },
-                    isError = !SettingsRepository.isValidSpeedLimit(limitDraft),
-                    singleLine = true,
-                    placeholder = { Text("None") },
-                    modifier = Modifier.width(120.dp)
-                )
+                    }
+
+                    DropdownMenu(
+                        expanded = limitMenuOpen,
+                        onDismissRequest = { limitMenuOpen = false }
+                    ) {
+                        SettingsRepository.SPEED_LIMITS.forEach { (value, label) ->
+                            DropdownMenuItem(
+                                text = { Text(label) },
+                                onClick = {
+                                    limitMenuOpen = false
+                                    scope.launch {
+                                        SettingsRepository.setSpeedLimit(context, value)
+                                    }
+                                },
+                                trailingIcon = if (value == speedLimit) {
+                                    {
+                                        Icon(
+                                            Icons.Filled.Check,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp),
+                                            tint = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+                                } else null
+                            )
+                        }
+                    }
+                }
             }
         }
 

--- a/app/src/main/res/drawable/ic_notification_cancel.xml
+++ b/app/src/main/res/drawable/ic_notification_cancel.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Close, for the notification action that abandons a download. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notification_pause.xml
+++ b/app/src/main/res/drawable/ic_notification_pause.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Pause, for the notification action that holds a running download. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6,19h4V5H6v14zM14,5v14h4V5h-4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notification_resume.xml
+++ b/app/src/main/res/drawable/ic_notification_resume.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Play, for the notification action that starts a held download again. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8,5v14l11,-7z" />
+</vector>


### PR DESCRIPTION
A download can be held and picked up again, from the card and from the notification.

The engine has no pause of its own, so the process is stopped the way a cancel stops it. What makes it a pause is what does not happen afterwards: the part file is left alone, nothing is published, and the link goes back to the head of the queue with its record intact. Starting again hands the engine the same part file, which it carries on from.

Three things had to be got right for that to hold up:

- **The retry branch was purging fragments on a pause.** A stopped process looked like a payload whose addresses had expired, so the recovery path threw away the part file and started the download over, which is the one thing a pause must not do. A pause is now a reason not to retry, the same as a cancel.
- **The readout restarted at zero.** The engine counts what the current run fetched, not what is on disk, so a resumed download reported 0% with 190 MB already written. The same gap opens without any resume at all, because a video and its audio are two transfers and the second one starts its count at nothing with most of the file down. The temp directory is measured instead, before the run and again as it goes, and the readout never falls below what those bytes are worth.
- **Cancelling a held download left its record behind.** There is no process to kill and no run to tidy up after it, so the cancel did nothing and the download let itself back in on the next launch. It now purges its files, clears the record and drops its notification.

Pause, Resume and Cancel are offered in the notification as well as on the card, carried to the same object the card talks to so the two cannot drift into meaning different things by the same name. A held download keeps a notification of its own, because the running one belongs to the foreground service and goes down with it.

Verified on a device: a 453 MB download paused at 32% with 165 MB on disk, resumed from there rather than from zero, and the notification tracked the card throughout.
