### PR TITLE
Offer only what is still owed when downloading a set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,23 @@ Everything merged since 1.0.0, plus what is open in review.
   stay pure JVM, and tests are named for the behaviour a user would notice breaking.
 
 ### Fixed
+- **A set action offered to download what was already saved.** Reading a new link adds it to
+  what is already on screen, which is what makes a growing list of results useful. The set
+  action counted the whole list, so one new video alongside one already downloaded read as
+  two waiting and Download all fetched the saved one a second time. The action now covers
+  only what is still owed, and the button disappears once nothing is. A link already
+  downloaded keeps its place in the list, marked, because seeing what arrived is the point
+  of the list. Both records are consulted: what finished in this run, and what finished in
+  any run, which is what a link read after a restart turns on.
+- **Pasting several links at once said the paste was invalid.** The field took everything
+  typed into it as a single address, and an address cannot contain a space, so a set of links
+  copied together was rejected as one malformed link. Anything separated by whitespace is now
+  read as the several links it is, which is how links arrive when they are copied from
+  somewhere else.
+- **The card and the list disagreed on what counted as already downloaded.** One compared
+  addresses as they were written and the other reduced them to the media first, so a share
+  link and an address bar link for the same video were the same media in one layout and two
+  in the other.
 - **A finished file never reached the user's folder on Android 7 through 10.** Publishing a
   download or a conversion is a MediaStore insert from Android 11 and a direct file write
   below it, and the direct write needs a storage permission nothing had ever asked for. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,8 @@ Everything merged since 1.0.0, plus what is open in review.
   speed and ETA on it were routinely stale. It is redrawn on a timer instead.
 
 ### Changed
+- **A history row whose file has gone reads Deleted** rather than File missing. The file is
+  not mislaid, and almost always it is gone because the user removed it.
 - **The converter sits directly under More.** It used to be behind a Tools screen whose
   entire content was that one row, which is a tap and a screen spent saying one word. Tools
   remains, empty, for whatever the next tool turns out to be.

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -208,6 +208,26 @@ fun DownloadScreen(
     // Links already downloaded, so a repeat can be pointed out before it is started again.
     val history by DownloadHistoryRepository.getHistory(context)
         .collectAsState(initial = emptyList())
+
+    /**
+     * The links the set action still owes a download on.
+     *
+     * A link that has already been fetched keeps its place in the list, marked, because
+     * seeing what arrived is the point of the list. It is not something to fetch a second
+     * time. Reading a new link used to add it to what was already on screen and offer to
+     * download the lot, so one new video alongside one already saved read as two waiting,
+     * and Download all fetched the saved one again.
+     *
+     * Both records are consulted. The batch says what finished in this run, and the history
+     * says what finished in any run, which is what a link read after a restart turns on.
+     */
+    val pendingResults = remember(state.results, state.batch, history) {
+        state.results.filterNot { info ->
+            state.batch.any { item -> item.url == info.url && item.state == BatchState.DONE } ||
+                history.any { entry -> LinkKey.sameMedia(entry.url, info.url) }
+        }
+    }
+
     var alreadyHave by remember { mutableStateOf<HistoryEntry?>(null) }
 
     // Marks a link that arrived from another app's share sheet. That is the one route into
@@ -546,7 +566,7 @@ fun DownloadScreen(
                             batchItem = batchItem,
                             waitingForWifi = state.waitingForWifi,
                             alreadyDownloaded = state.isMultiple &&
-                                    history.any { it.url == info.url },
+                                    history.any { LinkKey.sameMedia(it.url, info.url) },
                             onOpenSheet = openSheet,
                             onCancel = downloadViewModel::cancelDownload,
                             onPause = downloadViewModel::pauseDownload,
@@ -593,7 +613,8 @@ fun DownloadScreen(
         }
 
         // One action for the whole set, which is the point of collecting links together.
-        if (state.isMultiple && !state.isDownloading) {
+        // Hidden once there is nothing left in the set to fetch.
+        if (state.isMultiple && !state.isDownloading && pendingResults.isNotEmpty()) {
             DownloadAllButton(
                 onClick = { batchSheetVisible = true },
                 modifier = Modifier
@@ -699,7 +720,7 @@ fun DownloadScreen(
 
     if (batchSheetVisible) {
         BatchDownloadSheet(
-            results = state.results,
+            results = pendingResults,
             options = options,
             onOptionsChange = {
                 scope.launch { SettingsRepository.setDownloadOptions(context, it) }

--- a/app/src/main/java/com/hazel/android/ui/screens/download/SearchScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/SearchScreen.kt
@@ -116,9 +116,20 @@ fun SearchScreen(
         history.filter { it !in queued && it.contains(text.trim(), ignoreCase = true) }
     }
 
+    /**
+     * Splits what is in the field into the links it holds.
+     *
+     * Someone with several links to hand copies them together and pastes them together,
+     * separated by whatever the place they came from used: a space, a newline, a tab. The
+     * field used to take the whole paste as one link, which cannot match an address and was
+     * reported as the paste being invalid rather than as several links having arrived.
+     */
+    fun typedLinks(): List<String> =
+        text.split(WHITESPACE).map { it.trim() }.filter { it.isNotBlank() }
+
     fun queueCurrent() {
-        val entry = text.trim()
-        if (entry.isNotBlank() && entry !in queued) queued = queued + entry
+        val entries = typedLinks().filterNot { it in queued }
+        if (entries.isNotEmpty()) queued = queued + entries
         text = ""
     }
 
@@ -133,7 +144,7 @@ fun SearchScreen(
     }
 
     fun submit() {
-        val all = (queued + text.trim()).filter { it.isNotBlank() }.distinct()
+        val all = (queued + typedLinks()).filter { it.isNotBlank() }.distinct()
         if (all.isEmpty()) return
 
         scope.launch {
@@ -402,3 +413,6 @@ private fun HistoryRow(
     }
     Spacer(modifier = Modifier.height(0.dp))
 }
+
+/** Any run of whitespace, which is what separates one pasted link from the next. */
+private val WHITESPACE = Regex("""\s+""")

--- a/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
@@ -540,8 +540,10 @@ private fun HistoryCard(
                 if (duration.isNotBlank()) Tag(duration)
                 if (entry.sizeBytes > 0) Tag(formatFileSize(entry.sizeBytes))
                 if (!present) {
+                    // "Deleted" rather than "File missing". The file is not mislaid, it is
+                    // gone, and almost always because the user removed it themselves.
                     Tag(
-                        "File missing",
+                        "Deleted",
                         background = MaterialTheme.colorScheme.error,
                         foreground = MaterialTheme.colorScheme.onError
                     )


### PR DESCRIPTION
## Fixed

- **The set action offered to re-download links that were already saved.** `BatchDownloadSheet` received `state.results`, which by design accumulates: reading a new link prepends it and keeps what was already listed. So one new video alongside one already downloaded read as two waiting, and Download all fetched the saved one again.

  A new `pendingResults` in `DownloadScreen` filters the list before it reaches the sheet, and gates the Download all button's visibility. It consults two records, because neither is sufficient alone:
  - `state.batch` entries marked `DONE` — what finished in this run.
  - Download history via `LinkKey.sameMedia` — what finished in any run. This is the one that matters after a restart, since `DownloadViewModel.kt:497` sets `batch = emptyList()` on every fetch while deliberately keeping `results`.

- **Pasting several links at once was rejected as invalid.** `submit()` built its list as `queued + text.trim()`, taking everything typed as a single address, and `URL_PATTERN` is `^https?://\S+$`, which no whitespace can satisfy. Several links copied together were reported as one malformed link. Text is now split on whitespace, so a paste of several links is read as several links. The chip flow is unchanged.

- **The card and the compact row disagreed on identity.** `MediaCard` compared history URLs with `it.url == info.url` while `MediaRow` used `LinkKey.sameMedia`. A share link and an address-bar link for the same video were one item in one layout and two in the other. Both use `LinkKey.sameMedia` now.

## Verified on device 

Using three YouTube links pasted together in one go:

| Step | Before | After |
|---|---|---|
| Paste 3 links at once | "Invalid URL, must start with http:// or https://" | 3 links resolved |
| Set sheet, none downloaded | — | 3 links, ~401.9 MB |
| Download one as audio | — | Card shows Saved |
| Set sheet after that | 3 links (saved one included) | **2 links, ~281.3 MB** |

No crashes. 27 unit tests pass.