### PR TITLE
Open the app on a shorter, single launch budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Hazel are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **The app opens sooner.** The wait was the launch window and then the splash screen, one
+  after the other, with the splash always holding for a fixed 1.4 seconds on top of however
+  long the start itself took. The hold is now what is left of a 900 ms budget counted from
+  the moment the process starts, so a slow start spends that budget instead of adding to it,
+  and a fast one still shows the splash long enough to be seen rather than flashed. The
+  highlight sweeping through the wordmark was retimed to finish inside the shorter stay, and
+  the mark in the launch window was moved to sit where the splash screen draws it, so it no
+  longer jumps as one replaces the other.
+- **Unpacking the download engine no longer competes with the launch.** yt-dlp and FFmpeg
+  unpack and check for updates on a background thread, but the work was starting while the
+  app was still drawing its first screen and took CPU and disk from it. It now starts once
+  that screen is up, and still starts on its own for a launch with no UI, such as a
+  notification action resuming a download after the process was killed.
+
 ## [1.0.2] - 2026-08-31
 
 ### Fixed

--- a/app/src/main/java/com/hazel/android/HazelApp.kt
+++ b/app/src/main/java/com/hazel/android/HazelApp.kt
@@ -15,8 +15,10 @@ import com.yausername.youtubedl_android.YoutubeDL
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 
 class HazelApp : Application(), SingletonImageLoader.Factory {
 
@@ -33,6 +35,9 @@ class HazelApp : Application(), SingletonImageLoader.Factory {
 
     val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    /** Whether [startLibraryInit] has already run. */
+    private val libraryInitStarted = AtomicBoolean(false)
+
     override fun onCreate() {
         super.onCreate()
         instance = this
@@ -43,10 +48,29 @@ class HazelApp : Application(), SingletonImageLoader.Factory {
         // Install crash logger — captures uncaught exceptions in-memory
         CrashLogger.install(this)
 
-        initLibraries()
+        // Unpacking yt-dlp and FFmpeg is the heaviest thing the app ever does at launch,
+        // and starting it here put it in competition with the work that gets the first
+        // frame on screen. The UI asks for it once it has drawn instead. This is the
+        // fallback for a start with no UI, such as a notification action resuming a
+        // download after the process was killed. Whenever there is a UI it wins this
+        // race, because the call only acts the first time.
+        applicationScope.launch {
+            delay(LIBRARY_INIT_FALLBACK_MS)
+            startLibraryInit()
+        }
     }
 
-    private fun initLibraries() {
+    /**
+     * Unpack and update the download engine, once per process.
+     *
+     * Called from the UI as soon as it has drawn, so the work happens in the gap where the
+     * user is looking at a finished screen rather than in the gap where they are waiting
+     * for one. Safe to call from anywhere and as often as anything likes: every call after
+     * the first returns immediately.
+     */
+    fun startLibraryInit() {
+        if (!libraryInitStarted.compareAndSet(false, true)) return
+
         applicationScope.launch {
             try {
                 YoutubeDL.getInstance().init(this@HazelApp)
@@ -73,5 +97,13 @@ class HazelApp : Application(), SingletonImageLoader.Factory {
     companion object {
         lateinit var instance: HazelApp
             private set
+
+        /**
+         * How long to wait for the UI to ask for the engine before starting it anyway.
+         *
+         * Long enough that a normal launch always gets there first, short enough that a
+         * start with no UI is not left waiting on it.
+         */
+        private const val LIBRARY_INIT_FALLBACK_MS = 2_000L
     }
 }

--- a/app/src/main/java/com/hazel/android/MainActivity.kt
+++ b/app/src/main/java/com/hazel/android/MainActivity.kt
@@ -2,6 +2,8 @@ package com.hazel.android
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.Process
+import android.os.SystemClock
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -15,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import com.hazel.android.data.SettingsRepository
 import com.hazel.android.download.DownloadNotificationHelper
@@ -67,6 +70,14 @@ class MainActivity : ComponentActivity() {
         setContent {
             val scope = rememberCoroutineScope()
 
+            // The download engine unpacks itself on a background thread, but the unpacking
+            // still competes for the same CPU and disk as the first frame. Asked for only
+            // once that frame exists, so the launch is not paying for it.
+            LaunchedEffect(Unit) {
+                withFrameNanos { }
+                HazelApp.instance.startLibraryInit()
+            }
+
             val savedTheme by SettingsRepository.isDarkTheme(this).collectAsState(initial = null)
             val isDark = savedTheme ?: true // Default to dark on first install
 
@@ -76,12 +87,14 @@ class MainActivity : ComponentActivity() {
             // than painting once in the wrong colours and correcting itself.
             val resolvedAccent = accentName
 
-            // The splash is held for one full sweep of its highlight. Preferences usually
-            // load faster than that, and without the floor the splash would appear and
+            // The splash is held for what is left of one short budget counted from the
+            // start of the process, so the time already spent on the system's launch
+            // window counts towards it instead of being added to it. Preferences usually
+            // load faster than that, and without a floor the splash could appear and
             // vanish within a frame or two, which reads as a glitch rather than a launch.
             var minimumShown by remember { mutableStateOf(false) }
             LaunchedEffect(Unit) {
-                delay(SPLASH_MINIMUM_MS)
+                delay(remainingSplashHoldMs())
                 minimumShown = true
             }
 
@@ -109,6 +122,20 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    /**
+     * How much longer to hold the splash, in milliseconds.
+     *
+     * What the user waits through is one span, not two: the system's launch window and
+     * then this screen, which are drawn to look the same. So the budget is measured from
+     * the moment the process started, and a slow start spends the budget rather than
+     * extending it. A fast start still gets [SPLASH_FLOOR_MS], because a splash that comes
+     * and goes inside a couple of frames looks like a fault.
+     */
+    private fun remainingSplashHoldMs(): Long {
+        val sinceProcessStart = SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime()
+        return (SPLASH_BUDGET_MS - sinceProcessStart).coerceIn(SPLASH_FLOOR_MS, SPLASH_BUDGET_MS)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -162,5 +189,8 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-/** One sweep of the splash highlight, which is the shortest it is worth showing for. */
-private const val SPLASH_MINIMUM_MS = 1400L
+/** The whole launch, from the process starting to the app being on screen. */
+private const val SPLASH_BUDGET_MS = 900L
+
+/** The least the splash is worth showing for once it is up. */
+private const val SPLASH_FLOOR_MS = 350L

--- a/app/src/main/java/com/hazel/android/ui/screens/SplashScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/SplashScreen.kt
@@ -38,7 +38,7 @@ import com.hazel.android.R
  * and a highlight travels through the wordmark beneath it, which is the only thing that
  * separates this from a frozen frame when the wait runs long.
  */
-private const val SWEEP_DURATION_MS = 1400
+private const val SWEEP_DURATION_MS = 900
 
 @Composable
 fun SplashScreen(modifier: Modifier = Modifier) {

--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -2,9 +2,15 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Deep black background -->
     <item android:drawable="@color/splash_background" />
-    <!-- Centered white lightning bolt icon -->
+    <!--
+        The white lightning bolt, sitting where the splash screen draws it rather than in
+        the middle of the window. The splash screen puts the wordmark under the mark, which
+        lifts the mark off centre, and matching that here means the mark does not jump when
+        one screen replaces the other.
+    -->
     <item
         android:gravity="center"
+        android:bottom="58dp"
         android:width="112dp"
         android:height="112dp"
         android:drawable="@drawable/splash_icon" />


### PR DESCRIPTION
Startup showed the system launch window for however long the cold start took, then held the splash screen for a further fixed 1.4 seconds.

- The splash hold is now what is left of a 900 ms budget counted from process start, with a 350 ms floor so a fast start still shows it rather than flashing it.
- The wordmark highlight sweep is retimed from 1400 ms to 900 ms to complete within the shorter stay.
- The mark in the launch window drawable is shifted up 29dp to sit where the splash screen draws it, so it does not jump at the handover.
- yt-dlp and FFmpeg init plus the yt-dlp update check moved out of `Application.onCreate`. `HazelApp.startLibraryInit()` is called from the UI after the first frame, is idempotent, and has a 2 s fallback in `onCreate` for a launch with no UI.

Files: `MainActivity.kt`, `HazelApp.kt`, `SplashScreen.kt`, `res/drawable/splash_background.xml`, `CHANGELOG.md`.


