### PR TITLE
Unit tests for the link key and the metadata parser

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,7 +165,7 @@ dependencies {
     // DataStore
     implementation(libs.androidx.datastore.preferences)
 
-    // Download Engine — yt-dlp + FFmpeg for Android
+    // Download engine: yt-dlp plus FFmpeg for Android
     implementation(libs.youtubedl.android.library)
     implementation(libs.youtubedl.android.ffmpeg)
 
@@ -177,6 +177,13 @@ dependencies {
     // formats and never downloads: yt-dlp owns both, and this falls back to it on any
     // failure, so a stale extractor costs speed rather than function.
     implementation(libs.newpipe.extractor)
+
+    // Unit tests, covering the two pure parts worth pinning: the link key and the metadata
+    // parser fed saved engine payloads. kotlin-test brings the JUnit runner with it.
+    // org.json is the real implementation, because the one the Android stubs provide throws
+    // on every call rather than parsing anything.
+    testImplementation(libs.kotlin.test.junit)
+    testImplementation(libs.json)
 
     // Coroutines
     implementation(libs.kotlinx.coroutines.android)

--- a/app/src/main/java/com/hazel/android/download/MediaProbe.kt
+++ b/app/src/main/java/com/hazel/android/download/MediaProbe.kt
@@ -289,7 +289,11 @@ object MediaProbe {
         audioFormats = listOf(BEST_AUDIO)
     )
 
-    private fun parse(url: String, root: JSONObject): MediaInfo {
+    /**
+     * Internal rather than private so the unit tests can feed it saved engine payloads.
+     * Nothing outside this module calls it.
+     */
+    internal fun parse(url: String, root: JSONObject): MediaInfo {
         // Carousels and multi-part posts come back as a playlist wrapper even with
         // --no-playlist. Fall through to the first entry that actually carries media.
         val media = root.optJSONArray("entries")

--- a/app/src/test/java/com/hazel/android/download/MediaProbeParseTest.kt
+++ b/app/src/test/java/com/hazel/android/download/MediaProbeParseTest.kt
@@ -1,0 +1,208 @@
+package com.hazel.android.download
+
+import org.json.JSONObject
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.Test
+
+/**
+ * The parser is fed the shapes yt-dlp actually hands back, saved rather than fetched.
+ *
+ * Its whole job is to degrade instead of failing. YouTube fills in every field, and most
+ * other extractors do not: Instagram commonly omits the title, the uploader, the duration,
+ * the codec names and every per-format size, and sometimes describes the media as a single
+ * direct stream with no format list at all. Each of those is a case where the app has to
+ * carry on with less, and none of them raises anything if it stops working.
+ */
+class MediaProbeParseTest {
+
+    private fun parse(json: String) = MediaProbe.parse("https://example.com/x", JSONObject(json))
+
+    // A full payload, of the shape a well described source returns.
+    private val complete = """
+        {
+          "id": "kUox2TPnpzo",
+          "title": "Games Everyone Hated",
+          "uploader": "L321",
+          "duration": 1187,
+          "thumbnails": [
+            {"url": "https://img/small.jpg", "width": 120},
+            {"url": "https://img/large.jpg", "width": 1280}
+          ],
+          "formats": [
+            {"format_id": "399", "ext": "mp4", "vcodec": "av01.0.08M", "acodec": "none",
+             "height": 1080, "fps": 60, "tbr": 3330.0, "filesize": 455606272},
+            {"format_id": "137", "ext": "mp4", "vcodec": "avc1.640028", "acodec": "none",
+             "height": 1080, "fps": 30, "tbr": 4710.0, "filesize": 644245094},
+            {"format_id": "251", "ext": "webm", "vcodec": "none", "acodec": "opus",
+             "tbr": 130.0, "filesize": 19293798}
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `a complete payload comes back whole`() {
+        val info = parse(complete)
+
+        assertEquals("Games Everyone Hated", info.title)
+        assertEquals("L321", info.uploader)
+        assertEquals(1187, info.durationSeconds)
+        assertEquals("https://img/large.jpg", info.thumbnail)
+    }
+
+    @Test
+    fun `video and audio streams are told apart`() {
+        val info = parse(complete)
+
+        assertTrue(info.videoFormats.any { it.formatId == "399" })
+        assertTrue(info.videoFormats.any { it.formatId == "137" })
+        assertTrue(info.audioFormats.any { it.formatId == "251" })
+        assertFalse(info.videoFormats.any { it.formatId == "251" })
+    }
+
+    @Test
+    fun `a size the source stated is taken as stated`() {
+        val format = parse(complete).videoFormats.first { it.formatId == "399" }
+
+        assertEquals(455_606_272L, format.fileSizeBytes)
+        assertFalse(format.isEstimatedSize)
+    }
+
+    @Test
+    fun `a size the source withheld is worked out from the bitrate and marked as a guess`() {
+        val info = parse(
+            """
+            {
+              "title": "No sizes here",
+              "duration": 100,
+              "formats": [
+                {"format_id": "22", "ext": "mp4", "vcodec": "avc1", "acodec": "mp4a",
+                 "height": 720, "tbr": 1000.0}
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val format = info.videoFormats.first { !it.isGeneric }
+        assertTrue(format.isEstimatedSize)
+        assertTrue(format.fileSizeBytes > 0)
+    }
+
+    @Test
+    fun `a source describing one direct stream still offers it as a real format`() {
+        val info = parse("""{"title": "Bare", "url": "https://cdn/clip.mp4"}""")
+
+        // No format list at all, which is the ordinary Instagram shape. The stream the
+        // payload points at is offered under a synthesised id rather than the media being
+        // called undownloadable, and it is assumed to carry both tracks because there is
+        // nothing in the payload saying otherwise.
+        val synthesised = info.videoFormats.first { !it.isGeneric }
+        assertEquals("0", synthesised.formatId)
+        assertTrue(synthesised.hasVideo)
+        assertTrue(synthesised.hasAudio)
+        assertTrue(info.hasResolvedFormats)
+    }
+
+    @Test
+    fun `every tab is headed by a best row whatever the source reported`() {
+        val bare = parse("""{"title": "Bare", "url": "https://cdn/clip.mp4"}""")
+        val full = parse(complete)
+
+        for (info in listOf(bare, full)) {
+            assertTrue(info.videoFormats.first().isGeneric)
+            assertTrue(info.audioFormats.first().isGeneric)
+            assertTrue(info.videoFormats.first().selector.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `a payload with no title at all does not come back blank`() {
+        val info = parse("""{"id": "abc123", "url": "https://cdn/clip.mp4"}""")
+        assertTrue(info.title.isNotBlank())
+    }
+
+    @Test
+    fun `a carousel wrapper falls through to the entry that carries the media`() {
+        val info = parse(
+            """
+            {
+              "_type": "playlist",
+              "title": "A post with two parts",
+              "entries": [
+                {"id": "cover", "title": "Cover"},
+                {"id": "clip", "title": "The clip", "duration": 30,
+                 "formats": [
+                   {"format_id": "0", "ext": "mp4", "vcodec": "avc1", "acodec": "mp4a",
+                    "height": 720, "tbr": 900.0, "filesize": 3375000}
+                 ]}
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals("The clip", info.title)
+        assertTrue(info.videoFormats.any { it.formatId == "0" })
+    }
+
+    @Test
+    fun `a format the source described as unavailable is not offered`() {
+        val info = parse(
+            """
+            {
+              "title": "Mixed",
+              "formats": [
+                {"format_id": "gone", "ext": "mp4", "vcodec": "none", "acodec": "none"},
+                {"format_id": "good", "ext": "mp4", "vcodec": "avc1", "acodec": "none",
+                 "height": 720, "tbr": 900.0, "filesize": 3375000}
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertFalse(info.videoFormats.any { it.formatId == "gone" })
+        assertFalse(info.audioFormats.any { it.formatId == "gone" })
+    }
+
+    @Test
+    fun `the same format listed twice is only offered once`() {
+        val info = parse(
+            """
+            {
+              "title": "Repeats",
+              "formats": [
+                {"format_id": "137", "ext": "mp4", "vcodec": "avc1", "acodec": "none",
+                 "height": 1080, "tbr": 4000.0, "filesize": 100},
+                {"format_id": "137", "ext": "mp4", "vcodec": "avc1", "acodec": "none",
+                 "height": 1080, "tbr": 4000.0, "filesize": 100}
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, info.videoFormats.count { it.formatId == "137" })
+    }
+
+    @Test
+    fun `a video only stream is paired with an audio track to merge`() {
+        val info = parse(complete)
+
+        assertNotNull(info.mergeAudio)
+        assertEquals("251", info.mergeAudio!!.formatId)
+        assertFalse(info.bestVideo!!.hasAudio)
+    }
+
+    @Test
+    fun `the url asked about is the url reported back`() {
+        val info = MediaProbe.parse("https://example.com/asked", JSONObject(complete))
+        assertTrue(info.url.isNotBlank())
+    }
+
+    @Test
+    fun `a thumbnail list with no usable entry reports none rather than failing`() {
+        val info = parse("""{"title": "No art", "thumbnails": [], "url": "https://cdn/c.mp4"}""")
+        assertNull(info.thumbnail)
+    }
+}

--- a/app/src/test/java/com/hazel/android/util/LinkKeyTest.kt
+++ b/app/src/test/java/com/hazel/android/util/LinkKeyTest.kt
@@ -1,0 +1,127 @@
+package com.hazel.android.util
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.test.Test
+
+/**
+ * The link key decides two things the user notices: whether a metadata read is reused, and
+ * whether a repeat download is caught before it starts. Both are silent when they go wrong.
+ * A share sheet link and an address bar link for the same video once produced two different
+ * keys, so the cache missed every time and the same file downloaded twice without a word.
+ */
+class LinkKeyTest {
+
+    @Test
+    fun `share and address bar forms of one video agree`() {
+        assertTrue(
+            LinkKey.sameMedia(
+                "https://youtu.be/kUox2TPnpzo",
+                "https://www.youtube.com/watch?v=kUox2TPnpzo"
+            )
+        )
+    }
+
+    @Test
+    fun `the share sheet's tracking parameter is not part of the media`() {
+        assertEquals(
+            LinkKey.canonical("https://youtu.be/kUox2TPnpzo"),
+            LinkKey.canonical("https://youtu.be/kUox2TPnpzo?si=CJpDuLYmG1d_0TOk")
+        )
+    }
+
+    @Test
+    fun `a video opened from inside a playlist is the same video`() {
+        assertTrue(
+            LinkKey.sameMedia(
+                "https://www.youtube.com/watch?v=kUox2TPnpzo",
+                "https://www.youtube.com/watch?v=kUox2TPnpzo&list=PLabc123&index=4"
+            )
+        )
+    }
+
+    @Test
+    fun `a timestamp does not make it a different video`() {
+        assertTrue(
+            LinkKey.sameMedia(
+                "https://youtu.be/kUox2TPnpzo",
+                "https://youtu.be/kUox2TPnpzo?t=142"
+            )
+        )
+    }
+
+    @Test
+    fun `shorts, embed and live forms all reduce to the id`() {
+        val watch = LinkKey.canonical("https://www.youtube.com/watch?v=kUox2TPnpzo")
+        assertEquals(watch, LinkKey.canonical("https://www.youtube.com/shorts/kUox2TPnpzo"))
+        assertEquals(watch, LinkKey.canonical("https://www.youtube.com/embed/kUox2TPnpzo"))
+        assertEquals(watch, LinkKey.canonical("https://www.youtube.com/live/kUox2TPnpzo"))
+    }
+
+    @Test
+    fun `the key names the service rather than the host it was written with`() {
+        assertEquals("youtube/kUox2TPnpzo", LinkKey.canonical("https://youtu.be/kUox2TPnpzo"))
+    }
+
+    @Test
+    fun `two different videos never collapse onto one key`() {
+        assertNotEquals(
+            LinkKey.canonical("https://youtu.be/kUox2TPnpzo"),
+            LinkKey.canonical("https://youtu.be/dQw4w9WgXcQ")
+        )
+        assertFalse(
+            LinkKey.sameMedia(
+                "https://www.youtube.com/watch?v=kUox2TPnpzo",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+        )
+    }
+
+    @Test
+    fun `a site with no known id form still drops the noise around it`() {
+        assertEquals(
+            LinkKey.canonical("https://example.com/media/clip"),
+            LinkKey.canonical("https://www.example.com/media/clip/?utm_source=x&fbclid=y")
+        )
+    }
+
+    @Test
+    fun `parameters that identify the media on such a site are kept`() {
+        assertNotEquals(
+            LinkKey.canonical("https://example.com/watch?id=1"),
+            LinkKey.canonical("https://example.com/watch?id=2")
+        )
+    }
+
+    @Test
+    fun `the order parameters were written in does not matter`() {
+        assertEquals(
+            LinkKey.canonical("https://example.com/w?a=1&b=2"),
+            LinkKey.canonical("https://example.com/w?b=2&a=1")
+        )
+    }
+
+    @Test
+    fun `something that is not an address is still comparable to itself`() {
+        assertTrue(LinkKey.sameMedia("not a url at all", "not a url at all"))
+        assertEquals(LinkKey.canonical("NOT A URL"), LinkKey.canonical("  not a url  "))
+    }
+
+    @Test
+    fun `two blank links are not treated as the same media`() {
+        assertFalse(LinkKey.sameMedia("", ""))
+    }
+
+    @Test
+    fun `the digest is stable, filename safe, and follows the key rather than the spelling`() {
+        val share = LinkKey.digest("https://youtu.be/kUox2TPnpzo?si=abc")
+        val bar = LinkKey.digest("https://www.youtube.com/watch?v=kUox2TPnpzo")
+
+        assertEquals(share, bar)
+        assertEquals(share, LinkKey.digest("https://youtu.be/kUox2TPnpzo?si=abc"))
+        assertEquals(32, share.length)
+        assertTrue(share.all { it.isDigit() || it in 'a'..'f' })
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ browser = "1.8.0"
 coil = "3.1.0"
 material3 = "1.5.0-alpha12"
 newpipeExtractor = "v0.26.5"
+json = "20250517"
 
 
 [libraries]
@@ -40,6 +41,8 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
+json = { group = "org.json", name = "json", version.ref = "json" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
The app has had no tests. This adds the smallest set with a real payoff: 26 assertions over the two pure parts that fail silently when they break, running on the JVM in about a second with no device involved.

**The link key.** It decides whether a metadata read is reused and whether a repeat download is caught before it starts. A share sheet link and an address bar link for the same video once produced two different keys, so the cache missed every time and the same file downloaded twice without a word. Nothing raised and nothing logged. The suite pins the forms that have to agree, and just as importantly the ones that must not: two different videos are never allowed to collapse onto one key, and a parameter that genuinely identifies the media on an unknown site is kept rather than stripped.

**The metadata parser**, fed saved engine payloads rather than fetched ones. Its whole job is to degrade instead of failing, because most extractors report far less than YouTube does: no title, no duration, no per-format sizes, sometimes no format list at all, sometimes a carousel wrapper around the thing you actually asked for. Those paths only run against sources nobody tests by hand, and yt-dlp changes the shape of its output between releases. `parse` is `internal` rather than `private` so the tests can reach it; nothing else outside the module calls it.

### On what is not covered

**The notification and progress text.** Left out deliberately. Testing it properly meant lifting the line parsing out of the view model and the notification helper into a pure object, and that area is settled and not being worked on, so the refactor would have cost more than it protected.

**Everything else.** Almost none of the rest can be unit tested as it stands: the logic lives inside Composables and a view model that talks to Android directly. Moving it out to make it testable is its own piece of work, not a side effect of adding a test suite.

`kotlin-test` over bare JUnit assertions, on the same JUnit runner. `org.json` is on the test classpath because the implementation the Android stubs provide throws on every call instead of parsing anything.