### PR TITLE
Rebuild the converter screen and fix shared storage below Android 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Everything merged since 1.0.0, plus what is open in review.
 
 ### Added
+- **Every audio format the engine can produce**, chosen from a sheet rather than from three
+  fixed rows. Opus, AAC and MP3 head the list because they are the three anybody actually
+  wants, and each format carries a word or two saying what picking it costs: Best, Most
+  compatible, Lossless, Big file. MP3 stays the default rather than the one tagged Best,
+  because Opus in a `.opus` file only plays out of the box from Android 10 and converting
+  perfectly into something that will not play is not an improvement.
 - **Playlists and channels resolve to every item they hold.** A playlist link produced one
   card, because the metadata read was told to ignore playlists outright. It now asks the
   engine what the link actually holds and reads the answer off its own `_type`, so a
@@ -80,6 +86,33 @@ Everything merged since 1.0.0, plus what is open in review.
   stay pure JVM, and tests are named for the behaviour a user would notice breaking.
 
 ### Fixed
+- **A finished file never reached the user's folder on Android 7 through 10.** Publishing a
+  download or a conversion is a MediaStore insert from Android 11 and a direct file write
+  below it, and the direct write needs a storage permission nothing had ever asked for. The
+  write threw, the failure was caught and logged, and the file stayed in the app's own
+  storage where nothing else on the phone can see it. It is asked for now, as a download or
+  a conversion starts, and where it is refused the screen says the file stayed inside the
+  app instead of naming a folder it never reached.
+- **A file written that way was invisible until something else happened to scan it.** The
+  pre-MediaStore path put the file in the folder and told nothing about it, so no music
+  player or gallery listed it. It is handed to the media scanner as part of the move now.
+- **The converted file reported its size as nothing.** The size was read after the file had
+  been moved out of the folder it was read from, so every conversion finished by announcing
+  zero bytes.
+- **Opening a folder could not work on any version this app supports.** The last of the three
+  attempts built a `file://` intent, which has thrown `FileUriExposedException` since
+  Android 7. The documents URI it tries first was also assembled by pasting a path into a
+  string, leaving the separators unencoded, and it fell back to the whole path when the file
+  was not on the primary volume. It is built through `DocumentsContract` now, and the last
+  attempt opens the system's own picker at the folder rather than an intent that cannot run.
+- **Videos the system could not identify were unpickable.** The converter's picker asked for
+  video types alone, and a document provider that does not recognise a container reports it
+  as a generic stream of bytes, so those files were greyed out. The file the user came to
+  convert was the one they could not choose.
+- **A file whose provider withheld its name became a file called Unknown.** The name is now
+  looked for in the provider, then in the address, and the extension falls back to the
+  declared type, so the cached copy still carries something the engine can recognise. The
+  name is also made safe to use as a filename before it becomes one.
 - **The app crashed when a download was refused for being on mobile data.** With downloads
   set to Wi-Fi only, starting one on mobile data killed the app a few seconds later with
   `ForegroundServiceDidNotStartInTimeException`, leaving the notification behind to say the
@@ -153,6 +186,22 @@ Everything merged since 1.0.0, plus what is open in review.
   speed and ETA on it were routinely stale. It is redrawn on a timer instead.
 
 ### Changed
+- **The converter screen is three decisions in a column**: what to convert, what to turn it
+  into, where it lands. Each is one row that says what it is currently set to, and nothing
+  else appears until it has something to say.
+- **One line of engine output instead of a growing list.** The converter used to stack every
+  line the engine printed into a panel that pushed the rest of the screen off the bottom.
+  It now shows the line the engine is on, replaced in place as the next one arrives, with
+  the percentage on the same row. What the engine said four seconds ago is of no use to
+  anybody watching it work.
+- **The Convert button stays visible while it works.** Material drains a disabled button, and
+  the button spends the whole conversion disabled, so the spinner and the word were barely
+  there. Nothing chosen yet and a conversion already running are now told apart: the first
+  recedes, the second stays lit.
+- **Secondary text across the converter is legible in both themes.** It was drawn by fading
+  the primary text colour, which lands somewhere unreadable on one theme or the other. It
+  uses the theme's own secondary colour now, and the dark theme gained a neutral one rather
+  than inheriting Material's violet-tinted default.
 - **APKs are named after what they are.** Every output was `app-<abi>-<buildType>.apk`, which
   is indistinguishable from every other build once a few of them share a downloads folder.
   They are now `Hazel-v1.0.0-arm64-v8a-stable.apk`: the app, the version, the architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Everything merged since 1.0.0, plus what is open in review.
 
 ### Added
+- **The saved file is named before it is made.** Tapping Convert opens a sheet holding the
+  name the audio will be saved under, filled in from the video's own filename so the usual
+  answer is to leave it and press Start. What is typed there names the file and is written
+  into its title tag, because a file called one thing and announcing itself as another is a
+  distinction nobody asked for.
+- **A License entry under More**, opening the licence in the user's own browser rather than
+  the in-app one: a licence is a thing people save, share and read alongside something else,
+  and none of that works in a window that closes with the screen behind it. The project is
+  licensed GPL-3.0, and the text now ships in the repository.
 - **Every audio format the engine can produce**, chosen from a sheet rather than from three
   fixed rows. Opus, AAC and MP3 head the list because they are the three anybody actually
   wants, and each format carries a word or two saying what picking it costs: Best, Most
@@ -186,6 +195,9 @@ Everything merged since 1.0.0, plus what is open in review.
   speed and ETA on it were routinely stale. It is redrawn on a timer instead.
 
 ### Changed
+- **The converter sits directly under More.** It used to be behind a Tools screen whose
+  entire content was that one row, which is a tap and a screen spent saying one word. Tools
+  remains, empty, for whatever the next tool turns out to be.
 - **The converter screen is three decisions in a column**: what to convert, what to turn it
   into, where it lands. Each is one row that says what it is currently set to, and nothing
   else appears until it has something to say.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/app/src/main/java/com/hazel/android/converter/AudioFormats.kt
+++ b/app/src/main/java/com/hazel/android/converter/AudioFormats.kt
@@ -1,0 +1,118 @@
+package com.hazel.android.converter
+
+/**
+ * What a converted file can come out as.
+ *
+ * The three at the top are the three anybody actually wants, in the order the choice
+ * usually goes: the one that sounds best for its size, the one that sounds nearly as good
+ * and plays on more things, and the one that plays on everything ever made. The rest are
+ * there because somebody always needs one of them, not because they are worth scrolling
+ * past on the way to MP3.
+ */
+data class AudioFormat(
+    /** Handed to yt-dlp as `--audio-format`. */
+    val id: String,
+    /** What the row is headed with. */
+    val name: String,
+    /** Shown beside the name. The engine has the final say on the actual extension. */
+    val extension: String,
+    /** One line saying what choosing this gets you. */
+    val summary: String,
+    val tags: List<AudioTag>
+)
+
+/**
+ * A word on a format, so the list can be read without knowing what any of them mean.
+ *
+ * Quality and size are the two things being traded, so the tags name one or the other and
+ * never both at once. A format is at most two of these.
+ */
+enum class AudioTag(val label: String) {
+    BEST("Best"),
+    RECOMMENDED("Recommended"),
+    COMPATIBLE("Most compatible"),
+    NORMAL("Normal"),
+    SMALL("Small file"),
+    LOSSLESS("Lossless"),
+    BIG("Big file"),
+    BIGGEST("Biggest file")
+}
+
+object AudioFormats {
+
+    val OPUS = AudioFormat(
+        id = "opus",
+        name = "Opus",
+        extension = "opus",
+        summary = "Best quality for the size. Needs a recent player.",
+        tags = listOf(AudioTag.BEST, AudioTag.SMALL)
+    )
+
+    val AAC = AudioFormat(
+        id = "aac",
+        name = "AAC",
+        extension = "aac",
+        summary = "Nearly as good as Opus, and far more players take it.",
+        tags = listOf(AudioTag.RECOMMENDED)
+    )
+
+    val MP3 = AudioFormat(
+        id = "mp3",
+        name = "MP3",
+        extension = "mp3",
+        summary = "Plays on anything, at the cost of some quality.",
+        tags = listOf(AudioTag.COMPATIBLE, AudioTag.NORMAL)
+    )
+
+    /**
+     * The default, and deliberately not the one tagged Best.
+     *
+     * Opus in a `.opus` file is only playable out of the box from Android 10, so on the
+     * older phones this app still supports it would convert perfectly and then not play.
+     * MP3 plays on every one of them.
+     */
+    val DEFAULT = MP3
+
+    val all: List<AudioFormat> = listOf(
+        OPUS,
+        AAC,
+        MP3,
+        AudioFormat(
+            id = "m4a",
+            name = "M4A",
+            extension = "m4a",
+            summary = "The same AAC audio, in the container Apple devices expect.",
+            tags = listOf(AudioTag.NORMAL)
+        ),
+        AudioFormat(
+            id = "vorbis",
+            name = "Vorbis",
+            extension = "ogg",
+            summary = "Open format, quality between MP3 and Opus.",
+            tags = listOf(AudioTag.NORMAL)
+        ),
+        AudioFormat(
+            id = "flac",
+            name = "FLAC",
+            extension = "flac",
+            summary = "Every bit of the original audio kept, compressed losslessly.",
+            tags = listOf(AudioTag.LOSSLESS, AudioTag.BIG)
+        ),
+        AudioFormat(
+            id = "alac",
+            name = "ALAC",
+            extension = "m4a",
+            summary = "Apple's lossless format. Same idea as FLAC, different container.",
+            tags = listOf(AudioTag.LOSSLESS, AudioTag.BIG)
+        ),
+        AudioFormat(
+            id = "wav",
+            name = "WAV",
+            extension = "wav",
+            summary = "No compression at all. Perfect, and enormous.",
+            tags = listOf(AudioTag.LOSSLESS, AudioTag.BIGGEST)
+        )
+    )
+
+    fun byId(id: String): AudioFormat = all.firstOrNull { it.id == id } ?: DEFAULT
+}

--- a/app/src/main/java/com/hazel/android/converter/ConverterLog.kt
+++ b/app/src/main/java/com/hazel/android/converter/ConverterLog.kt
@@ -1,15 +1,10 @@
 package com.hazel.android.converter
 
-/** Severity of a single line in the converter's step list. */
-enum class LogLevel { INFO, SUCCESS, WARN, ERROR }
-
 /**
- * One step in the converter's progress list. [durationMs] is filled in once the step
- * finishes, which is what the UI uses to stop shimmering the active row.
+ * How to colour the one line the converter is currently showing.
+ *
+ * There is no log to go with it any more. While a conversion runs the screen shows what the
+ * engine is doing now and nothing else, so all that is left of the old step list is the
+ * question of whether the current line is ordinary progress or something gone wrong.
  */
-data class LogEntry(
-    val message: String,
-    val level: LogLevel = LogLevel.INFO,
-    val timestamp: Long = System.currentTimeMillis(),
-    val durationMs: Long? = null
-)
+enum class LogLevel { INFO, SUCCESS, WARN, ERROR }

--- a/app/src/main/java/com/hazel/android/converter/ConverterViewModel.kt
+++ b/app/src/main/java/com/hazel/android/converter/ConverterViewModel.kt
@@ -1,15 +1,17 @@
 package com.hazel.android.converter
 
 import android.content.Context
-import android.media.MediaScannerConnection
 import android.net.Uri
-import android.os.Environment
 import android.provider.OpenableColumns
-import com.hazel.android.util.StoragePaths
+import android.webkit.MimeTypeMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hazel.android.util.MediaStoreHelper
+import com.hazel.android.util.PermissionHelper
+import com.hazel.android.util.StoragePaths
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLRequest
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,13 +22,31 @@ data class ConversionState(
     val isConverting: Boolean = false,
     val progress: Float = 0f,
     val inputFileName: String = "",
+    val inputSizeBytes: Long = 0L,
     val inputFileUri: Uri? = null,
-    val selectedQuality: String = "320kbps",
-    val logs: List<LogEntry> = emptyList(),
+    val format: AudioFormat = AudioFormats.DEFAULT,
+    /**
+     * The one line the screen shows while a conversion runs, replaced as the engine
+     * reports the next thing it is doing.
+     *
+     * A list of every line the engine ever printed is a log, and a log is something to read
+     * afterwards when something went wrong. While the conversion is running the only useful
+     * question is what it is doing now, and one line answers it without the screen growing
+     * a scrolling panel that pushes everything else off the bottom.
+     */
+    val statusLine: String = "",
+    val statusLevel: LogLevel = LogLevel.INFO,
     val error: String? = null,
     val isComplete: Boolean = false,
     val outputPath: String = "",
-    val outputFileName: String = ""
+    val outputFileName: String = "",
+    val outputSizeBytes: Long = 0L,
+    /**
+     * True when the finished file could not be published into the user's own Music folder
+     * and stayed in the app's storage instead. Said out loud rather than swallowed: a file
+     * the user cannot find is the same as a file that was never made.
+     */
+    val savedToAppStorage: Boolean = false
 )
 
 class ConverterViewModel : ViewModel() {
@@ -37,244 +57,272 @@ class ConverterViewModel : ViewModel() {
     private val outputDir: File
         get() = StoragePaths.tempConverted
 
-    // ── Log helpers ──
-
-    private fun addLog(message: String, level: LogLevel = LogLevel.INFO) {
-        val now = System.currentTimeMillis()
-        val current = _state.value
-        val updatedLogs = current.logs.toMutableList()
-        if (updatedLogs.isNotEmpty()) {
-            val last = updatedLogs.last()
-            if (last.durationMs == null) {
-                updatedLogs[updatedLogs.lastIndex] = last.copy(durationMs = now - last.timestamp)
-            }
-        }
-        updatedLogs.add(LogEntry(message, level, now))
-        _state.value = current.copy(logs = updatedLogs)
-    }
-
-    private fun closeLastLog() {
-        val now = System.currentTimeMillis()
-        val current = _state.value
-        val updatedLogs = current.logs.toMutableList()
-        if (updatedLogs.isNotEmpty()) {
-            val last = updatedLogs.last()
-            if (last.durationMs == null) {
-                updatedLogs[updatedLogs.lastIndex] = last.copy(durationMs = now - last.timestamp)
-            }
-        }
-        _state.value = current.copy(logs = updatedLogs)
+    private fun say(message: String, level: LogLevel = LogLevel.INFO) {
+        _state.value = _state.value.copy(statusLine = message, statusLevel = level)
     }
 
     // ── File selection ──
 
+    /**
+     * Takes a file the user picked through the system document picker.
+     *
+     * The name and size are read here rather than at conversion time, because both come
+     * from a query against the provider that may not answer the same way later, and the
+     * screen wants to show them the moment the picker closes.
+     */
     fun selectFile(context: Context, uri: Uri) {
-        val fileName = getFileName(context, uri) ?: "Unknown file"
+        val name = displayName(context, uri)
         _state.value = _state.value.copy(
-            inputFileName = fileName,
+            inputFileName = name,
+            inputSizeBytes = fileSize(context, uri),
             inputFileUri = uri,
             error = null,
-            isComplete = false
+            isComplete = false,
+            statusLine = "",
+            progress = 0f
         )
     }
 
-    fun setQuality(quality: String) {
-        _state.value = _state.value.copy(selectedQuality = quality)
+    fun setFormat(format: AudioFormat) {
+        _state.value = _state.value.copy(format = format)
     }
 
-    // ── Conversion — yt-dlp --extract-audio with --enable-file-urls ──
+    // ── Conversion, through yt-dlp's audio extraction, which runs the bundled FFmpeg ──
 
     fun convert(context: Context) {
         val uri = _state.value.inputFileUri ?: return
         if (_state.value.isConverting) return
 
-        // No permission needed — converts write to app-specific dir (always writable)
         _state.value = _state.value.copy(
-            isConverting = true, progress = 0f,
-            error = null, isComplete = false, logs = emptyList()
+            isConverting = true,
+            progress = 0f,
+            error = null,
+            isComplete = false,
+            statusLine = "Preparing",
+            statusLevel = LogLevel.INFO,
+            savedToAppStorage = false
         )
 
         viewModelScope.launch(Dispatchers.IO) {
-            var tempInputFile: File? = null
+            var tempInput: File? = null
             try {
-                addLog("Preparing input file...", LogLevel.INFO)
+                val format = _state.value.format
+                val sourceName = _state.value.inputFileName
 
-                // Copy SAF file → temp WITH original extension (yt-dlp needs it)
-                val originalExt = _state.value.inputFileName.substringAfterLast(".", "mp4")
-                tempInputFile = File(
+                // The engine reads a path, not a content URI, so the picked file is copied
+                // into the cache first. The original extension comes with it, because the
+                // engine works out what it is holding from the name.
+                say("Reading the file")
+                tempInput = File(
                     context.cacheDir,
-                    "convert_input_${System.currentTimeMillis()}.${originalExt}"
+                    "convert_input_${System.currentTimeMillis()}.${sourceExtension(context, uri, sourceName)}"
                 )
-                context.contentResolver.openInputStream(uri)?.use { input ->
-                    tempInputFile.outputStream().use { output ->
-                        input.copyTo(output)
+                val copied = runCatching {
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        tempInput.outputStream().use { output -> input.copyTo(output) }
                     }
-                } ?: run {
-                    addLog("Cannot read input file", LogLevel.ERROR)
-                    closeLastLog()
-                    _state.value = _state.value.copy(
-                        isConverting = false, error = "Cannot read input file"
-                    )
+                }.getOrNull()
+
+                if (copied == null || tempInput.length() == 0L) {
+                    finishWithError("That file could not be read. Pick it again.")
                     return@launch
                 }
 
-                val inputSize = tempInputFile.length()
-                addLog(
-                    "Input: ${_state.value.inputFileName} (${formatSize(inputSize)})",
-                    LogLevel.SUCCESS
-                )
+                say("Converting to ${format.name}")
+                _state.value = _state.value.copy(progress = 0.05f)
 
-                val quality = _state.value.selectedQuality
-                addLog("Converting to $quality...", LogLevel.INFO)
-                _state.value = _state.value.copy(progress = 0.1f)
+                // Everything already in the output folder, so the file this run produces
+                // can be told apart from anything an earlier run left behind.
+                val before = outputDir.listFiles()?.map { it.name }?.toSet().orEmpty()
 
-                val baseName = _state.value.inputFileName.substringBeforeLast(".")
-                val ext = when (quality) {
-                    "AAC 256k" -> "m4a"
-                    "FLAC" -> "flac"
-                    else -> "mp3"
-                }
-                val outputFile = File(outputDir, "${baseName}.${ext}")
-
-                // yt-dlp: --enable-file-urls allows local file:// paths
-                // --extract-audio invokes bundled FFmpeg internally
-                val request = com.yausername.youtubedl_android.YoutubeDLRequest(
-                    "file://${tempInputFile.absolutePath}"
-                ).apply {
+                val baseName = safeBaseName(sourceName)
+                val request = YoutubeDLRequest("file://${tempInput.absolutePath}").apply {
                     addOption("--enable-file-urls")
                     addOption("-x")
-                    addOption("-o", outputFile.absolutePath.replace(".${ext}", ".%(ext)s"))
-
-                    when (quality) {
-                        "320kbps" -> {
-                            addOption("--audio-format", "mp3")
-                            addOption("--audio-quality", "0")
-                        }
-                        "AAC 256k" -> {
-                            addOption("--audio-format", "m4a")
-                            addOption("--audio-quality", "0")
-                        }
-                        "FLAC" -> {
-                            addOption("--audio-format", "flac")
-                            addOption("--audio-quality", "0")
-                        }
-                    }
+                    addOption("--audio-format", format.id)
+                    addOption("--audio-quality", "0")
+                    addOption("-o", File(outputDir, "$baseName.%(ext)s").absolutePath)
                 }
 
-                addLog("Running Engine...", LogLevel.INFO)
-
-                com.yausername.youtubedl_android.YoutubeDL.getInstance().execute(
-                    request, null
-                ) { progress, _, line ->
-                    val percent = progress.coerceIn(0f, 100f)
-                    _state.value = _state.value.copy(progress = percent / 100f)
-
-                    // Pipe ALL raw yt-dlp/FFmpeg output into normal log stream
-                    if (line.isNotBlank()) {
-                        // Clean line: strip [generic], [ExtractAudio], [ffmpeg] etc. prefixes
-                        var cleaned = line.trim()
-                            .replace(Regex("^\\[\\w+] "), "")  // strip [tag] prefix
-                            .replace(Regex("^\\[\\w+:\\w+] "), "") // strip [tag:sub]
-                            .trim()
-
-                        // Skip noisy lines
-                        if (cleaned.startsWith("Extracting URL:") ||
-                            cleaned.startsWith("Downloading webpage") ||
-                            cleaned.isBlank()) return@execute
-
-                        val level = when {
-                            cleaned.lowercase().contains("error") -> LogLevel.ERROR
-                            cleaned.lowercase().contains("warning") -> LogLevel.WARN
-                            cleaned.contains("Destination") || cleaned.contains("Output") -> LogLevel.SUCCESS
-                            cleaned.contains("Stream") || cleaned.contains("Duration") -> LogLevel.SUCCESS
-                            else -> LogLevel.INFO
-                        }
-                        addLog(cleaned, level)
+                YoutubeDL.getInstance().execute(request, null) { progress, _, line ->
+                    if (progress > 0f) {
+                        _state.value = _state.value.copy(
+                            progress = (progress.coerceIn(0f, 100f) / 100f) * 0.9f
+                        )
                     }
+                    readable(line)?.let { say(it, levelOf(it)) }
                 }
 
-                addLog("Conversion complete", LogLevel.SUCCESS)
-                _state.value = _state.value.copy(progress = 0.9f)
-
-                // Find actual output (yt-dlp may adjust extension)
-                val actualOutput = outputDir.listFiles()
-                    ?.filter { it.isFile && it.name.startsWith(baseName) }
+                val produced = outputDir.listFiles()
+                    ?.filter { it.isFile && it.name !in before }
                     ?.maxByOrNull { it.lastModified() }
-                    ?: outputFile
+                    ?: outputDir.listFiles()
+                        ?.filter { it.isFile && it.name.startsWith(baseName) }
+                        ?.maxByOrNull { it.lastModified() }
 
-                if (!actualOutput.exists() || actualOutput.length() == 0L) {
-                    addLog("Output file is empty or missing", LogLevel.ERROR)
-                    closeLastLog()
-                    _state.value = _state.value.copy(
-                        isConverting = false, error = "Output file empty"
-                    )
+                if (produced == null || produced.length() == 0L) {
+                    finishWithError("The conversion produced nothing. Try another format.")
                     return@launch
                 }
 
-                // Move converted file from temp to public Music/Hazel/ via MediaStore
-                addLog("Saving to Music...", LogLevel.INFO)
-                try {
-                    com.hazel.android.util.MediaStoreHelper.moveToPublicStorage(
-                        context, outputDir, StoragePaths.MUSIC_RELATIVE_PATH, isMusic = true
-                    )
-                } catch (e: Exception) {
-                    addLog("Note: Files saved to app storage", LogLevel.WARN)
-                }
+                // Read before the move, because moving it is what takes it out of this
+                // folder, and a file that is no longer there reports a length of nothing.
+                val outputName = produced.name
+                val outputSize = produced.length()
 
-                val outputSize = actualOutput.length()
-                addLog(
-                    "Output: ${actualOutput.name} (${formatSize(outputSize)})",
-                    LogLevel.SUCCESS
-                )
+                say("Saving to ${StoragePaths.CONVERTED_DISPLAY}")
+                _state.value = _state.value.copy(progress = 0.95f)
 
-                addLog("Cleaning temp files...", LogLevel.INFO)
-                delay(100)
-                addLog("Finished", LogLevel.SUCCESS)
-                closeLastLog()
+                val published = publish(context)
 
                 _state.value = _state.value.copy(
                     isConverting = false,
                     isComplete = true,
                     progress = 1f,
-                    outputFileName = actualOutput.name,
-                    outputPath = StoragePaths.CONVERTED_DISPLAY
+                    statusLine = "",
+                    outputFileName = outputName,
+                    outputSizeBytes = outputSize,
+                    outputPath = if (published) StoragePaths.CONVERTED_DISPLAY
+                    else "Hazel's own storage",
+                    savedToAppStorage = !published
                 )
-
             } catch (e: Exception) {
-                val errorMsg = e.message ?: "Conversion failed"
-                addLog("ERROR: $errorMsg", LogLevel.ERROR)
-                closeLastLog()
-                _state.value = _state.value.copy(
-                    isConverting = false, error = errorMsg
-                )
+                finishWithError(readable(e.message.orEmpty()) ?: "The conversion failed.")
             } finally {
-                // Always clean temp file — even on crash
-                tempInputFile?.delete()
+                tempInput?.delete()
             }
         }
     }
 
+    /**
+     * Moves the finished file into the user's own Music folder.
+     *
+     * @return false when it had to be left in the app's storage, which up to Android 10
+     *   is what a refused storage permission means. The caller says so on screen rather
+     *   than reporting a success the user cannot go and find.
+     */
+    private fun publish(context: Context): Boolean {
+        if (!PermissionHelper.canWriteSharedStorage(context)) return false
+        return runCatching {
+            MediaStoreHelper.moveToPublicStorage(
+                context, outputDir, StoragePaths.MUSIC_RELATIVE_PATH, isMusic = true
+            )
+            outputDir.listFiles()?.none { it.isFile } ?: true
+        }.getOrDefault(false)
+    }
+
+    private fun finishWithError(message: String) {
+        _state.value = _state.value.copy(
+            isConverting = false,
+            progress = 0f,
+            statusLine = "",
+            error = message
+        )
+    }
+
     fun resetState() {
-        _state.value = ConversionState()
+        _state.value = ConversionState(format = _state.value.format)
     }
 
-    // ── Helpers ──
-
-    private fun getFileName(context: Context, uri: Uri): String? {
-        return context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-            if (cursor.moveToFirst()) {
-                val nameIdx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                if (nameIdx >= 0) cursor.getString(nameIdx) else null
-            } else null
-        }
+    fun dismissError() {
+        _state.value = _state.value.copy(error = null)
     }
 
-    private fun formatSize(bytes: Long): String {
+    // ── Reading what the engine says ──
+
+    /**
+     * Trims an engine line down to something worth putting on screen, or nothing.
+     *
+     * Every line carries the stage that produced it in brackets, which repeats on every
+     * line and says nothing. What is left is either a sentence about the work or a file
+     * path, and a path fills the line without telling the reader anything they can use.
+     */
+    private fun readable(line: String): String? {
+        val cleaned = line.trim()
+            .replace(TAG_PREFIX, "")
+            .trim()
+        if (cleaned.isBlank()) return null
+        if (NOISE.any { cleaned.startsWith(it, ignoreCase = true) }) return null
+        if (cleaned.startsWith("/") || cleaned.contains("/storage/")) return null
+        return cleaned.take(120)
+    }
+
+    private fun levelOf(line: String): LogLevel {
+        val lower = line.lowercase()
         return when {
-            bytes >= 1_073_741_824 -> "%.1f GB".format(bytes / 1_073_741_824.0)
-            bytes >= 1_048_576 -> "%.1f MB".format(bytes / 1_048_576.0)
-            bytes >= 1024 -> "%.1f KB".format(bytes / 1024.0)
-            else -> "$bytes B"
+            "error" in lower -> LogLevel.ERROR
+            "warning" in lower -> LogLevel.WARN
+            else -> LogLevel.INFO
         }
+    }
+
+    // ── Reading the picked file ──
+
+    private fun displayName(context: Context, uri: Uri): String {
+        val fromProvider = runCatching {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0 && cursor.moveToFirst()) cursor.getString(index) else null
+            }
+        }.getOrNull()
+
+        // A provider is under no obligation to answer either query, and some do not. The
+        // last path segment is a poor name but it is a real one, and it keeps the rest of
+        // the run from being built on the word "Unknown".
+        return fromProvider?.takeIf { it.isNotBlank() }
+            ?: uri.lastPathSegment?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+            ?: "Video"
+    }
+
+    private fun fileSize(context: Context, uri: Uri): Long = runCatching {
+        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val index = cursor.getColumnIndex(OpenableColumns.SIZE)
+            if (index >= 0 && cursor.moveToFirst() && !cursor.isNull(index)) {
+                cursor.getLong(index)
+            } else 0L
+        } ?: 0L
+    }.getOrDefault(0L)
+
+    /**
+     * The extension to give the cached copy, which is how the engine recognises the file.
+     *
+     * The name is asked first and the MIME type second, because a provider that hands back
+     * a name with no extension will usually still say what the file is.
+     */
+    private fun sourceExtension(context: Context, uri: Uri, name: String): String {
+        val fromName = name.substringAfterLast('.', "")
+            .takeIf { it.isNotBlank() && it.length in 1..5 && it.all { c -> c.isLetterOrDigit() } }
+        if (fromName != null) return fromName.lowercase()
+
+        val fromMime = runCatching {
+            MimeTypeMap.getSingleton()
+                .getExtensionFromMimeType(context.contentResolver.getType(uri))
+        }.getOrNull()
+
+        return fromMime?.takeIf { it.isNotBlank() } ?: "mp4"
+    }
+
+    /**
+     * The picked name, made safe to use as a filename.
+     *
+     * A display name comes from the provider and is not a path component: it can carry
+     * separators and characters the filesystem will not take, and the output template is
+     * built out of it.
+     */
+    private fun safeBaseName(name: String): String {
+        val stem = name.substringBeforeLast('.', name).trim()
+        val safe = stem.map { if (it in ILLEGAL || it.code < 32) '_' else it }
+            .joinToString("")
+            .trim('_', ' ', '.')
+        return safe.take(80).ifBlank { "audio" }
+    }
+
+    private companion object {
+        val TAG_PREFIX = Regex("""^\[[^]]+]\s*""")
+        val NOISE = listOf(
+            "Extracting URL", "Downloading webpage", "Downloading 1 format",
+            "Deleting original file"
+        )
+        const val ILLEGAL = "/\\:*?\"<>|"
     }
 }

--- a/app/src/main/java/com/hazel/android/converter/ConverterViewModel.kt
+++ b/app/src/main/java/com/hazel/android/converter/ConverterViewModel.kt
@@ -26,6 +26,13 @@ data class ConversionState(
     val inputFileUri: Uri? = null,
     val format: AudioFormat = AudioFormats.DEFAULT,
     /**
+     * What the saved file is called, editable before the conversion starts.
+     *
+     * It is the filename and the title tag at once, because a file called one thing and
+     * announcing itself as another is a distinction nobody asked for.
+     */
+    val outputName: String = "",
+    /**
      * The one line the screen shows while a conversion runs, replaced as the engine
      * reports the next thing it is doing.
      *
@@ -76,11 +83,16 @@ class ConverterViewModel : ViewModel() {
             inputFileName = name,
             inputSizeBytes = fileSize(context, uri),
             inputFileUri = uri,
+            outputName = safeBaseName(name),
             error = null,
             isComplete = false,
             statusLine = "",
             progress = 0f
         )
+    }
+
+    fun setOutputName(name: String) {
+        _state.value = _state.value.copy(outputName = name)
     }
 
     fun setFormat(format: AudioFormat) {
@@ -135,13 +147,22 @@ class ConverterViewModel : ViewModel() {
                 // can be told apart from anything an earlier run left behind.
                 val before = outputDir.listFiles()?.map { it.name }?.toSet().orEmpty()
 
-                val baseName = safeBaseName(sourceName)
+                val title = _state.value.outputName.trim()
+                    .ifBlank { safeBaseName(sourceName) }
+                val baseName = safeBaseName(title)
+
                 val request = YoutubeDLRequest("file://${tempInput.absolutePath}").apply {
                     addOption("--enable-file-urls")
                     addOption("-x")
                     addOption("--audio-format", format.id)
                     addOption("--audio-quality", "0")
                     addOption("-o", File(outputDir, "$baseName.%(ext)s").absolutePath)
+
+                    // The tags go in during the conversion rather than in a pass of their
+                    // own: extracting the audio is already an FFmpeg run, and these are
+                    // arguments to it. Aimed at that one step by name, so no other step the
+                    // engine might run picks them up.
+                    metadataArgs(title)?.let { addOption("--postprocessor-args", it) }
                 }
 
                 YoutubeDL.getInstance().execute(request, null) { progress, _, line ->
@@ -209,6 +230,20 @@ class ConverterViewModel : ViewModel() {
             )
             outputDir.listFiles()?.none { it.isFile } ?: true
         }.getOrDefault(false)
+    }
+
+    /**
+     * The tagging argument for the extraction step, or null when there is nothing to say.
+     *
+     * Quoted because a title is whatever the user typed and regularly contains spaces, and
+     * the engine hands this string on as a shell-shaped argument list. A quote inside the
+     * text is dropped rather than escaped: it cannot survive that round trip intact, and
+     * losing a character out of a title is a great deal better than a mangled command.
+     */
+    private fun metadataArgs(title: String): String? {
+        if (title.isBlank()) return null
+        val safe = title.replace("\"", "").replace("\\", "")
+        return "ExtractAudio:-metadata title=\"$safe\""
     }
 
     private fun finishWithError(message: String) {

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -749,6 +749,12 @@ class DownloadViewModel : ViewModel() {
 
         com.hazel.android.util.PermissionHelper.ensureNotificationPermission(context)
 
+        // Asked here, on the versions that still need it, because this is where a finished
+        // file is about to be published into the user's own Download folder. Up to Android
+        // 10 that is a direct file write and needs the permission; without it the move
+        // failed and the file stayed in the app's folder without anything saying so.
+        com.hazel.android.util.PermissionHelper.ensureSharedStorageWrite(context)
+
         val queued = plans.map { it.toQueued(options, treeUri) }
         val alreadyRunning = _state.value.isDownloading
 

--- a/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
@@ -238,7 +238,7 @@ fun AppNavigation(
             composable(Screen.More.route) {
                 MoreScreen(
                     onNavigateToAppearance = { navController.navigate("appearance") },
-                    onNavigateToTools = { navController.navigate("tools") },
+                    onNavigateToConverter = { navController.navigate("converter") },
                     onNavigateToStorageLocations = { navController.navigate("storage_locations") },
                     onNavigateToCookies = { navController.navigate("cookies") },
                     onNavigateToFetchSettings = { navController.navigate("fetch_settings") },
@@ -273,10 +273,7 @@ fun AppNavigation(
                 )
             }
             composable("tools") {
-                ToolsScreen(
-                    onNavigateToConverter = { navController.navigate("converter") },
-                    onBack = { navController.popBackStack() }
-                )
+                ToolsScreen(onBack = { navController.popBackStack() })
             }
             composable("converter") {
                 ConverterScreen(onBack = { navController.popBackStack() })

--- a/app/src/main/java/com/hazel/android/ui/screens/converter/ConverterScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/converter/ConverterScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
@@ -61,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
@@ -98,17 +100,30 @@ fun ConverterScreen(
     val context = LocalContext.current
 
     var formatSheetOpen by remember { mutableStateOf(false) }
+    var detailsSheetOpen by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val detailsSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     // Whether a finished file will reach the user's own Music folder. Only ever false up to
     // Android 10, where that is a direct file write and the permission can be refused.
     var canPublish by remember { mutableStateOf(PermissionHelper.canWriteSharedStorage(context)) }
 
+    // Asked for once the details are settled, so the run starts the moment it is answered
+    // either way. A refusal is not a reason to stop: it only changes where the file lands.
     val storageRequest = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { granted ->
         canPublish = granted || !PermissionHelper.needsLegacyStorageWrite()
         converterViewModel.convert(context)
+    }
+
+    fun beginConversion() {
+        detailsSheetOpen = false
+        if (PermissionHelper.needsLegacyStorageWrite() && !canPublish) {
+            storageRequest.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        } else {
+            converterViewModel.convert(context)
+        }
     }
 
     // ACTION_OPEN_DOCUMENT, which every version this app runs on has. The list is wider than
@@ -195,13 +210,7 @@ fun ConverterScreen(
         ConvertButton(
             isConverting = state.isConverting,
             enabled = state.inputFileUri != null && !state.isConverting,
-            onClick = {
-                if (PermissionHelper.needsLegacyStorageWrite() && !canPublish) {
-                    storageRequest.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                } else {
-                    converterViewModel.convert(context)
-                }
-            }
+            onClick = { detailsSheetOpen = true }
         )
 
         AnimatedVisibility(
@@ -235,6 +244,21 @@ fun ConverterScreen(
         }
 
         Spacer(Modifier.height(32.dp))
+    }
+
+    if (detailsSheetOpen) {
+        ModalBottomSheet(
+            onDismissRequest = { detailsSheetOpen = false },
+            sheetState = detailsSheetState,
+            containerColor = MaterialTheme.colorScheme.surface
+        ) {
+            DetailsSheetContent(
+                outputName = state.outputName,
+                extension = state.format.extension,
+                onName = converterViewModel::setOutputName,
+                onConfirm = { beginConversion() }
+            )
+        }
     }
 
     if (formatSheetOpen) {
@@ -651,6 +675,127 @@ private fun ErrorCard(message: String, onDismiss: () -> Unit) {
             Spacer(Modifier.height(6.dp))
             TextButton(onClick = onDismiss, contentPadding = ButtonDefaults.TextButtonContentPadding) {
                 Text("Dismiss", style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}
+
+// ── The details sheet ──
+
+/**
+ * What the saved file will be called and who it says made it, asked once, just before the
+ * conversion starts.
+ *
+ * Asked here rather than on the screen behind it because neither field is a decision until
+ * the moment of converting: the name arrives filled in from the video, and most of the time
+ * the right answer is to leave it and press the button.
+ */
+@Composable
+private fun DetailsSheetContent(
+    outputName: String,
+    extension: String,
+    onName: (String) -> Unit,
+    onConfirm: () -> Unit
+) {
+    Column(modifier = Modifier.padding(start = 22.dp, end = 22.dp, bottom = 28.dp)) {
+        Text(
+            "Save as",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Names the file, and is written into its title tag.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(Modifier.height(18.dp))
+
+        FlatField(
+            value = outputName,
+            onValueChange = onName,
+            label = "Name",
+            // The extension is the format's to decide, so it is shown and not typed.
+            suffix = {
+                Text(
+                    ".$extension",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        )
+
+        Spacer(Modifier.height(20.dp))
+
+        Button(
+            onClick = onConfirm,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            // Not "Convert" a second time. The button behind this sheet says that, and two
+            // of them in a row reads as the first one not having worked.
+            Text("Start", style = MaterialTheme.typography.titleSmall)
+        }
+    }
+}
+
+/**
+ * A text field drawn as one of the screen's own surfaces.
+ *
+ * No outline and no indicator line. Material's bordered fields put a notch in their own
+ * border to hold the label, which is a lot of drawing for two words and sits oddly next to
+ * the flat rows the rest of the screen is made of. The label goes above the text instead,
+ * where it reads the same way the rows do.
+ */
+@Composable
+private fun FlatField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    placeholder: String? = null,
+    suffix: @Composable (() -> Unit)? = null
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(2.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(Modifier.weight(1f)) {
+                    if (value.isEmpty() && placeholder != null) {
+                        Text(
+                            placeholder,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
+                    }
+                    BasicTextField(
+                        value = value,
+                        onValueChange = onValueChange,
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        textStyle = MaterialTheme.typography.bodyLarge.copy(
+                            color = MaterialTheme.colorScheme.onSurface
+                        ),
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary)
+                    )
+                }
+                suffix?.let {
+                    Spacer(Modifier.width(8.dp))
+                    it()
+                }
             }
         }
     }

--- a/app/src/main/java/com/hazel/android/ui/screens/converter/ConverterScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/converter/ConverterScreen.kt
@@ -1,10 +1,8 @@
 package com.hazel.android.ui.screens.converter
 
 import android.Manifest
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
@@ -20,6 +18,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -40,6 +39,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -48,6 +48,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -79,7 +80,6 @@ import com.hazel.android.ui.theme.WarningAmber
 import com.hazel.android.util.FolderUtil
 import com.hazel.android.util.PermissionHelper
 import com.hazel.android.util.StoragePaths
-import java.io.File
 
 /**
  * Turns a video already on the phone into an audio file, with no network involved.
@@ -222,7 +222,7 @@ fun ConverterScreen(
                 sizeBytes = state.outputSizeBytes,
                 where = state.outputPath,
                 inAppStorage = state.savedToAppStorage,
-                onOpen = { openFolder(context, StoragePaths.finalConverted) },
+                onOpen = { FolderUtil.open(context, StoragePaths.finalConverted) },
                 onAgain = converterViewModel::resetState
             )
         }
@@ -283,7 +283,7 @@ private fun Header(onBack: () -> Unit) {
             Text(
                 "Video to audio, nothing leaves the phone",
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }
@@ -339,7 +339,7 @@ private fun SourceCard(
                         "Anything on the phone or an SD card"
                     },
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             if (chosen && enabled) {
@@ -381,7 +381,7 @@ private fun SettingRow(
                 Text(
                     label,
                     style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
@@ -403,7 +403,7 @@ private fun SettingRow(
                     Icons.Filled.ChevronRight,
                     contentDescription = null,
                     modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
@@ -412,6 +412,10 @@ private fun SettingRow(
 
 @Composable
 private fun ConvertButton(isConverting: Boolean, enabled: Boolean, onClick: () -> Unit) {
+    // Two different reasons for a button not to be tappable, and they must not look alike.
+    // Nothing chosen yet is a button waiting to be used and should recede. A conversion
+    // already running is the most active thing on the screen, and Material's disabled
+    // treatment drained it until the word and the spinner were barely there at all.
     Button(
         onClick = onClick,
         modifier = Modifier
@@ -421,7 +425,17 @@ private fun ConvertButton(isConverting: Boolean, enabled: Boolean, onClick: () -
         shape = RoundedCornerShape(16.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            disabledContainerColor = if (isConverting) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+            },
+            disabledContentColor = if (isConverting) {
+                MaterialTheme.colorScheme.onPrimary
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            }
         )
     ) {
         if (isConverting) {
@@ -485,26 +499,28 @@ private fun ProgressPanel(progress: Float, line: String, level: LogLevel) {
             AnimatedContent(
                 targetState = line,
                 transitionSpec = { fadeIn() togetherWith fadeOut() },
-                label = "convertStatus"
+                label = "convertStatus",
+                modifier = Modifier.weight(1f)
             ) { current ->
                 Text(
                     current,
                     style = MaterialTheme.typography.bodySmall,
                     fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.fillMaxWidth()
+                    overflow = TextOverflow.Ellipsis
                 )
             }
+            Spacer(Modifier.width(10.dp))
+            // On the row it belongs to. Underneath it read as a second status below the
+            // first, which is one status too many for one progress bar.
+            Text(
+                "${(animated * 100).toInt()}%",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary
+            )
         }
-
-        Spacer(Modifier.height(6.dp))
-        Text(
-            "${(animated * 100).toInt()}%",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
-        )
     }
 }
 
@@ -521,70 +537,92 @@ private fun ResultCard(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 16.dp),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(18.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
     ) {
-        Column(Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    painter = painterResource(R.drawable.small_right_tick),
-                    contentDescription = null,
-                    tint = SuccessGreen,
-                    modifier = Modifier.size(16.dp)
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    fileName,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
-                )
-            }
-            Spacer(Modifier.height(4.dp))
-            Text(
-                buildString {
-                    if (sizeBytes > 0) {
-                        append(formatSize(sizeBytes))
-                        append("  ·  ")
-                    }
-                    append(where)
-                },
-                style = MaterialTheme.typography.labelSmall,
-                color = if (inAppStorage) WarningAmber
-                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
-            )
-
-            Spacer(Modifier.height(14.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                Button(
-                    onClick = onOpen,
+        Column {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
                     modifier = Modifier
-                        .weight(1f)
-                        .height(40.dp),
-                    shape = RoundedCornerShape(12.dp)
+                        .size(34.dp)
+                        .clip(RoundedCornerShape(17.dp))
+                        .background(SuccessGreen.copy(alpha = 0.16f)),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Icon(Icons.Filled.FolderOpen, null, Modifier.size(16.dp))
-                    Spacer(Modifier.width(6.dp))
-                    Text("Open", style = MaterialTheme.typography.labelMedium)
-                }
-                Button(
-                    onClick = onAgain,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(40.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        contentColor = MaterialTheme.colorScheme.onSurface
+                    Icon(
+                        painter = painterResource(R.drawable.small_right_tick),
+                        contentDescription = null,
+                        tint = SuccessGreen,
+                        modifier = Modifier.size(16.dp)
                     )
-                ) {
-                    Text("Convert another", style = MaterialTheme.typography.labelMedium)
                 }
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Saved",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = SuccessGreen
+                    )
+                    Text(
+                        fileName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        buildString {
+                            if (sizeBytes > 0) {
+                                append(formatSize(sizeBytes))
+                                append("  ·  ")
+                            }
+                            append(where)
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (inAppStorage) WarningAmber
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            // Two words, side by side, separated by a hairline rather than by two filled
+            // shapes. The work is already done: the card is reporting, not asking, and a
+            // pair of solid buttons under a finished job reads as another decision to make.
+            HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
+            Row(modifier = Modifier.height(46.dp)) {
+                FlatAction("Open folder", Modifier.weight(1f), onOpen)
+                VerticalDivider(
+                    modifier = Modifier.padding(vertical = 9.dp),
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+                )
+                FlatAction("Convert another", Modifier.weight(1f), onAgain)
             }
         }
+    }
+}
+
+/** One word, the whole width of its half, with nothing drawn around it. */
+@Composable
+private fun FlatAction(label: String, modifier: Modifier = Modifier, onClick: () -> Unit) {
+    Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary
+        )
     }
 }
 
@@ -608,7 +646,7 @@ private fun ErrorCard(message: String, onDismiss: () -> Unit) {
             Text(
                 message,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Spacer(Modifier.height(6.dp))
             TextButton(onClick = onDismiss, contentPadding = ButtonDefaults.TextButtonContentPadding) {
@@ -648,7 +686,7 @@ private fun SheetHeading(text: String) {
         text,
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.SemiBold,
-        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+        color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(start = 22.dp, top = 6.dp, bottom = 6.dp)
     )
 }
@@ -676,7 +714,7 @@ private fun FormatRow(format: AudioFormat, isSelected: Boolean, onPick: (AudioFo
                     ".${format.extension}",
                     style = MaterialTheme.typography.labelSmall,
                     fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.width(8.dp))
                 TagStrip(format.tags)
@@ -685,7 +723,7 @@ private fun FormatRow(format: AudioFormat, isSelected: Boolean, onPick: (AudioFo
             Text(
                 format.summary,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
         if (isSelected) {
@@ -712,15 +750,15 @@ private fun TagStrip(tags: List<AudioTag>) {
             val loud = tag in LOUD_TAGS
             Surface(
                 shape = RoundedCornerShape(5.dp),
-                color = if (loud) MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
-                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.07f)
+                color = if (loud) MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
+                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
             ) {
                 Text(
                     tag.label,
                     style = MaterialTheme.typography.labelSmall,
                     fontWeight = FontWeight.Medium,
                     color = if (loud) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
                 )
             }
@@ -749,59 +787,4 @@ private fun formatSize(bytes: Long): String = when {
     bytes >= 1_048_576 -> "%.1f MB".format(bytes / 1_048_576.0)
     bytes >= 1024 -> "%.0f KB".format(bytes / 1024.0)
     else -> "$bytes B"
-}
-
-/**
- * Opens the output folder in whatever the device uses to browse files.
- *
- * Three attempts, because there is no one intent every builder answers: the documents
- * provider first, then the app's own file provider, then a plain chooser. The path is put
- * on screen as the last resort, so the user can at least go and find it themselves.
- */
-private fun openFolder(context: Context, folder: File) {
-    if (!folder.exists()) folder.mkdirs()
-
-    val attempts: List<() -> Intent> = listOf(
-        {
-            val relative = folder.absolutePath.substringAfter("/storage/emulated/0/")
-            Intent(Intent.ACTION_VIEW).apply {
-                setDataAndType(
-                    Uri.parse(
-                        "content://com.android.externalstorage.documents/document/primary:" +
-                            relative.replace("/", "%2F")
-                    ),
-                    "vnd.android.document/directory"
-                )
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-        },
-        {
-            Intent(Intent.ACTION_VIEW).apply {
-                setDataAndType(
-                    androidx.core.content.FileProvider.getUriForFile(
-                        context, "${context.packageName}.fileprovider", folder
-                    ),
-                    "resource/folder"
-                )
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-        },
-        {
-            Intent.createChooser(
-                Intent(Intent.ACTION_VIEW).apply {
-                    data = Uri.parse("file://${folder.absolutePath}")
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                },
-                "Open folder"
-            )
-        }
-    )
-
-    for (build in attempts) {
-        val worked = runCatching { context.startActivity(build()) }.isSuccess
-        if (worked) return
-    }
-
-    Toast.makeText(context, folder.absolutePath, Toast.LENGTH_LONG).show()
 }

--- a/app/src/main/java/com/hazel/android/ui/screens/converter/ConverterScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/converter/ConverterScreen.kt
@@ -1,20 +1,23 @@
 package com.hazel.android.ui.screens.converter
 
+import android.Manifest
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
-import androidx.compose.animation.slideInVertically
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,48 +26,69 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.MovieCreation
 import androidx.compose.material.icons.filled.Transform
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import com.hazel.android.util.FolderUtil
-import com.hazel.android.util.StoragePaths
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hazel.android.R
+import com.hazel.android.converter.AudioFormat
+import com.hazel.android.converter.AudioFormats
+import com.hazel.android.converter.AudioTag
 import com.hazel.android.converter.ConverterViewModel
-import com.hazel.android.converter.LogEntry
 import com.hazel.android.converter.LogLevel
+import com.hazel.android.ui.theme.ErrorRed
+import com.hazel.android.ui.theme.SuccessGreen
+import com.hazel.android.ui.theme.WarningAmber
+import com.hazel.android.util.FolderUtil
+import com.hazel.android.util.PermissionHelper
+import com.hazel.android.util.StoragePaths
+import java.io.File
 
+/**
+ * Turns a video already on the phone into an audio file, with no network involved.
+ *
+ * The screen is three decisions in a column, in the order they are made: what to convert,
+ * what to turn it into, and where it lands. Everything else on the screen is a consequence
+ * of one of those three, so nothing appears until it has something to say.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConverterScreen(
     onBack: () -> Unit = {},
@@ -73,433 +97,711 @@ fun ConverterScreen(
     val state by converterViewModel.state.collectAsState()
     val context = LocalContext.current
 
-    val filePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument()
-    ) { uri: Uri? ->
-        uri?.let { converterViewModel.selectFile(context, it) }
+    var formatSheetOpen by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // Whether a finished file will reach the user's own Music folder. Only ever false up to
+    // Android 10, where that is a direct file write and the permission can be refused.
+    var canPublish by remember { mutableStateOf(PermissionHelper.canWriteSharedStorage(context)) }
+
+    val storageRequest = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        canPublish = granted || !PermissionHelper.needsLegacyStorageWrite()
+        converterViewModel.convert(context)
     }
 
-    val logListState = rememberLazyListState()
-    LaunchedEffect(state.logs.size) {
-        if (state.logs.isNotEmpty()) logListState.animateScrollToItem(state.logs.size - 1)
+    // ACTION_OPEN_DOCUMENT, which every version this app runs on has. The list is wider than
+    // just video because a provider decides the type of what it holds, and plenty of them
+    // hand back a generic type for a container they do not recognise. Those files would
+    // otherwise be shown greyed out and unpickable, which reads as the app refusing them.
+    val filePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        uri?.let { picked ->
+            // Held for as long as the picker's own grant allows, which covers the run. Some
+            // providers refuse to make it persistable, so this is attempted and not relied
+            // upon: the file is copied into the cache before any work starts either way.
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    picked, Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            }
+            converterViewModel.selectFile(context, picked)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        canPublish = PermissionHelper.canWriteSharedStorage(context)
     }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
     ) {
-        // Compact header with back arrow
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 4.dp, bottom = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(
-                onClick = onBack,
-                modifier = Modifier.size(32.dp)
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.back),
-                    contentDescription = "Back",
-                    tint = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-            Spacer(modifier = Modifier.width(8.dp))
-            Column {
-                Text(
-                    text = "Offline Converter",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    text = "Video to Audio",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
-                )
-            }
-        }
+        Header(onBack = onBack)
 
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(Modifier.height(18.dp))
 
-        // File Picker
-        OutlinedButton(
-            onClick = { filePickerLauncher.launch(arrayOf("video/*")) },
-            modifier = Modifier.fillMaxWidth().height(52.dp),
-            shape = RoundedCornerShape(14.dp),
-            enabled = !state.isConverting
-        ) {
-            Icon(Icons.Filled.FolderOpen, null, modifier = Modifier.size(20.dp))
-            Spacer(modifier = Modifier.width(8.dp))
+        SourceCard(
+            fileName = state.inputFileName,
+            sizeBytes = state.inputSizeBytes,
+            enabled = !state.isConverting,
+            onPick = { filePicker.launch(PICKER_TYPES) }
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        SettingRow(
+            icon = { tint ->
+                Icon(Icons.Filled.GraphicEq, null, Modifier.size(20.dp), tint = tint)
+            },
+            label = "Convert to",
+            value = state.format.name,
+            trailing = { TagStrip(state.format.tags) },
+            enabled = !state.isConverting,
+            onClick = { formatSheetOpen = true }
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        SettingRow(
+            icon = { tint ->
+                Icon(Icons.Filled.FolderOpen, null, Modifier.size(20.dp), tint = tint)
+            },
+            label = "Saved to",
+            value = if (canPublish) StoragePaths.CONVERTED_DISPLAY else "Hazel's own storage",
+            enabled = true,
+            onClick = { FolderUtil.open(context, StoragePaths.finalConverted) }
+        )
+
+        // Only ever shown on the versions that can refuse. Said before the conversion runs
+        // rather than after it, because it is the sort of thing worth knowing while it can
+        // still be changed.
+        if (!canPublish && PermissionHelper.needsLegacyStorageWrite()) {
+            Spacer(Modifier.height(6.dp))
             Text(
-                text = state.inputFileName.ifBlank { "Choose a video file" },
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 1, overflow = TextOverflow.Ellipsis
+                "Without storage access the file stays inside Hazel, where other apps cannot see it.",
+                style = MaterialTheme.typography.labelSmall,
+                color = WarningAmber,
+                modifier = Modifier.padding(horizontal = 4.dp)
             )
         }
 
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(Modifier.height(18.dp))
 
-        // Where converted files land. This is the only place the audio output folder is
-        // shown, so it sits with the tool that writes to it rather than in a shared list.
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(14.dp),
-            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
-        ) {
-            Row(
-                modifier = Modifier
-                    .clickable { FolderUtil.open(context, StoragePaths.finalConverted) }
-                    .padding(horizontal = 14.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    Icons.Filled.FolderOpen,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        "Saved to",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                    )
-                    Text(
-                        StoragePaths.CONVERTED_DISPLAY,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Quality Options
-        Text(
-            text = "Output Quality",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-
-        val qualities = listOf(
-            Triple("320kbps", "MP3 · High Quality", "Best MP3, most compatible"),
-            Triple("AAC 256k", "AAC · Premium", "Better quality per size"),
-            Triple("FLAC", "FLAC · Lossless", "Perfect copy, large file"),
-        )
-
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            qualities.forEach { (id, title, subtitle) ->
-                val isSelected = state.selectedQuality == id
-                Surface(
-                    onClick = { if (!state.isConverting) converterViewModel.setQuality(id) },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    color = if (isSelected) MaterialTheme.colorScheme.primaryContainer
-                            else MaterialTheme.colorScheme.surface,
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            Icons.Filled.AudioFile, null, modifier = Modifier.size(20.dp),
-                            tint = if (isSelected) MaterialTheme.colorScheme.primary
-                                   else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                title, style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                color = if (isSelected) MaterialTheme.colorScheme.primary
-                                       else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
-                            )
-                            Text(subtitle, style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f))
-                        }
-                        if (isSelected) {
-                            Icon(Icons.Filled.Check, null, Modifier.size(20.dp),
-                                tint = MaterialTheme.colorScheme.primary)
-                        }
-                    }
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // Convert Button
-        Button(
-            onClick = { converterViewModel.convert(context) },
-            modifier = Modifier.fillMaxWidth().height(46.dp),
+        ConvertButton(
+            isConverting = state.isConverting,
             enabled = state.inputFileUri != null && !state.isConverting,
-            shape = RoundedCornerShape(14.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary
-            )
-        ) {
-            if (state.isConverting) {
-                CircularProgressIndicator(Modifier.size(18.dp), MaterialTheme.colorScheme.onPrimary, strokeWidth = 2.dp)
-                Spacer(Modifier.width(8.dp))
-                Text("Converting...", style = MaterialTheme.typography.titleMedium)
-            } else {
-                Icon(Icons.Filled.Transform, null, Modifier.size(20.dp))
-                Spacer(Modifier.width(8.dp))
-                Text("Convert", style = MaterialTheme.typography.titleMedium)
+            onClick = {
+                if (PermissionHelper.needsLegacyStorageWrite() && !canPublish) {
+                    storageRequest.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                } else {
+                    converterViewModel.convert(context)
+                }
             }
+        )
+
+        AnimatedVisibility(
+            visible = state.isConverting,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            ProgressPanel(
+                progress = state.progress,
+                line = state.statusLine,
+                level = state.statusLevel
+            )
         }
 
-        // ── Progress + Logs ──
-        AnimatedVisibility(
-            visible = state.isConverting || state.isComplete || state.error != null,
-            enter = fadeIn(tween(300)) + slideInVertically(tween(300))
+        AnimatedVisibility(visible = state.isComplete, enter = fadeIn(), exit = fadeOut()) {
+            ResultCard(
+                fileName = state.outputFileName,
+                sizeBytes = state.outputSizeBytes,
+                where = state.outputPath,
+                inAppStorage = state.savedToAppStorage,
+                onOpen = { openFolder(context, StoragePaths.finalConverted) },
+                onAgain = converterViewModel::resetState
+            )
+        }
+
+        AnimatedVisibility(visible = state.error != null, enter = fadeIn(), exit = fadeOut()) {
+            ErrorCard(
+                message = state.error.orEmpty(),
+                onDismiss = converterViewModel::dismissError
+            )
+        }
+
+        Spacer(Modifier.height(32.dp))
+    }
+
+    if (formatSheetOpen) {
+        ModalBottomSheet(
+            onDismissRequest = { formatSheetOpen = false },
+            sheetState = sheetState,
+            containerColor = MaterialTheme.colorScheme.surface
         ) {
-            Column(modifier = Modifier.padding(top = 12.dp)) {
-                if (state.isConverting) {
-                    LinearProgressIndicator(
-                        progress = { state.progress },
-                        modifier = Modifier.fillMaxWidth().height(4.dp).clip(RoundedCornerShape(2.dp)),
-                        color = MaterialTheme.colorScheme.primary,
-                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                    )
-                    Spacer(Modifier.height(8.dp))
+            FormatSheetContent(
+                selected = state.format,
+                onPick = {
+                    converterViewModel.setFormat(it)
+                    formatSheetOpen = false
                 }
+            )
+        }
+    }
+}
 
-                // Step logs with shimmer on active entry
-                LazyColumn(
-                    state = logListState,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f, fill = false),
-                    verticalArrangement = Arrangement.spacedBy(2.dp)
-                ) {
-                    itemsIndexed(state.logs) { index, entry ->
-                        val isLast = index == state.logs.lastIndex && entry.durationMs == null
-                        ConverterLogRow(entry, isActive = isLast)
-                    }
-                }
+// ── Pieces ──
 
-                // Completion row — tick + filename + path + Open/Next buttons
-                if (state.isComplete) {
-                    Spacer(Modifier.height(8.dp))
-                    Surface(Modifier.fillMaxWidth(), RoundedCornerShape(12.dp),
-                        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)) {
-                        Column(Modifier.padding(14.dp)) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    painter = painterResource(R.drawable.small_right_tick),
-                                    contentDescription = null,
-                                    tint = com.hazel.android.ui.theme.SuccessGreen,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(
-                                    state.outputFileName,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    maxLines = 1, overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f)
-                                )
-                            }
-                            Spacer(Modifier.height(2.dp))
-                            Text(
-                                state.outputPath,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
-                            )
-                            Spacer(Modifier.height(10.dp))
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(10.dp)
-                            ) {
-                                // Open folder — opens converted output folder in file manager
-                                Button(
-                                    onClick = {
-                                        val folder = com.hazel.android.util.StoragePaths.finalConverted
-                                        openConverterFolderInFileManager(context, folder)
-                                    },
-                                    modifier = Modifier.weight(1f).height(38.dp),
-                                    shape = RoundedCornerShape(10.dp),
-                                    colors = ButtonDefaults.buttonColors(
-                                        containerColor = MaterialTheme.colorScheme.primary,
-                                        contentColor = MaterialTheme.colorScheme.onPrimary
-                                    )
-                                ) {
-                                    Icon(Icons.Filled.FolderOpen, null, modifier = Modifier.size(16.dp))
-                                    Spacer(Modifier.width(4.dp))
-                                    Text("Open", style = MaterialTheme.typography.labelMedium)
-                                }
-                                // Next conversion
-                                Button(
-                                    onClick = { converterViewModel.resetState() },
-                                    modifier = Modifier.weight(1f).height(38.dp),
-                                    shape = RoundedCornerShape(10.dp),
-                                    colors = ButtonDefaults.buttonColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                        contentColor = MaterialTheme.colorScheme.onSurface
-                                    )
-                                ) {
-                                    Text("Next", style = MaterialTheme.typography.labelMedium)
-                                }
-                        }
-                        }
-                    }
-                }
-
-                // Error card
-                if (state.error != null) {
-                    Spacer(Modifier.height(8.dp))
-                    Surface(Modifier.fillMaxWidth(), RoundedCornerShape(12.dp),
-                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)) {
-                        Column(Modifier.padding(16.dp)) {
-                            Text("Conversion Failed", style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.error)
-                            Spacer(Modifier.height(4.dp))
-                            Text(state.error ?: "", style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f))
-                        }
-                    }
-                }
-            }
+@Composable
+private fun Header(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBack, modifier = Modifier.size(32.dp)) {
+            Icon(
+                painter = painterResource(R.drawable.back),
+                contentDescription = "Back",
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Column {
+            Text(
+                "Offline Converter",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                "Video to audio, nothing leaves the phone",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+            )
         }
     }
 }
 
 /**
- * Log row with custom SVG icons and shimmer on active entry.
+ * The file to convert.
+ *
+ * Empty it is the one thing to do on the screen and is sized accordingly. Filled it steps
+ * back into a row, because by then the decision worth looking at is the next one down.
  */
 @Composable
-private fun ConverterLogRow(log: LogEntry, isActive: Boolean) {
-    val shimmerBrush = if (isActive) {
-        val infiniteTransition = rememberInfiniteTransition(label = "shimmer")
-        val translateAnim by infiniteTransition.animateFloat(
-            initialValue = -300f, targetValue = 1000f,
-            animationSpec = infiniteRepeatable(
-                animation = tween(1200, easing = androidx.compose.animation.core.LinearEasing),
-                repeatMode = RepeatMode.Restart
-            ), label = "shimmerTranslate"
-        )
-        androidx.compose.ui.graphics.Brush.linearGradient(
-            colors = listOf(
-                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
-                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
-                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-            ),
-            start = androidx.compose.ui.geometry.Offset(translateAnim, 0f),
-            end = androidx.compose.ui.geometry.Offset(translateAnim + 400f, 0f)
-        )
-    } else null
+private fun SourceCard(
+    fileName: String,
+    sizeBytes: Long,
+    enabled: Boolean,
+    onPick: () -> Unit
+) {
+    val chosen = fileName.isNotBlank()
 
-    val iconRes = when (log.level) {
-        LogLevel.SUCCESS -> R.drawable.small_right_tick
-        LogLevel.ERROR -> R.drawable.small_error_x
-        LogLevel.WARN -> R.drawable.small_warn
-        LogLevel.INFO -> R.drawable.small_chevron
-    }
-    val tintColor = when (log.level) {
-        LogLevel.SUCCESS -> com.hazel.android.ui.theme.SuccessGreen
-        LogLevel.ERROR -> com.hazel.android.ui.theme.ErrorRed
-        LogLevel.WARN -> com.hazel.android.ui.theme.WarningAmber
-        LogLevel.INFO -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
-    }
-
-    val durationStr = log.durationMs?.let { " (${it}ms)" } ?: ""
-
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth()
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        color = if (chosen) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+        else MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
     ) {
-        Icon(
-            painter = painterResource(iconRes),
-            contentDescription = null,
-            tint = tintColor,
-            modifier = Modifier.size(14.dp)
-        )
-        Spacer(modifier = Modifier.width(6.dp))
+        Row(
+            modifier = Modifier
+                .clickable(enabled = enabled, onClick = onPick)
+                .padding(horizontal = 16.dp, vertical = if (chosen) 14.dp else 22.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Filled.MovieCreation,
+                contentDescription = null,
+                modifier = Modifier.size(if (chosen) 22.dp else 26.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    if (chosen) fileName else "Choose a video file",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    if (chosen) {
+                        if (sizeBytes > 0) formatSize(sizeBytes) else "Ready"
+                    } else {
+                        "Anything on the phone or an SD card"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                )
+            }
+            if (chosen && enabled) {
+                Text(
+                    "Change",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
 
-        if (shimmerBrush != null) {
-            Text(
-                log.message + durationStr,
-                style = TextStyle(brush = shimmerBrush, fontFamily = FontFamily.Monospace,
-                    fontSize = 12.sp, fontWeight = FontWeight.SemiBold),
-                maxLines = 1, overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
+/** One tappable line: an icon, what it is, what it is set to. */
+@Composable
+private fun SettingRow(
+    icon: @Composable (Color) -> Unit,
+    label: String,
+    value: String,
+    enabled: Boolean,
+    trailing: @Composable (() -> Unit)? = null,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 13.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            icon(MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        value,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    trailing?.let {
+                        Spacer(Modifier.width(8.dp))
+                        it()
+                    }
+                }
+            }
+            if (enabled) {
+                Icon(
+                    Icons.Filled.ChevronRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConvertButton(isConverting: Boolean, enabled: Boolean, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        enabled = enabled,
+        shape = RoundedCornerShape(16.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
+        )
+    ) {
+        if (isConverting) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                color = MaterialTheme.colorScheme.onPrimary,
+                strokeWidth = 2.dp
             )
+            Spacer(Modifier.width(10.dp))
+            Text("Converting", style = MaterialTheme.typography.titleSmall)
         } else {
-            Text(
-                log.message,
-                fontSize = 12.sp, fontFamily = FontFamily.Monospace,
-                color = when (log.level) {
-                    LogLevel.SUCCESS -> com.hazel.android.ui.theme.SuccessGreen
-                    LogLevel.ERROR -> com.hazel.android.ui.theme.ErrorRed
-                    LogLevel.WARN -> com.hazel.android.ui.theme.WarningAmber
-                    LogLevel.INFO -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                },
-                maxLines = 1, overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
+            Icon(Icons.Filled.Transform, null, Modifier.size(20.dp))
+            Spacer(Modifier.width(10.dp))
+            Text("Convert", style = MaterialTheme.typography.titleSmall)
+        }
+    }
+}
+
+/**
+ * The bar, and the one line under it.
+ *
+ * The line is replaced in place as the engine reports the next thing it is doing, rather
+ * than added to a list that grows down the screen. What the engine said four seconds ago is
+ * of no use to anybody watching it work, and a panel of it pushes everything else off the
+ * bottom of the screen.
+ */
+@Composable
+private fun ProgressPanel(progress: Float, line: String, level: LogLevel) {
+    val animated by animateFloatAsState(targetValue = progress, label = "convertProgress")
+
+    Column(modifier = Modifier.padding(top = 16.dp)) {
+        LinearProgressIndicator(
+            progress = { animated },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp)),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(6.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(
+                        when (level) {
+                            LogLevel.ERROR -> ErrorRed
+                            LogLevel.WARN -> WarningAmber
+                            LogLevel.SUCCESS -> SuccessGreen
+                            LogLevel.INFO -> MaterialTheme.colorScheme.primary
+                        }
+                    )
             )
+            Spacer(Modifier.width(10.dp))
+            // Crossfaded rather than swapped, so a line replaced several times a second
+            // reads as one line changing instead of as flicker.
+            AnimatedContent(
+                targetState = line,
+                transitionSpec = { fadeIn() togetherWith fadeOut() },
+                label = "convertStatus"
+            ) { current ->
+                Text(
+                    current,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
 
-        // Duration badge
-        if (log.durationMs != null) {
+        Spacer(Modifier.height(6.dp))
+        Text(
+            "${(animated * 100).toInt()}%",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+        )
+    }
+}
+
+@Composable
+private fun ResultCard(
+    fileName: String,
+    sizeBytes: Long,
+    where: String,
+    inAppStorage: Boolean,
+    onOpen: () -> Unit,
+    onAgain: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    painter = painterResource(R.drawable.small_right_tick),
+                    contentDescription = null,
+                    tint = SuccessGreen,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    fileName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            Spacer(Modifier.height(4.dp))
             Text(
-                "%.2fs".format(log.durationMs / 1000.0),
-                fontSize = 10.sp, fontFamily = FontFamily.Monospace,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                buildString {
+                    if (sizeBytes > 0) {
+                        append(formatSize(sizeBytes))
+                        append("  ·  ")
+                    }
+                    append(where)
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = if (inAppStorage) WarningAmber
+                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+            )
+
+            Spacer(Modifier.height(14.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                Button(
+                    onClick = onOpen,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(40.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Icon(Icons.Filled.FolderOpen, null, Modifier.size(16.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Open", style = MaterialTheme.typography.labelMedium)
+                }
+                Button(
+                    onClick = onAgain,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(40.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurface
+                    )
+                ) {
+                    Text("Convert another", style = MaterialTheme.typography.labelMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorCard(message: String, onDismiss: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "That did not convert",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
+            Spacer(Modifier.height(6.dp))
+            TextButton(onClick = onDismiss, contentPadding = ButtonDefaults.TextButtonContentPadding) {
+                Text("Dismiss", style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}
+
+// ── The format sheet ──
+
+@Composable
+private fun FormatSheetContent(selected: AudioFormat, onPick: (AudioFormat) -> Unit) {
+    val (common, rest) = AudioFormats.all.partition { it in COMMON }
+
+    Column(modifier = Modifier.padding(bottom = 28.dp)) {
+        Text(
+            "Convert to",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(start = 22.dp, end = 22.dp, bottom = 12.dp)
+        )
+
+        SheetHeading("The three worth using")
+        common.forEach { FormatRow(it, it.id == selected.id, onPick) }
+
+        Spacer(Modifier.height(10.dp))
+        SheetHeading("Everything else")
+        rest.forEach { FormatRow(it, it.id == selected.id, onPick) }
+    }
+}
+
+@Composable
+private fun SheetHeading(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+        modifier = Modifier.padding(start = 22.dp, top = 6.dp, bottom = 6.dp)
+    )
+}
+
+@Composable
+private fun FormatRow(format: AudioFormat, isSelected: Boolean, onPick: (AudioFormat) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onPick(format) }
+            .padding(horizontal = 22.dp, vertical = 11.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    format.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.SemiBold,
+                    color = if (isSelected) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    ".${format.extension}",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                )
+                Spacer(Modifier.width(8.dp))
+                TagStrip(format.tags)
+            }
+            Spacer(Modifier.height(2.dp))
+            Text(
+                format.summary,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+            )
+        }
+        if (isSelected) {
+            Icon(
+                Icons.Filled.Check,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.primary
             )
         }
     }
 }
 
 /**
- * Opens a folder in the system's default file manager.
+ * The words beside a format.
+ *
+ * Quality tags carry the accent colour and size tags do not, so the two are told apart at a
+ * glance without anybody reading them.
  */
-private fun openConverterFolderInFileManager(context: android.content.Context, folder: java.io.File) {
-    if (!folder.exists()) folder.mkdirs()
-    try {
-        val relativePath = folder.absolutePath.substringAfter("/storage/emulated/0/")
-        val encodedPath = relativePath.replace("/", "%2F")
-        val uri = android.net.Uri.parse(
-            "content://com.android.externalstorage.documents/document/primary:$encodedPath"
-        )
-        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, "vnd.android.document/directory")
-            addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        context.startActivity(intent)
-    } catch (_: Exception) {
-        try {
-            val uri = androidx.core.content.FileProvider.getUriForFile(
-                context, "${context.packageName}.fileprovider", folder
-            )
-            val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
-                setDataAndType(uri, "resource/folder")
-                addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            context.startActivity(intent)
-        } catch (_: Exception) {
-            try {
-                val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
-                    data = android.net.Uri.parse("file://${folder.absolutePath}")
-                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-                context.startActivity(android.content.Intent.createChooser(intent, "Open folder"))
-            } catch (_: Exception) {
-                android.widget.Toast.makeText(
-                    context, "Path: ${folder.absolutePath}", android.widget.Toast.LENGTH_LONG
-                ).show()
+@Composable
+private fun TagStrip(tags: List<AudioTag>) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        tags.forEach { tag ->
+            val loud = tag in LOUD_TAGS
+            Surface(
+                shape = RoundedCornerShape(5.dp),
+                color = if (loud) MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
+                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.07f)
+            ) {
+                Text(
+                    tag.label,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Medium,
+                    color = if (loud) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                )
             }
         }
     }
+}
+
+// ── Helpers ──
+
+private val COMMON = listOf(AudioFormats.OPUS, AudioFormats.AAC, AudioFormats.MP3)
+
+private val LOUD_TAGS = setOf(AudioTag.BEST, AudioTag.RECOMMENDED, AudioTag.LOSSLESS)
+
+/**
+ * Every video type, plus the generic one.
+ *
+ * A document provider decides what type it reports for what it holds, and a container it
+ * does not recognise, which regularly means Matroska or a transport stream, comes back as
+ * a generic stream of bytes. Filtering on video alone leaves those greyed out in the
+ * picker, so the file the user came to convert is the one they cannot select.
+ */
+private val PICKER_TYPES = arrayOf("video/*", "application/octet-stream")
+
+private fun formatSize(bytes: Long): String = when {
+    bytes >= 1_073_741_824 -> "%.1f GB".format(bytes / 1_073_741_824.0)
+    bytes >= 1_048_576 -> "%.1f MB".format(bytes / 1_048_576.0)
+    bytes >= 1024 -> "%.0f KB".format(bytes / 1024.0)
+    else -> "$bytes B"
+}
+
+/**
+ * Opens the output folder in whatever the device uses to browse files.
+ *
+ * Three attempts, because there is no one intent every builder answers: the documents
+ * provider first, then the app's own file provider, then a plain chooser. The path is put
+ * on screen as the last resort, so the user can at least go and find it themselves.
+ */
+private fun openFolder(context: Context, folder: File) {
+    if (!folder.exists()) folder.mkdirs()
+
+    val attempts: List<() -> Intent> = listOf(
+        {
+            val relative = folder.absolutePath.substringAfter("/storage/emulated/0/")
+            Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(
+                    Uri.parse(
+                        "content://com.android.externalstorage.documents/document/primary:" +
+                            relative.replace("/", "%2F")
+                    ),
+                    "vnd.android.document/directory"
+                )
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        },
+        {
+            Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(
+                    androidx.core.content.FileProvider.getUriForFile(
+                        context, "${context.packageName}.fileprovider", folder
+                    ),
+                    "resource/folder"
+                )
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        },
+        {
+            Intent.createChooser(
+                Intent(Intent.ACTION_VIEW).apply {
+                    data = Uri.parse("file://${folder.absolutePath}")
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                },
+                "Open folder"
+            )
+        }
+    )
+
+    for (build in attempts) {
+        val worked = runCatching { context.startActivity(build()) }.isSuccess
+        if (worked) return
+    }
+
+    Toast.makeText(context, folder.absolutePath, Toast.LENGTH_LONG).show()
 }

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -3,6 +3,7 @@ package com.hazel.android.ui.screens.more
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -61,7 +62,7 @@ import com.hazel.android.util.TempStorage
 @Composable
 fun MoreScreen(
     onNavigateToAppearance: () -> Unit = {},
-    onNavigateToTools: () -> Unit = {},
+    onNavigateToConverter: () -> Unit = {},
     onNavigateToStorageLocations: () -> Unit = {},
     onNavigateToCookies: () -> Unit = {},
     onNavigateToFetchSettings: () -> Unit = {},
@@ -166,7 +167,7 @@ fun MoreScreen(
             shape = RoundedCornerShape(16.dp),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
         ) {
-            // Download location — read-only
+            // Download location, read-only
             ListItem(
                 headlineContent = { Text("Downloads") },
                 leadingContent = {
@@ -188,7 +189,7 @@ fun MoreScreen(
                 color = MaterialTheme.colorScheme.surfaceVariant
             )
 
-            // Appearance — theme + accent color
+            // Appearance: theme and accent colour
             ListItem(
                 headlineContent = { Text("Appearance") },
                 leadingContent = {
@@ -311,11 +312,16 @@ fun MoreScreen(
                 color = MaterialTheme.colorScheme.surfaceVariant
             )
 
-            // Tools — standalone utilities
+            // The one tool the app has, reached directly. It used to sit behind a Tools
+            // screen that held nothing else, which is a tap and a screen to say one word.
             ListItem(
-                headlineContent = { Text("Tools") },
+                headlineContent = { Text("Offline convert video to audio") },
                 leadingContent = {
-                    Icon(Icons.Filled.Handyman, null, tint = MaterialTheme.colorScheme.primary)
+                    Icon(
+                        painterResource(R.drawable.music), null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp)
+                    )
                 },
                 trailingContent = {
                     Icon(
@@ -325,7 +331,7 @@ fun MoreScreen(
                     )
                 },
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                modifier = Modifier.clickable { onNavigateToTools() }
+                modifier = Modifier.clickable { onNavigateToConverter() }
             )
 
             HorizontalDivider(
@@ -333,7 +339,7 @@ fun MoreScreen(
                 color = MaterialTheme.colorScheme.surfaceVariant
             )
 
-            // Check for updates — navigates to the dedicated yt-dlp update screen
+            // Check for updates, which opens the dedicated yt-dlp update screen
             ListItem(
                 headlineContent = { Text("yt-dlp Engine Update") },
                 leadingContent = {
@@ -364,25 +370,46 @@ fun MoreScreen(
                     Icon(Icons.Filled.Code, null, tint = MaterialTheme.colorScheme.primary)
                 },
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                modifier = Modifier.clickable { openSourceRepository(context) }
+                modifier = Modifier.clickable { openExternally(context, SOURCE_URL) }
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant
+            )
+
+            // Opened in the user's own browser rather than in the app's, because a licence
+            // is a thing people save, share and read next to something else, and none of
+            // that is possible in a window that closes when this screen does.
+            ListItem(
+                headlineContent = { Text("License") },
+                leadingContent = {
+                    Icon(
+                        Icons.Filled.Gavel, null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                modifier = Modifier.clickable { openExternally(context, LICENSE_URL) }
             )
         }
     }
 }
 
 /**
- * Opens the project's page in whatever the user browses with.
+ * Hands an address to whatever the user browses with.
  *
  * Failure is swallowed: a device with no browser at all cannot be helped by a crash, and
- * this is the least important thing on the screen.
+ * nothing that opens this way is load-bearing.
  */
-private fun openSourceRepository(context: android.content.Context) {
+private fun openExternally(context: android.content.Context, url: String) {
     runCatching {
         context.startActivity(
-            Intent(Intent.ACTION_VIEW, Uri.parse(SOURCE_URL))
+            Intent(Intent.ACTION_VIEW, Uri.parse(url))
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         )
     }
 }
 
 private const val SOURCE_URL = "https://github.com/SibtainOcn/Hazel"
+private const val LICENSE_URL = "https://github.com/SibtainOcn/Hazel/blob/main/LICENSE"

--- a/app/src/main/java/com/hazel/android/ui/screens/more/ToolsScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/ToolsScreen.kt
@@ -30,11 +30,15 @@ import androidx.compose.ui.unit.dp
 import com.hazel.android.R
 
 /**
- * Container for Hazel's standalone utilities that aren't part of the download flow.
+ * Where a standalone utility goes, once there is one.
+ *
+ * Empty at the moment. The converter used to live here and now sits directly under More,
+ * because a screen whose whole content is one row is a tap spent on saying one word. Kept
+ * rather than deleted: the next tool has somewhere to go, and nothing links here until it
+ * does.
  */
 @Composable
 fun ToolsScreen(
-    onNavigateToConverter: () -> Unit,
     onBack: () -> Unit
 ) {
     Column(
@@ -69,31 +73,10 @@ fun ToolsScreen(
             )
         }
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-        ) {
-            ListItem(
-                headlineContent = { Text("Offline Converter", fontWeight = FontWeight.Medium) },
-                supportingContent = { Text("Video to audio, no internet needed") },
-                leadingContent = {
-                    Icon(
-                        painterResource(R.drawable.music), null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(24.dp)
-                    )
-                },
-                trailingContent = {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowForwardIos, null,
-                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                        modifier = Modifier.size(16.dp)
-                    )
-                },
-                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                modifier = Modifier.clickable { onNavigateToConverter() }
-            )
-        }
+        Text(
+            "Nothing here yet.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }

--- a/app/src/main/java/com/hazel/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/hazel/android/ui/theme/Color.kt
@@ -9,6 +9,16 @@ val DarkSurfaceVariant = Color(0xFF1E1E1E)
 val DarkOnBackground = Color(0xFFE0E0E0)
 val DarkOnSurface = Color(0xFFCCCCCC)
 
+/**
+ * Secondary text on a dark surface: labels, one-line explanations, units beside a value.
+ *
+ * Named rather than left to Material, whose dark default is a violet-tinted grey that sits
+ * oddly against the neutral greys everything else here is built from. Light enough to read
+ * at a glance, which is the point of setting it: the alternative was dimming the primary
+ * colour down with alpha, and that lands somewhere unreadable on one theme or the other.
+ */
+val DarkOnSurfaceVariant = Color(0xFFAFAFAF)
+
 // Light Theme — a warm paper ground rather than a neutral white.
 //
 // A pure white background under a full-bleed thumbnail reads as glare, and Material's own

--- a/app/src/main/java/com/hazel/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hazel/android/ui/theme/Theme.kt
@@ -32,6 +32,7 @@ fun HazelTheme(
             surface = DarkSurface,
             onSurface = DarkOnSurface,
             surfaceVariant = DarkSurfaceVariant,
+            onSurfaceVariant = DarkOnSurfaceVariant,
             error = ErrorRed,
             onError = DarkBackground,
         )

--- a/app/src/main/java/com/hazel/android/util/FolderUtil.kt
+++ b/app/src/main/java/com/hazel/android/util/FolderUtil.kt
@@ -3,6 +3,9 @@ package com.hazel.android.util
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.DocumentsContract
 import android.widget.Toast
 import androidx.core.content.FileProvider
 import java.io.File
@@ -10,44 +13,78 @@ import java.io.File
 /**
  * Handing a folder to whatever app the device uses to browse files.
  *
- * There is no single intent every OEM's file manager understands, so each strategy below is
- * tried in turn and the first one that resolves wins. The last resort simply tells the user
- * the path, which is still better than a silent no-op.
+ * There is no one intent every builder's file manager answers, so each approach below is
+ * tried in turn and the first that resolves wins. What each of them needs differs by
+ * version as well as by device, which is why the order matters and why the last resort is
+ * simply telling the user the path.
  */
 object FolderUtil {
+
+    /** The provider that owns everything on the built-in storage. */
+    private const val EXTERNAL_STORAGE_PROVIDER = "com.android.externalstorage.documents"
 
     /** Opens a folder that lives on the filesystem, creating it first if it is missing. */
     fun open(context: Context, folder: File) {
         if (!folder.exists()) folder.mkdirs()
 
-        // Documents UI content URI, which most stock file managers accept.
-        val relativePath = folder.absolutePath.substringAfter("/storage/emulated/0/")
-        val encodedPath = relativePath.replace("/", "%2F")
-        val documentsUri = Uri.parse(
-            "content://com.android.externalstorage.documents/document/primary:$encodedPath"
-        )
-        if (startView(context, documentsUri, "vnd.android.document/directory")) return
+        val documentUri = documentUriFor(folder)
 
-        // FileProvider URI with the folder MIME type some managers expect.
-        val providerUri = try {
+        // Most stock file managers open a documents URI directly, on every version from
+        // Android 7 onwards.
+        if (documentUri != null &&
+            startView(context, documentUri, "vnd.android.document/directory")
+        ) return
+
+        // Some builders' own managers answer to this and nothing else.
+        val providerUri = runCatching {
             FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", folder)
-        } catch (_: Exception) {
-            null
-        }
+        }.getOrNull()
         if (providerUri != null &&
             startView(context, providerUri, "resource/folder", grantRead = true)
         ) return
 
-        // Let the user pick a handler themselves.
-        try {
-            val intent = Intent(Intent.ACTION_VIEW).apply {
-                data = Uri.parse("file://${folder.absolutePath}")
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            context.startActivity(Intent.createChooser(intent, "Open folder"))
-        } catch (_: Exception) {
-            Toast.makeText(context, "Path: ${folder.absolutePath}", Toast.LENGTH_LONG).show()
+        // The system's own picker, opened at this folder. Nothing is being picked: it is
+        // the one file browser guaranteed to be present, and this is how it is asked to
+        // start somewhere in particular. EXTRA_INITIAL_URI only exists from Android 8, and
+        // is a hint even there, so a device that ignores it opens the picker at its own
+        // idea of the top rather than failing.
+        if (documentUri != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val opened = runCatching {
+                context.startActivity(
+                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                        putExtra(DocumentsContract.EXTRA_INITIAL_URI, documentUri)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                )
+            }.isSuccess
+            if (opened) return
         }
+
+        // Deliberately not a file:// intent. Passing one has thrown FileUriExposedException
+        // since Android 7, which is every version this app runs on, so the path is put on
+        // screen instead where the user can at least go and find it.
+        Toast.makeText(context, folder.absolutePath, Toast.LENGTH_LONG).show()
+    }
+
+    /**
+     * The documents URI for a folder on the built-in storage.
+     *
+     * Built through DocumentsContract rather than by pasting a path into a string, which
+     * left the separators unencoded and quietly produced a URI for the wrong folder. Null
+     * for anything that is not on the primary volume, such as a removable card, where the
+     * document id is the volume's own and cannot be worked out from the path.
+     */
+    private fun documentUriFor(folder: File): Uri? {
+        val root = Environment.getExternalStorageDirectory().absolutePath
+        val path = folder.absolutePath
+        if (!path.startsWith(root)) return null
+
+        val relative = path.removePrefix(root).trim('/')
+        if (relative.isBlank()) return null
+
+        return runCatching {
+            DocumentsContract.buildDocumentUri(EXTERNAL_STORAGE_PROVIDER, "primary:$relative")
+        }.getOrNull()
     }
 
     /**
@@ -55,14 +92,26 @@ object FolderUtil {
      * to a document URI first, since a tree URI on its own is not viewable.
      */
     fun openTree(context: Context, treeUri: Uri) {
-        val documentUri = try {
-            android.provider.DocumentsContract.buildDocumentUriUsingTree(
-                treeUri, android.provider.DocumentsContract.getTreeDocumentId(treeUri)
+        val documentUri = runCatching {
+            DocumentsContract.buildDocumentUriUsingTree(
+                treeUri, DocumentsContract.getTreeDocumentId(treeUri)
             )
-        } catch (_: Exception) {
-            treeUri
-        }
+        }.getOrDefault(treeUri)
+
         if (startView(context, documentUri, "vnd.android.document/directory")) return
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val opened = runCatching {
+                context.startActivity(
+                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                        putExtra(DocumentsContract.EXTRA_INITIAL_URI, documentUri)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                )
+            }.isSuccess
+            if (opened) return
+        }
+
         Toast.makeText(context, MediaStoreHelper.describeTree(treeUri), Toast.LENGTH_LONG).show()
     }
 
@@ -71,7 +120,7 @@ object FolderUtil {
         uri: Uri,
         mimeType: String,
         grantRead: Boolean = false
-    ): Boolean = try {
+    ): Boolean = runCatching {
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, mimeType)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -79,7 +128,5 @@ object FolderUtil {
         }
         context.startActivity(intent)
         true
-    } catch (_: Exception) {
-        false
-    }
+    }.getOrDefault(false)
 }

--- a/app/src/main/java/com/hazel/android/util/MediaStoreHelper.kt
+++ b/app/src/main/java/com/hazel/android/util/MediaStoreHelper.kt
@@ -50,7 +50,7 @@ object MediaStoreHelper {
                 if (Build.VERSION.SDK_INT >= 30) {
                     moveViaMediaStore(context, file, relativePath, isMusic)?.let(onMoved)
                 } else {
-                    moveViaDirect(file, relativePath).let(onMoved)
+                    moveViaDirect(context, file, relativePath).let(onMoved)
                 }
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to move ${file.name}: ${e.message}")
@@ -143,7 +143,7 @@ object MediaStoreHelper {
     /**
      * API ≤ 29: Direct file move using WRITE_EXTERNAL_STORAGE.
      */
-    private fun moveViaDirect(sourceFile: File, relativePath: String): Uri {
+    private fun moveViaDirect(context: Context, sourceFile: File, relativePath: String): Uri {
         val destDir = File(Environment.getExternalStorageDirectory(), relativePath)
         if (!destDir.exists()) destDir.mkdirs()
 
@@ -152,7 +152,7 @@ object MediaStoreHelper {
         // Try rename first (instant if same partition)
         if (sourceFile.renameTo(destFile)) {
             Log.d(TAG, "Moved ${sourceFile.name} to $relativePath via rename")
-            return Uri.fromFile(destFile)
+            return scanned(context, destFile)
         }
 
         // Fallback: zero-copy channel transfer
@@ -163,7 +163,24 @@ object MediaStoreHelper {
         }
         sourceFile.delete()
         Log.d(TAG, "Moved ${sourceFile.name} to $relativePath via copy")
-        return Uri.fromFile(destFile)
+        return scanned(context, destFile)
+    }
+
+    /**
+     * Tells the media scanner about a file written directly to disk.
+     *
+     * Only the pre-MediaStore path needs this. A file that appears in a folder without
+     * being scanned is invisible to every music player and gallery on the device, which
+     * reads as a download that never arrived, so on those versions the move is only really
+     * finished once the index knows about it.
+     */
+    private fun scanned(context: Context, file: File): Uri {
+        runCatching {
+            MediaScannerConnection.scanFile(
+                context, arrayOf(file.absolutePath), arrayOf(getMimeType(file)), null
+            )
+        }
+        return Uri.fromFile(file)
     }
 
     /**

--- a/app/src/main/java/com/hazel/android/util/PermissionHelper.kt
+++ b/app/src/main/java/com/hazel/android/util/PermissionHelper.kt
@@ -10,11 +10,18 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 
 /**
- * Simplified permission helper for Hazel.
+ * The runtime permissions Hazel asks for, and the two occasions it asks.
  *
- * Downloads and conversions write to the app-specific dir and are published through
- * MediaStore, so no storage permission is required. The only runtime permission the
- * app asks for is POST_NOTIFICATIONS (Android 13+) for download progress notifications.
+ * Notifications, from Android 13, because a download that finishes while the app is closed
+ * has nothing else to say so with.
+ *
+ * Writing to shared storage, up to Android 10 only. Above that a finished file is published
+ * through MediaStore, which grants an app access to the entries it creates itself and needs
+ * no permission at all. Below that there is no MediaStore route: the file is written
+ * straight into `Download/Hazel` or `Music/Hazel`, and WRITE_EXTERNAL_STORAGE is the only
+ * thing that permits it. Nothing used to ask for it, so on Android 7 through 10 every
+ * finished download and every converted file failed that last step and stayed in the app's
+ * own folder, where the user cannot find it. It failed quietly, which is why it lasted.
  */
 object PermissionHelper {
 
@@ -26,7 +33,7 @@ object PermissionHelper {
     fun register(activity: ComponentActivity) {
         runtimeLauncher = activity.registerForActivityResult(
             ActivityResultContracts.RequestMultiplePermissions()
-        ) { /* result ignored — notifications are optional */ }
+        ) { /* result ignored: both permissions degrade rather than block */ }
     }
 
     /**
@@ -39,6 +46,36 @@ object PermissionHelper {
             ) {
                 runtimeLauncher?.launch(arrayOf(Manifest.permission.POST_NOTIFICATIONS))
             }
+        }
+    }
+
+    /**
+     * Whether this version of Android needs a permission before a file can be written into
+     * the user's own Download or Music folder.
+     *
+     * False from Android 11, where MediaStore does the publishing. The permission is not
+     * merely unnecessary there: it is declared with a maxSdkVersion, so asking would be
+     * asking for something the app does not hold and cannot be granted.
+     */
+    fun needsLegacyStorageWrite(): Boolean = Build.VERSION.SDK_INT < 30
+
+    /** Whether a file can be written into shared storage as things currently stand. */
+    fun canWriteSharedStorage(context: Context): Boolean =
+        !needsLegacyStorageWrite() || ContextCompat.checkSelfPermission(
+            context, Manifest.permission.WRITE_EXTERNAL_STORAGE
+        ) == PackageManager.PERMISSION_GRANTED
+
+    /**
+     * Asks for the shared storage write, on the versions that need one.
+     *
+     * Called as a run starts rather than at launch, so the request arrives attached to the
+     * thing it is for. A refusal is not fatal: the file still converts and still downloads,
+     * it just lands in the app's own folder, and the screen says so instead of pretending
+     * it went somewhere else.
+     */
+    fun ensureSharedStorageWrite(context: Context) {
+        if (needsLegacyStorageWrite() && !canWriteSharedStorage(context)) {
+            runtimeLauncher?.launch(arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE))
         }
     }
 }


### PR DESCRIPTION
## Fixed

- **A finished file never reached the user's folder on Android 7 through 10.** `MediaStoreHelper.moveToPublicStorage` inserts via MediaStore from API 30 and does a direct file write below it. The direct write needs `WRITE_EXTERNAL_STORAGE`, which nothing ever requested at runtime, so it threw, the failure was caught and logged, and the file stayed in app-specific storage. This affected **downloads as well as conversions**. Now requested as a run starts, in `PermissionHelper.ensureSharedStorageWrite()`, and where refused the converter says the file stayed inside the app rather than naming a folder it never reached.
- **Files written that way were invisible.** `moveViaDirect` never notified the media scanner, so no music player or gallery listed them. It now scans as part of the move.
- **The converted file reported a size of zero.** `actualOutput.length()` was read after `moveToPublicStorage` had moved the file out of that folder. Read before the move now.
- **`FolderUtil.open`'s last fallback could never run.** It built a `file://` intent, which throws `FileUriExposedException` on API 24+, i.e. every version this app supports. The documents URI it tries first was string-concatenated with unencoded separators, and `substringAfter` returned the whole path when the folder was not on the primary volume. Now built with `DocumentsContract.buildDocumentUri`, with a null guard for non-primary volumes, and the final fallback is `ACTION_OPEN_DOCUMENT_TREE` with `EXTRA_INITIAL_URI` (API 26+).
- **Videos with a generic MIME type were unpickable.** The picker filtered on `video/*` alone; providers report unrecognised containers as `application/octet-stream`, so those files were greyed out. Both types are passed now.
- **A file whose provider withheld `DISPLAY_NAME` became "Unknown file"**, and the extension was then derived from that. Name falls back to the URI's last segment; extension falls back to `MimeTypeMap` on the declared type. The name is sanitised before being used as a filename.
- The duplicate `openFolder` in `ConverterScreen.kt` is gone; `FolderUtil` is the single implementation.

## Added

- `AudioFormats` — Opus, AAC, MP3, M4A, Vorbis, FLAC, ALAC, WAV, each with a summary and tags (`Best`, `Recommended`, `Most compatible`, `Normal`, `Small file`, `Lossless`, `Big file`, `Biggest file`). Picked from a `ModalBottomSheet`; Opus/AAC/MP3 grouped at the top.
- MP3 stays the default rather than Opus: `.opus` playback is only guaranteed from Android 10.

## Changed

- **Converter screen rebuilt** as three rows: source, format, destination. `ConversionState` replaces `logs: List<LogEntry>` with `statusLine` + `statusLevel`.
- **One line of engine output**, replaced in place with a crossfade, percentage on the same row. The old `LazyColumn` of every line pushed the rest of the screen off the bottom.
- **Convert button stays lit while converting.** Explicit `disabledContainerColor`/`disabledContentColor` distinguish "nothing chosen" from "already running"; Material's default drained both alike.
- **Result card** is flat: green tick badge, `Saved` + filename + size · location, and two borderless text-only actions split by hairlines.
- **Contrast.** Secondary text used faded `onSurface`, which lands unreadable in one theme or the other. It now uses `onSurfaceVariant`, and the dark scheme gained an explicit neutral `DarkOnSurfaceVariant` (`#AFAFAF`) instead of inheriting Material's violet-tinted default.
- `ConverterLog.kt` reduced to `LogLevel`; `LogEntry` is gone.

## Verified on device ( Android 13)

- Picker lists videos; name and size resolve (`VID20260830194214.mp4`, 19.7 MB)
- Conversion runs with the button legible and a single updating status line
- Result card renders as designed; file confirmed in `/sdcard/Music/Hazel/`
- Default is MP3, format sheet renders all eight with tags
- No crashes; 27 unit tests pass

Merged `main` in to pick up the Wi-Fi fix from #13.