### PR TITLE
Choose the format, the soundtrack and the sign-in per source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A soundtrack can be chosen where a source publishes several.** A row under the quality
+  card names the one the download will take, and tapping it opens the list of what the
+  source actually offers. The choice reaches the download as the track's own id with the
+  engine's language filter behind it, so a track that has since gone is replaced by another
+  in the same language rather than by the original. It is on the single sheet, on the set
+  sheet for a whole run, and in the instant settings as a standing preference; anything that
+  does not carry the chosen language is downloaded with what it has.
+- **The download sheet and the set sheet close with the link and an incognito switch.**
+  Tapping the address copies it and opens it, in the site's own app when that is installed
+  and in the browser otherwise. The switch is the same setting the rest of the app reads,
+  and it says which way it went.
+- **Hazel Instant has its own settings.** Container, filename template, cover art, chapters,
+  subtitles and SponsorBlock are set for the share target itself and kept apart from the
+  sheet's, so a choice made for a download being watched cannot change what an unattended
+  share does with the next link. The screen also says whether saved sign-ins are in use.
+
 ### Changed
+- **The format list was rebuilt.** It opens half way up the screen, each row leads with its
+  container as a block, the quality is the headline with the format id beside it, and what
+  was measured sits under it as pills that scroll rather than wrapping the row into
+  different heights. Rows are laid out once per ordering, which is what makes a fast fling
+  smooth, and the list opens on the row that is currently chosen.
+- **The best row is shown from outside the list.** A source that reports formats no longer
+  gets a synthesised "best" entry mixed in with the real ones: the generic row now only
+  appears where a source listed nothing of that kind, and the sheet shows the best concrete
+  format from the moment it opens, including while the rest are still being read.
+- **The audio tab keeps its own choice.** Each tab holds what it is set to, so switching to
+  audio no longer shows a video resolution, and opening the format list from the audio tab
+  leads with the audio section.
+- **The last ten links are remembered across restarts.** What a read produced is rebuilt
+  from what it wrote, so a link pasted again fills its sheet at once, and a collection opens
+  as the set of cards it opened as last time instead of being walked again.
+- **The dark theme's own container tones.** The search field took Material's dark default,
+  which is derived from a violet neutral and read as a lilac bar across a black screen.
 - **The app opens sooner.** The wait was the launch window and then the splash screen, one
   after the other, with the splash always holding for a fixed 1.4 seconds on top of however
   long the start itself took. The hold is now what is left of a 900 ms budget counted from
@@ -21,6 +55,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   app was still drawing its first screen and took CPU and disk from it. It now starts once
   that screen is up, and still starts on its own for a launch with no UI, such as a
   notification action resuming a download after the process was killed.
+
+### Fixed
+- **Signing in cut the format list down to 360p.** The largest site now answers a signed-in
+  request with a single stream unless it carries a token the app cannot produce. A link is
+  read anonymously first and the sign-in is used only when the media will not open without
+  it, so a public link keeps its full ladder and a private, members-only or age-restricted
+  one still opens. The download asks the same way the read did.
+- **Sign-ins are scoped to the site they were collected on.** One file held every cookie and
+  was sent with every request, so an account on one site was handed to another site's
+  servers. Each site now gets its own, and a site with no saved sign-in is fetched without
+  one.
+- **A finished download could not be opened on older Android versions.** The saved file was
+  recorded under a `file://` address, which the system refuses to pass to another app from
+  Android 7 onwards, so the file was there and the history said it was missing. Files are
+  now handed over as content addresses, a refused direct write falls back to the media
+  index, and anything that cannot be published is kept and offered from where it is rather
+  than recorded as saved somewhere it never reached.
+- **A chosen soundtrack was lost on the way to the download.** A queued item was rebuilt
+  from what was written down for it, and the audio track written down was the source's
+  default, so the file arrived in the original language whatever the sheet had said.
+- **The set card showed a resolution twice.** The measured size was pushed off the end of
+  the row by a headline that repeated what the quality already said.
 
 ## [1.0.2] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the same language rather than by the original. It is on the single sheet, on the set
   sheet for a whole run, and in the instant settings as a standing preference; anything that
   does not carry the chosen language is downloaded with what it has.
+- **A Support screen, reached from More.** It says what the app takes from anyone, which is
+  nothing, and offers the two places money can go alongside the ways of helping that cost
+  none. Everything opens in the in-app browser, so nothing here leaves the app.
 - **The download sheet and the set sheet close with the link and an incognito switch.**
   Tapping the address copies it and opens it, in the site's own app when that is installed
   and in the browser otherwise. The switch is the same setting the rest of the app reads,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,20 @@
     -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!--
+         What the app is allowed to see of the rest of the device. From Android 11 an app
+         cannot resolve an intent at another package without saying so, and the sheet offers
+         to open a link where it belongs: in the site's own app when it is installed, in the
+         browser otherwise.
+    -->
+    <queries>
+        <package android:name="com.google.android.youtube" />
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:name=".HazelApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/hazel/android/data/CookieRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/CookieRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.hazel.android.download.SiteAccess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -46,6 +47,15 @@ object CookieRepository {
 
     private val USE_COOKIES_KEY = booleanPreferencesKey("use_cookies")
     private val COOKIES_KEY = stringPreferencesKey("cookie_entries")
+
+    /**
+     * The browser identity the last sign-in was made under.
+     *
+     * Recorded because a site issues its cookies to one browser and expects them back from
+     * that same browser. Sending them under the app's own identity is what makes a good
+     * sign-in look like a stranger holding someone else's cookies.
+     */
+    private val USER_AGENT_KEY = stringPreferencesKey("cookie_user_agent")
 
     /** Header yt-dlp expects at the top of a Netscape cookie file. */
     const val FILE_HEADER = "# Netscape HTTP Cookie File\n" +
@@ -161,6 +171,110 @@ object CookieRepository {
         val file = cookieFile(context)
         return file.takeIf { it.exists() && it.length() > 0 }
     }
+
+    /** Records the browser identity a sign-in was collected under. */
+    suspend fun setUserAgent(context: Context, userAgent: String) {
+        context.dataStore.edit { prefs -> prefs[USER_AGENT_KEY] = userAgent }
+    }
+
+    fun getUserAgent(context: Context): Flow<String> =
+        context.dataStore.data.map { prefs -> prefs[USER_AGENT_KEY].orEmpty() }
+
+    /**
+     * The sign-in to send with a fetch of [url], or [SiteAccess.NONE] when nothing saved
+     * covers that site.
+     *
+     * Cookies are scoped to the site they were collected on. One file holding every sign-in
+     * would hand a video site's account cookies to a photo site's servers, which is both a
+     * thing the user never agreed to and a way of making a request look stranger than an
+     * anonymous one. A link to a site with no saved sign-in is fetched without any.
+     *
+     * The single place the rest of the app asks, so a read and the download that follows it
+     * are made under the same identity.
+     */
+    suspend fun accessFor(context: Context, url: String): SiteAccess {
+        if (!getUseCookies(context).first()) return SiteAccess.NONE
+
+        val site = siteKeyOf(hostOf(url)) ?: return SiteAccess.NONE
+        val entries = getEntries(context).first()
+            .filter { it.enabled && it.content.isNotBlank() && covers(it, site) }
+        if (entries.isEmpty()) return SiteAccess.NONE
+
+        val file = writeSiteFile(context, site, entries) ?: return SiteAccess.NONE
+        return SiteAccess(cookieFile = file, userAgent = getUserAgent(context).first())
+    }
+
+    /** Whether a saved sign-in belongs to [site]. */
+    private fun covers(entry: CookieEntry, site: String): Boolean {
+        siteKeyOf(hostOf(entry.url))?.let { return it == site }
+
+        // An imported set names no site, so its own cookies are asked instead. The domain
+        // is the first field of a Netscape line.
+        return entry.content.lineSequence().any { line ->
+            val domain = line.substringBefore('\t').trim().removePrefix(".")
+            domain.isNotBlank() && siteKeyOf(domain) == site
+        }
+    }
+
+    /** The cookie file for one site, written fresh so it always matches the saved list. */
+    private suspend fun writeSiteFile(
+        context: Context,
+        site: String,
+        entries: List<CookieEntry>
+    ): File? = withContext(Dispatchers.IO) {
+        val body = buildString {
+            append(FILE_HEADER)
+            append('\n')
+            entries.forEach { entry ->
+                entry.content.lineSequence().forEach { line ->
+                    if (line.isNotBlank() && !line.startsWith("#")) {
+                        append(line)
+                        append('\n')
+                    }
+                }
+            }
+        }
+
+        val file = File(context.cacheDir, "cookies-$site.txt")
+        runCatching { file.writeText(body) }.getOrNull() ?: return@withContext null
+        file.takeIf { it.length() > 0 }
+    }
+
+    /**
+     * What counts as the same site.
+     *
+     * The registrable domain, with the short forms a site publishes for itself folded into
+     * the name they belong to. Without that, a shortened link looks like a different site
+     * from the one the user signed in to and is fetched as a stranger.
+     */
+    private fun siteKeyOf(url: String): String? {
+        val host = url.takeIf { it.isNotBlank() } ?: return null
+        SITE_ALIASES[host]?.let { return it }
+
+        val registrable = host.split('.').takeLast(2).joinToString(".")
+        return SITE_ALIASES[registrable] ?: registrable.takeIf { it.contains('.') }
+    }
+
+    private fun hostOf(value: String): String {
+        if (value.isBlank()) return ""
+        val withScheme = if ("://" in value) value else "https://$value"
+        return runCatching { java.net.URI(withScheme).host.orEmpty() }
+            .getOrDefault("")
+            .lowercase()
+            .removePrefix("www.")
+    }
+
+    /** Short forms and sister domains, mapped to the site they are part of. */
+    private val SITE_ALIASES = mapOf(
+        "youtu.be" to "youtube.com",
+        "youtube-nocookie.com" to "youtube.com",
+        "instagr.am" to "instagram.com",
+        "x.com" to "twitter.com",
+        "fb.watch" to "facebook.com",
+        "fb.com" to "facebook.com",
+        "vm.tiktok.com" to "tiktok.com",
+        "vt.tiktok.com" to "tiktok.com"
+    )
 
     /** Whole cookie file as text, for copying out. */
     suspend fun exportText(context: Context): String = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/hazel/android/data/DownloadQueueRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/DownloadQueueRepository.kt
@@ -38,6 +38,10 @@ data class QueuedDownload(
     val mergeAudioSelector: String?,
     val mergeAudioSizeBytes: Long,
     val treeUri: String,
+    /** Whether reading this link needed the saved sign-in, which the download needs too. */
+    val requiresSignIn: Boolean = false,
+    /** The soundtrack chosen for it, for a source that published more than one. */
+    val audioLanguage: String? = null,
     /** The settings this link was asked for under, so a later change does not rewrite it. */
     val options: DownloadOptions,
     /**
@@ -143,6 +147,8 @@ object DownloadQueueRepository {
                     put("mergeAudio", item.mergeAudioSelector ?: JSONObject.NULL)
                     put("mergeAudioSize", item.mergeAudioSizeBytes)
                     put("treeUri", item.treeUri)
+                    put("requiresSignIn", item.requiresSignIn)
+                    put("audioLanguage", item.audioLanguage ?: JSONObject.NULL)
                     put("options", encodeOptions(item.options))
                     put("paused", item.paused)
                 }
@@ -181,6 +187,10 @@ object DownloadQueueRepository {
                     },
                     mergeAudioSizeBytes = item.optLong("mergeAudioSize"),
                     treeUri = item.optString("treeUri"),
+                    requiresSignIn = item.optBoolean("requiresSignIn"),
+                    audioLanguage = item.optString("audioLanguage").takeIf {
+                        it.isNotBlank() && it != "null"
+                    },
                     options = decodeOptions(item.optJSONObject("options")),
                     paused = item.optBoolean("paused")
                 )
@@ -254,6 +264,9 @@ fun QueuedDownload.toPlan(): DownloadPlan {
             formatId = it,
             selector = it,
             label = "",
+            // Carries the soundtrack it was chosen for, so looking the track up by
+            // language finds this one rather than falling back to the source's default.
+            language = audioLanguage,
             ext = "",
             vcodec = null,
             acodec = null,
@@ -276,15 +289,20 @@ fun QueuedDownload.toPlan(): DownloadPlan {
         audioFormats = listOfNotNull(
             format.takeIf { !it.hasVideo },
             mergeAudio
-        )
+        ),
+        requiresSignIn = requiresSignIn
     )
 
-    return DownloadPlan(info, format, title, author)
+    return DownloadPlan(info, format, title, author, audioLanguage)
 }
 
 /** What to write down for a link about to be queued. */
 fun DownloadPlan.toQueued(options: DownloadOptions, treeUri: String): QueuedDownload {
-    val mergeAudio = if (format.hasVideo && !format.hasAudio) info.mergeAudio else null
+    // The track for the soundtrack that was chosen, not whichever the source listed
+    // first. A queued item is rebuilt from these fields alone, so a language recorded
+    // here and a track recorded from somewhere else would disagree at download time.
+    val mergeAudio =
+        if (format.hasVideo && !format.hasAudio) info.mergeAudioFor(audioLanguage) else null
     return QueuedDownload(
         url = info.url,
         title = title,
@@ -302,6 +320,8 @@ fun DownloadPlan.toQueued(options: DownloadOptions, treeUri: String): QueuedDown
         mergeAudioSelector = mergeAudio?.selector,
         mergeAudioSizeBytes = mergeAudio?.fileSizeBytes ?: 0L,
         treeUri = treeUri,
+        requiresSignIn = info.requiresSignIn,
+        audioLanguage = audioLanguage,
         options = options
     )
 }

--- a/app/src/main/java/com/hazel/android/data/SettingsRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/SettingsRepository.kt
@@ -2,6 +2,7 @@ package com.hazel.android.data
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -67,48 +68,95 @@ object SettingsRepository {
     // Everything the sheet can adjust is read back as one DownloadOptions so the screen
     // observes a single flow instead of a dozen, and so a new knob only needs a key here.
 
-    private val VIDEO_CONTAINER_KEY = stringPreferencesKey("video_container")
-    private val AUDIO_CONTAINER_KEY = stringPreferencesKey("audio_container")
-    private val SPONSORBLOCK_KEY = stringSetPreferencesKey("sponsorblock_filters")
-    private val ADD_CHAPTERS_KEY = booleanPreferencesKey("add_chapters")
-    private val SPLIT_CHAPTERS_KEY = booleanPreferencesKey("split_by_chapters")
-    private val EMBED_SUBS_KEY = booleanPreferencesKey("embed_subs")
-    private val WRITE_SUBS_KEY = booleanPreferencesKey("write_subs")
-    private val WRITE_AUTO_SUBS_KEY = booleanPreferencesKey("write_auto_subs")
-    private val SUB_LANGUAGES_KEY = stringPreferencesKey("sub_languages")
+    /**
+     * One set of option keys.
+     *
+     * There are two sets, under different names in the same store. The sheet writes one and
+     * the instant share reads the other, so a decision made for a download being watched
+     * cannot silently change what an unattended share does with the next link, which is the
+     * one download nobody is there to correct.
+     *
+     * The unprefixed set keeps the names it has always had, so settings made before the
+     * split are still the sheet's settings.
+     */
+    private class OptionKeys(prefix: String) {
+        val videoContainer = stringPreferencesKey("${prefix}video_container")
+        val audioContainer = stringPreferencesKey("${prefix}audio_container")
+        val embedThumbnail = booleanPreferencesKey("${prefix}embed_thumbnail")
+        val filenameTemplate = stringPreferencesKey("${prefix}filename_template")
+        val sponsorBlock = stringSetPreferencesKey("${prefix}sponsorblock_filters")
+        val addChapters = booleanPreferencesKey("${prefix}add_chapters")
+        val splitChapters = booleanPreferencesKey("${prefix}split_by_chapters")
+        val embedSubs = booleanPreferencesKey("${prefix}embed_subs")
+        val writeSubs = booleanPreferencesKey("${prefix}write_subs")
+        val writeAutoSubs = booleanPreferencesKey("${prefix}write_auto_subs")
+        val subLanguages = stringPreferencesKey("${prefix}sub_languages")
+    }
+
+    private val SHEET_OPTIONS = OptionKeys("")
+    private val INSTANT_OPTIONS = OptionKeys("instant_")
+
+    private fun Preferences.readOptions(keys: OptionKeys): DownloadOptions {
+        val defaults = DownloadOptions()
+        return DownloadOptions(
+            videoContainer = this[keys.videoContainer] ?: defaults.videoContainer,
+            audioContainer = this[keys.audioContainer] ?: defaults.audioContainer,
+            embedThumbnail = this[keys.embedThumbnail] ?: defaults.embedThumbnail,
+            filenameTemplate = this[keys.filenameTemplate] ?: defaults.filenameTemplate,
+            sponsorBlockFilters = this[keys.sponsorBlock] ?: defaults.sponsorBlockFilters,
+            addChapters = this[keys.addChapters] ?: defaults.addChapters,
+            splitByChapters = this[keys.splitChapters] ?: defaults.splitByChapters,
+            embedSubs = this[keys.embedSubs] ?: defaults.embedSubs,
+            writeSubs = this[keys.writeSubs] ?: defaults.writeSubs,
+            writeAutoSubs = this[keys.writeAutoSubs] ?: defaults.writeAutoSubs,
+            subLanguages = this[keys.subLanguages] ?: defaults.subLanguages
+        )
+    }
+
+    private fun MutablePreferences.writeOptions(keys: OptionKeys, options: DownloadOptions) {
+        this[keys.videoContainer] = options.videoContainer
+        this[keys.audioContainer] = options.audioContainer
+        this[keys.embedThumbnail] = options.embedThumbnail
+        this[keys.filenameTemplate] = options.filenameTemplate
+        this[keys.sponsorBlock] = options.sponsorBlockFilters
+        this[keys.addChapters] = options.addChapters
+        this[keys.splitChapters] = options.splitByChapters
+        this[keys.embedSubs] = options.embedSubs
+        this[keys.writeSubs] = options.writeSubs
+        this[keys.writeAutoSubs] = options.writeAutoSubs
+        this[keys.subLanguages] = options.subLanguages
+    }
 
     fun getDownloadOptions(context: Context): Flow<DownloadOptions> =
-        context.dataStore.data.map { prefs ->
-            val defaults = DownloadOptions()
-            DownloadOptions(
-                videoContainer = prefs[VIDEO_CONTAINER_KEY] ?: defaults.videoContainer,
-                audioContainer = prefs[AUDIO_CONTAINER_KEY] ?: defaults.audioContainer,
-                embedThumbnail = prefs[EMBED_THUMBNAIL_KEY] ?: defaults.embedThumbnail,
-                filenameTemplate = prefs[FILENAME_TEMPLATE_KEY] ?: defaults.filenameTemplate,
-                sponsorBlockFilters = prefs[SPONSORBLOCK_KEY] ?: defaults.sponsorBlockFilters,
-                addChapters = prefs[ADD_CHAPTERS_KEY] ?: defaults.addChapters,
-                splitByChapters = prefs[SPLIT_CHAPTERS_KEY] ?: defaults.splitByChapters,
-                embedSubs = prefs[EMBED_SUBS_KEY] ?: defaults.embedSubs,
-                writeSubs = prefs[WRITE_SUBS_KEY] ?: defaults.writeSubs,
-                writeAutoSubs = prefs[WRITE_AUTO_SUBS_KEY] ?: defaults.writeAutoSubs,
-                subLanguages = prefs[SUB_LANGUAGES_KEY] ?: defaults.subLanguages
-            )
-        }
+        context.dataStore.data.map { prefs -> prefs.readOptions(SHEET_OPTIONS) }
 
     suspend fun setDownloadOptions(context: Context, options: DownloadOptions) {
-        context.dataStore.edit { prefs ->
-            prefs[VIDEO_CONTAINER_KEY] = options.videoContainer
-            prefs[AUDIO_CONTAINER_KEY] = options.audioContainer
-            prefs[EMBED_THUMBNAIL_KEY] = options.embedThumbnail
-            prefs[FILENAME_TEMPLATE_KEY] = options.filenameTemplate
-            prefs[SPONSORBLOCK_KEY] = options.sponsorBlockFilters
-            prefs[ADD_CHAPTERS_KEY] = options.addChapters
-            prefs[SPLIT_CHAPTERS_KEY] = options.splitByChapters
-            prefs[EMBED_SUBS_KEY] = options.embedSubs
-            prefs[WRITE_SUBS_KEY] = options.writeSubs
-            prefs[WRITE_AUTO_SUBS_KEY] = options.writeAutoSubs
-            prefs[SUB_LANGUAGES_KEY] = options.subLanguages
-        }
+        context.dataStore.edit { prefs -> prefs.writeOptions(SHEET_OPTIONS, options) }
+    }
+
+    private val INSTANT_AUDIO_LANGUAGE_KEY = stringPreferencesKey("instant_audio_language")
+
+    /**
+     * The soundtrack an instant share prefers, as a language tag, or blank for whichever
+     * the source leads with.
+     *
+     * Nothing is asked at share time, so this is a standing preference rather than a
+     * choice: a source that has the language gets it, and one that does not is downloaded
+     * with what it has.
+     */
+    fun getInstantAudioLanguage(context: Context): Flow<String> =
+        context.dataStore.data.map { prefs -> prefs[INSTANT_AUDIO_LANGUAGE_KEY].orEmpty() }
+
+    suspend fun setInstantAudioLanguage(context: Context, language: String) {
+        context.dataStore.edit { prefs -> prefs[INSTANT_AUDIO_LANGUAGE_KEY] = language }
+    }
+
+    /** The same knobs, kept separately for the share target that asks nothing. */
+    fun getInstantOptions(context: Context): Flow<DownloadOptions> =
+        context.dataStore.data.map { prefs -> prefs.readOptions(INSTANT_OPTIONS) }
+
+    suspend fun setInstantOptions(context: Context, options: DownloadOptions) {
+        context.dataStore.edit { prefs -> prefs.writeOptions(INSTANT_OPTIONS, options) }
     }
 
     // ── Link reading ──

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -1,6 +1,7 @@
 package com.hazel.android.download
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hazel.android.HazelApp
@@ -52,7 +53,12 @@ data class DownloadPlan(
     val info: MediaInfo,
     val format: MediaFormat,
     val title: String,
-    val author: String
+    val author: String,
+    /**
+     * The soundtrack to take, for a source that published more than one. Null means the
+     * one the source leads with, which is every ordinary link.
+     */
+    val audioLanguage: String? = null
 )
 
 data class DownloadState(
@@ -378,7 +384,11 @@ class DownloadViewModel : ViewModel() {
 
                 val isVideo = SettingsRepository.getQuickIsVideo(app).first()
                 val maxHeight = SettingsRepository.getQuickMaxHeight(app).first()
-                val format = info.autoPick(isVideo, maxHeight)
+                // A standing preference rather than a question. A source that does not
+                // publish this soundtrack is downloaded with the one it does have.
+                val audioLanguage = SettingsRepository.getInstantAudioLanguage(app).first()
+                    .takeIf { it.isNotBlank() }
+                val format = info.autoPick(isVideo, maxHeight, audioLanguage)
                 if (format == null) {
                     _state.value = _state.value.copy(instantSource = "")
                     DownloadNotificationHelper.showError(app, "Nothing to download from this link")
@@ -401,8 +411,13 @@ class DownloadViewModel : ViewModel() {
 
                 startBatch(
                     context = app,
-                    plans = listOf(DownloadPlan(info, format, info.title, info.uploader)),
-                    options = SettingsRepository.getDownloadOptions(app).first(),
+                    plans = listOf(
+                        DownloadPlan(info, format, info.title, info.uploader, audioLanguage)
+                    ),
+                    // The instant target's own settings, not the sheet's. Nobody is
+                    // watching this download, so it answers to the screen that was set up
+                    // for exactly that.
+                    options = SettingsRepository.getInstantOptions(app).first(),
                     treeUri = SettingsRepository.getDownloadTreeUri(app).first()
                 )
             }
@@ -420,7 +435,7 @@ class DownloadViewModel : ViewModel() {
         val app = HazelApp.instance
         return expand(
             url,
-            CookieRepository.activeCookieFile(app),
+            CookieRepository.accessFor(app, url),
             SettingsRepository.getFetchMode(app).first(),
             SettingsRepository.getForceIpv4(app).first(),
             SettingsRepository.getListingSource(app).first(),
@@ -432,7 +447,7 @@ class DownloadViewModel : ViewModel() {
             else runCatching {
                 probeWithRetry(
                     first.url,
-                    CookieRepository.activeCookieFile(app),
+                    CookieRepository.accessFor(app, first.url),
                     SettingsRepository.getFetchMode(app).first(),
                     SettingsRepository.getForceIpv4(app).first(),
                     "${MediaProbe.PROBE_PROCESS_ID}_direct_formats"
@@ -502,7 +517,6 @@ class DownloadViewModel : ViewModel() {
 
         fetchJob = viewModelScope.launch {
             val app = HazelApp.instance
-            val cookies = CookieRepository.activeCookieFile(app)
             val fetchMode = SettingsRepository.getFetchMode(app).first()
             val forceIpv4 = SettingsRepository.getForceIpv4(app).first()
 
@@ -526,7 +540,11 @@ class DownloadViewModel : ViewModel() {
                         async(Dispatchers.IO) {
                             runCatching {
                                 expand(
-                                    link, cookies, fetchMode, forceIpv4, listingSource,
+                                    link,
+                                    // Each link is read with the sign-in for its own
+                                    // site, and with none where there is not one.
+                                    CookieRepository.accessFor(app, link),
+                                    fetchMode, forceIpv4, listingSource,
                                     "${MediaProbe.PROBE_PROCESS_ID}_$index"
                                 )
                             }.onFailure { failure ->
@@ -602,18 +620,22 @@ class DownloadViewModel : ViewModel() {
      */
     private suspend fun expand(
         url: String,
-        cookies: File?,
+        access: SiteAccess,
         fetchMode: FetchMode,
         forceIpv4: Boolean,
         source: ListingSource,
         processKey: String
     ): List<MediaInfo> {
-        // A link read a moment ago is not read again. The engine costs seconds to start
-        // before it does any work, so the cheapest read is the one that does not happen.
+        // A link read recently is not read again. The engine costs seconds to start before
+        // it does any work, so the cheapest read is the one that does not happen. This
+        // holds across restarts as well: what the last read wrote is still on disk.
         InfoCache.metadataFor(url)?.let { return listOf(it) }
+        InfoCache.listingFor(url)?.let { listing ->
+            return listing.entries.map(MediaProbe::pendingFor)
+        }
 
         val contents = LinkResolver.resolve(
-            url, ytDlpCacheDir, cookies, fetchMode, forceIpv4, source, processKey
+            url, ytDlpCacheDir, access, fetchMode, forceIpv4, source, processKey
         )
 
         return when (contents) {
@@ -638,7 +660,7 @@ class DownloadViewModel : ViewModel() {
                 InfoCache.metadataFor(info.url)?.takeIf { it.hasResolvedFormats }
                     ?: probeWithRetry(
                         info.url,
-                        CookieRepository.activeCookieFile(app),
+                        CookieRepository.accessFor(app, info.url),
                         SettingsRepository.getFetchMode(app).first(),
                         SettingsRepository.getForceIpv4(app).first(),
                         "${MediaProbe.PROBE_PROCESS_ID}_formats"
@@ -671,16 +693,16 @@ class DownloadViewModel : ViewModel() {
      */
     private suspend fun probeWithRetry(
         url: String,
-        cookies: File?,
+        access: SiteAccess,
         fetchMode: FetchMode,
         forceIpv4: Boolean,
         processKey: String = MediaProbe.PROBE_PROCESS_ID
     ): MediaInfo = try {
-        MediaProbe.probe(url, ytDlpCacheDir, cookies, fetchMode, forceIpv4, processKey)
+        MediaProbe.probe(url, ytDlpCacheDir, access, fetchMode, forceIpv4, processKey)
     } catch (e: Exception) {
         if (isTerminal(e.message?.trim().orEmpty())) throw e
         MediaProbe.probe(
-            url, ytDlpCacheDir, cookies, FetchMode.THOROUGH, forceIpv4, processKey
+            url, ytDlpCacheDir, access, FetchMode.THOROUGH, forceIpv4, processKey
         )
     }
 
@@ -726,12 +748,13 @@ class DownloadViewModel : ViewModel() {
         options: DownloadOptions,
         title: String,
         author: String,
+        audioLanguage: String? = null,
         treeUri: String = ""
     ) {
         val info = _state.value.info ?: return
         startBatch(
             context = context,
-            plans = listOf(DownloadPlan(info, format, title, author)),
+            plans = listOf(DownloadPlan(info, format, title, author, audioLanguage)),
             options = options,
             treeUri = treeUri
         )
@@ -868,7 +891,6 @@ class DownloadViewModel : ViewModel() {
             // needed one in the first place.
             DownloadService.start(app, firstTitle)
 
-            val cookies = CookieRepository.activeCookieFile(app)
             val speedLimit = SettingsRepository.getSpeedLimit(app).first()
 
             while (true) {
@@ -877,6 +899,18 @@ class DownloadViewModel : ViewModel() {
                 val plan = next.toPlan()
                 val options = next.options
                 downloadTreeUri = next.treeUri
+
+                // The download asks the way the read that filled the sheet asked. On a
+                // site that answers a signed-in request with less, a public link is
+                // fetched anonymously and only the media that needed the sign-in carries
+                // it, so a download cannot come back smaller than the sheet promised.
+                val access = CookieRepository.accessFor(app, plan.info.url)
+                val planAccess = when {
+                    !access.hasCookies -> SiteAccess.NONE
+                    plan.info.requiresSignIn -> access
+                    cookiesNarrowTheFormats(plan.info.url) -> SiteAccess.NONE
+                    else -> access
+                }
 
                 isCancelled = false
                 isPaused = false
@@ -906,7 +940,9 @@ class DownloadViewModel : ViewModel() {
                         executeYtDlp(
                             buildRequest(
                                 plan.info.url, plan.format, options, plan.title, plan.author,
-                                cookies, speedLimit
+                                planAccess, speedLimit,
+                                plan.info.mergeAudioFor(plan.audioLanguage)?.selector,
+                                plan.audioLanguage
                             )
                         )
                     } catch (e: Exception) {
@@ -930,7 +966,9 @@ class DownloadViewModel : ViewModel() {
                         executeYtDlp(
                             buildRequest(
                                 plan.info.url, plan.format, options, plan.title, plan.author,
-                                cookies, speedLimit
+                                planAccess, speedLimit,
+                                plan.info.mergeAudioFor(plan.audioLanguage)?.selector,
+                                plan.audioLanguage
                             )
                         )
                     }
@@ -1217,8 +1255,20 @@ class DownloadViewModel : ViewModel() {
         options: DownloadOptions,
         title: String,
         author: String,
-        cookieFile: File?,
-        speedLimit: String
+        access: SiteAccess,
+        speedLimit: String,
+        /**
+         * The audio stream to mux into a video-only format. Worked out by the caller from
+         * the plan, so a download of a source with several soundtracks takes the one the
+         * sheet was showing rather than whichever the source listed first.
+         */
+        audioSelector: String?,
+        /**
+         * The soundtrack the sheet was set to, as a language tag. Named as well as
+         * resolved to an id, so the request can still ask for the right language if the id
+         * it was resolved to is not in the list the engine ends up with.
+         */
+        audioLanguage: String?
     ): YoutubeDLRequest = buildDownloadRequest(url).apply {
         val isVideo = format.hasVideo
         val container = (if (isVideo) options.videoContainer else options.audioContainer).trim()
@@ -1235,13 +1285,18 @@ class DownloadViewModel : ViewModel() {
         addOption("--cache-dir", ytDlpCacheDir.absolutePath)
 
         // Saved sign-ins, which are what make age-restricted and members-only media
-        // reachable. The same file serves every download until the user changes it.
-        cookieFile?.let { addOption("--cookies", it.absolutePath) }
+        // reachable, under the identity they were collected with. The read that filled the
+        // sheet used the same ones, so the format ids it showed are the ids this asks for.
+        applySiteAccess(access, url)
 
         // Whether the two streams have to be muxed back together after the download. The
         // container option decides the result when one was chosen, otherwise mp4 is used
         // because it is the container both streams are most likely to fit.
         var needsMerge = false
+
+        val languageFilter = audioLanguage
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "ba[language^=$it]" }
 
         when {
             // Generic rows carry a complete yt-dlp expression already.
@@ -1254,14 +1309,26 @@ class DownloadViewModel : ViewModel() {
             // available audio, then to the bare video, so a track that has since gone
             // missing cannot fail the whole download.
             isVideo && !format.hasAudio -> {
-                val audioId = _state.value.info?.mergeAudio?.selector
+                val audioId = audioSelector
                 val selector = buildString {
                     if (audioId != null) append("${format.selector}+$audioId/")
+                    // The engine's own way of asking for a soundtrack by name, which is
+                    // what still gets the right language when the id above has gone.
+                    languageFilter?.let { append("${format.selector}+$it/") }
                     append("${format.selector}+bestaudio/${format.selector}")
                 }
+                // The one line worth having in the log: what the download actually asked
+                // for. A soundtrack chosen in the sheet only means anything if it reaches
+                // this expression, and this is where that can be seen.
+                Log.i("Hazel", "format expression: $selector")
                 addOption("-f", selector)
                 needsMerge = true
             }
+            // An audio download is already the soundtrack that was chosen, so the filter
+            // only stands in for it if that stream is no longer offered.
+            !isVideo && languageFilter != null ->
+                addOption("-f", "${format.selector}/$languageFilter/ba")
+
             else -> addOption("-f", format.selector)
         }
 

--- a/app/src/main/java/com/hazel/android/download/InfoCache.kt
+++ b/app/src/main/java/com/hazel/android/download/InfoCache.kt
@@ -1,7 +1,11 @@
 package com.hazel.android.download
 
 import com.hazel.android.HazelApp
+import com.hazel.android.download.extractor.LinkContents
+import com.hazel.android.download.extractor.LinkEntry
 import com.hazel.android.util.LinkKey
+import org.json.JSONArray
+import org.json.JSONObject
 import java.io.File
 
 /**
@@ -12,35 +16,42 @@ import java.io.File
  * four doing the extraction. Almost none of that is the app's own work, so the only way to
  * make a repeat cheaper is not to do it again.
  *
- * Two things are kept, for two different readers:
+ * Three things are kept, for three different readers:
  *
  *  - the parsed [MediaInfo], so pasting a link again fills the card and the format sheet
  *    without a read at all;
  *  - the engine's own JSON, which the download hands straight back with `--load-info-json`
  *    so it skips its extraction. That measured 5.8 seconds down to 3.2 before a byte moved,
- *    the remainder being the engine starting up.
+ *    the remainder being the engine starting up;
+ *  - what a collection held, so a playlist pasted again opens as the set of cards it opened
+ *    as last time instead of being walked a second time.
  *
- * The JSON holds signed stream addresses that stop working after a few hours, so it is given
- * the shorter life of the two and every reader treats a miss as ordinary. Nothing here is
- * required to be present, and nothing here is trusted once it is old.
+ * All of it survives the app being closed, because the engine's payload is on disk and the
+ * parsed form is rebuilt from it on the first miss. Only the last [MAX_ENTRIES] links are
+ * kept: this is a convenience for links in current use, not a library.
+ *
+ * The JSON holds signed stream addresses that stop working after a few hours, so replaying
+ * it into a download has the shorter life of the two windows below. Every reader treats a
+ * miss as ordinary: nothing here is required to be present, and nothing here is trusted
+ * once it is old.
  */
 object InfoCache {
 
     /**
-     * How long parsed metadata stands in for a fresh read. Titles and formats do change,
-     * so this is short enough that a stale card is a matter of minutes.
+     * How long a read stands in for a fresh one. A title and a format list are stable for
+     * hours, and the worst a stale one costs is a download that re-reads the link.
      */
-    private const val METADATA_TTL_MS = 30 * 60 * 1000L
+    private const val METADATA_TTL_MS = 6 * 60 * 60 * 1000L
 
     /**
-     * How long the engine's JSON may be replayed into a download. Shorter, and deliberately
-     * well inside the life of the signed addresses inside it, because the cost of being
-     * wrong here is a failed download rather than a stale title.
+     * How long the engine's JSON may be replayed into a download. Much shorter, and
+     * deliberately well inside the life of the signed addresses inside it, because the cost
+     * of being wrong here is a failed download rather than a stale title.
      */
     private const val INFO_JSON_TTL_MS = 60 * 60 * 1000L
 
-    /** Kept small: this is a convenience for links in current use, not a library. */
-    private const val MAX_ENTRIES = 60
+    /** How many links are remembered. The oldest goes when a new one arrives. */
+    private const val MAX_ENTRIES = 10
 
     private data class Entry(val info: MediaInfo, val storedAt: Long)
 
@@ -52,16 +63,25 @@ object InfoCache {
     private val directory: File
         get() = File(HazelApp.instance.cacheDir, "info").apply { if (!exists()) mkdirs() }
 
-    /** Parsed metadata for [url], or null when nothing fresh is held. */
+    /**
+     * Parsed metadata for [url], or null when nothing fresh is held.
+     *
+     * A miss in memory is not the end of the question: the payload the last read wrote is
+     * still on disk after the app has been closed and reopened, and parsing it again costs
+     * nothing next to reading the link. That is what makes a link pasted yesterday open its
+     * sheet at once today.
+     */
     @Synchronized
     fun metadataFor(url: String): MediaInfo? {
         val key = LinkKey.canonical(url)
-        val entry = metadata[key] ?: return null
-        if (System.currentTimeMillis() - entry.storedAt > METADATA_TTL_MS) {
+        metadata[key]?.let { entry ->
+            if (System.currentTimeMillis() - entry.storedAt <= METADATA_TTL_MS) return entry.info
             metadata.remove(key)
-            return null
         }
-        return entry.info
+
+        val restored = restoreFromDisk(url) ?: return null
+        metadata[key] = Entry(restored, fileFor(url).lastModified())
+        return restored
     }
 
     /**
@@ -71,10 +91,7 @@ object InfoCache {
     fun infoJsonFor(url: String): File? {
         val file = fileFor(url)
         if (!file.exists()) return null
-        if (System.currentTimeMillis() - file.lastModified() > INFO_JSON_TTL_MS) {
-            file.delete()
-            return null
-        }
+        if (System.currentTimeMillis() - file.lastModified() > INFO_JSON_TTL_MS) return null
         return file
     }
 
@@ -87,6 +104,71 @@ object InfoCache {
         // replaying it into a download would select nothing.
         if (rawJson.isNullOrBlank()) return
         runCatching { fileFor(url).writeText(rawJson) }
+
+        // Which reads needed the sign-in is the app's own finding rather than anything in
+        // the payload, so it is kept beside it: the file is there or it is not.
+        runCatching {
+            val marker = signInMarkerFor(url)
+            if (info.requiresSignIn) marker.writeText("1") else marker.delete()
+        }
+        trimToLimit()
+    }
+
+    /** What a collection held, so pasting it again does not walk it a second time. */
+    @Synchronized
+    fun putListing(url: String, contents: LinkContents.Many) {
+        val json = JSONObject().apply {
+            put("title", contents.title)
+            put(
+                "entries",
+                JSONArray().apply {
+                    contents.entries.forEach { entry ->
+                        put(
+                            JSONObject().apply {
+                                put("url", entry.url)
+                                put("title", entry.title)
+                                put("uploader", entry.uploader)
+                                put("thumbnail", entry.thumbnail ?: JSONObject.NULL)
+                                put("duration", entry.durationSeconds)
+                            }
+                        )
+                    }
+                }
+            )
+        }
+        runCatching { listingFileFor(url).writeText(json.toString()) }
+        trimToLimit()
+    }
+
+    /** The remembered contents of a collection, or null when there are none worth using. */
+    @Synchronized
+    fun listingFor(url: String): LinkContents.Many? {
+        val file = listingFileFor(url)
+        if (!file.exists()) return null
+        if (System.currentTimeMillis() - file.lastModified() > METADATA_TTL_MS) {
+            file.delete()
+            return null
+        }
+
+        return runCatching {
+            val json = JSONObject(file.readText())
+            val array = json.optJSONArray("entries") ?: return null
+            val entries = (0 until array.length()).mapNotNull { index ->
+                array.optJSONObject(index)?.let { entry ->
+                    LinkEntry(
+                        url = entry.optString("url"),
+                        title = entry.optString("title"),
+                        uploader = entry.optString("uploader"),
+                        thumbnail = entry.optString("thumbnail")
+                            .takeIf { it.isNotBlank() && it != "null" },
+                        durationSeconds = entry.optInt("duration")
+                    )
+                }
+            }.filter { it.url.isNotBlank() }
+
+            if (entries.isEmpty()) null
+            else LinkContents.Many(title = json.optString("title"), entries = entries)
+        }.getOrNull()
     }
 
     /**
@@ -99,6 +181,8 @@ object InfoCache {
     fun invalidate(url: String) {
         metadata.remove(LinkKey.canonical(url))
         runCatching { fileFor(url).delete() }
+        runCatching { signInMarkerFor(url).delete() }
+        runCatching { listingFileFor(url).delete() }
     }
 
     @Synchronized
@@ -107,13 +191,55 @@ object InfoCache {
         runCatching { directory.listFiles()?.forEach { it.delete() } }
     }
 
-    /** Removes payloads that are past replaying, so the directory cannot grow unbounded. */
+    /** Removes what is past using, so the directory cannot grow unbounded. */
+    @Synchronized
     fun prune() {
         runCatching {
-            val cutoff = System.currentTimeMillis() - INFO_JSON_TTL_MS
+            val cutoff = System.currentTimeMillis() - METADATA_TTL_MS
             directory.listFiles()?.forEach { if (it.lastModified() < cutoff) it.delete() }
+        }
+        trimToLimit()
+    }
+
+    /** Rebuilds the parsed form from the payload the last read left on disk. */
+    private fun restoreFromDisk(url: String): MediaInfo? {
+        val file = fileFor(url)
+        if (!file.exists()) return null
+        if (System.currentTimeMillis() - file.lastModified() > METADATA_TTL_MS) {
+            file.delete()
+            return null
+        }
+
+        return runCatching {
+            MediaProbe.parse(url, JSONObject(file.readText()))
+                .copy(requiresSignIn = signInMarkerFor(url).exists())
+        }.getOrNull()
+    }
+
+    /**
+     * Keeps the newest [MAX_ENTRIES] links and deletes the rest.
+     *
+     * Counted by link rather than by file, since one link leaves a payload and may leave a
+     * marker beside it, and dropping half of a link would leave a record that says the
+     * wrong thing about it.
+     */
+    private fun trimToLimit() {
+        runCatching {
+            val files = directory.listFiles()?.toList().orEmpty()
+            val newestFirst = files
+                .groupBy { it.name.substringBefore('.') }
+                .entries
+                .sortedByDescending { group -> group.value.maxOf { it.lastModified() } }
+
+            newestFirst.drop(MAX_ENTRIES).forEach { group ->
+                group.value.forEach { it.delete() }
+            }
         }
     }
 
     private fun fileFor(url: String) = File(directory, "${LinkKey.digest(url)}.info.json")
+
+    private fun signInMarkerFor(url: String) = File(directory, "${LinkKey.digest(url)}.signin")
+
+    private fun listingFileFor(url: String) = File(directory, "${LinkKey.digest(url)}.list.json")
 }

--- a/app/src/main/java/com/hazel/android/download/MediaInfo.kt
+++ b/app/src/main/java/com/hazel/android/download/MediaInfo.kt
@@ -10,7 +10,15 @@ data class MediaInfo(
     val thumbnail: String?,
     val durationSeconds: Int,
     val videoFormats: List<MediaFormat>,
-    val audioFormats: List<MediaFormat>
+    val audioFormats: List<MediaFormat>,
+    /**
+     * True when this media would not open without the saved sign-in.
+     *
+     * Set by the read that found out, and carried to the download so it asks the same way.
+     * False is the ordinary case, and it is what keeps a public link away from a signed-in
+     * request on the sites that answer those with less.
+     */
+    val requiresSignIn: Boolean = false
 ) {
     /**
      * The entry the sheet opens on for each tab.
@@ -33,6 +41,28 @@ data class MediaInfo(
     val mergeAudio: MediaFormat?
         get() = audioFormats.firstOrNull { !it.isGeneric }
 
+    /**
+     * The soundtracks this media carries, in the order the source listed them, which puts
+     * the original first.
+     *
+     * Empty for almost everything: a source only names a language when it published more
+     * than one, so an empty list means there is nothing to choose between.
+     */
+    val audioLanguages: List<String>
+        get() = audioFormats.mapNotNull { it.language }.distinct()
+
+    /** The best audio in [language], falling back to the best of any when it has none. */
+    fun bestAudioFor(language: String?): MediaFormat? {
+        if (language.isNullOrBlank()) return bestAudio
+        return audioFormats.firstOrNull { !it.isGeneric && it.language == language } ?: bestAudio
+    }
+
+    /** The track a muxed video download takes its sound from, in [language] where there is one. */
+    fun mergeAudioFor(language: String?): MediaFormat? {
+        if (language.isNullOrBlank()) return mergeAudio
+        return audioFormats.firstOrNull { !it.isGeneric && it.language == language } ?: mergeAudio
+    }
+
     /** True once the source has reported at least one concrete format. */
     val hasResolvedFormats: Boolean
         get() = videoFormats.any { !it.isGeneric } || audioFormats.any { !it.isGeneric }
@@ -46,8 +76,8 @@ data class MediaInfo(
      * clears the ceiling the smallest available is taken, since a download slightly over
      * budget is a better answer than no download at all.
      */
-    fun autoPick(isVideo: Boolean, maxHeight: Int): MediaFormat? {
-        if (!isVideo) return bestAudio
+    fun autoPick(isVideo: Boolean, maxHeight: Int, audioLanguage: String? = null): MediaFormat? {
+        if (!isVideo) return bestAudioFor(audioLanguage)
 
         val concrete = videoFormats.filter { !it.isGeneric }
         if (concrete.isEmpty() || maxHeight <= 0) return bestVideo
@@ -70,6 +100,12 @@ data class MediaFormat(
     val formatId: String,
     val selector: String,
     val label: String,
+    /**
+     * The dubbed track this stream carries, as the source named it, or null where it named
+     * nothing. Most media has one soundtrack and reports no language at all; the field only
+     * has anything to say about the sources that publish several.
+     */
+    val language: String? = null,
     val ext: String,
     val vcodec: String?,
     val acodec: String?,
@@ -84,6 +120,17 @@ data class MediaFormat(
     /** True when the size came from the bitrate rather than from the source itself. */
     val isEstimatedSize: Boolean = false
 ) {
+    /**
+     * The headline without the measured resolution after it.
+     *
+     * The full label belongs in the format list, where a row is wide and the resolution is
+     * what separates two entries with the same note. A card in a set has room for one
+     * badge and a size beside it, and there the resolution pushes the size off the end of
+     * the row to say something "2160P" already said.
+     */
+    val shortLabel: String
+        get() = label.substringBefore(" (").trim().ifBlank { label }
+
     /** Codec badge text, e.g. "AVC1" for video or "OPUS" for audio. */
     val codecLabel: String
         get() {
@@ -103,6 +150,21 @@ data class MediaFormat(
         }
 
     val bitrateLabel: String get() = formatBitrate(bitrateKbps)
+}
+
+/**
+ * What to call a language code on screen.
+ *
+ * Sources write these as tags rather than words, and "hi-IN" says nothing to the person
+ * choosing between soundtracks. The device already knows the names, so the tag is only
+ * shown when it turns out not to be one Android recognises.
+ */
+fun languageLabel(code: String): String {
+    val locale = java.util.Locale.forLanguageTag(code.replace('_', '-'))
+    return locale.getDisplayName(java.util.Locale.getDefault())
+        .takeIf { it.isNotBlank() && it != code }
+        ?.replaceFirstChar { it.uppercase() }
+        ?: code
 }
 
 /** "1.2 GB" / "40.2 MB" / "812 KB", or blank when the size is unknown. */

--- a/app/src/main/java/com/hazel/android/download/MediaProbe.kt
+++ b/app/src/main/java/com/hazel/android/download/MediaProbe.kt
@@ -4,6 +4,7 @@ import com.hazel.android.download.extractor.LinkContents
 import com.hazel.android.download.extractor.LinkEntry
 import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLRequest
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -32,19 +33,53 @@ object MediaProbe {
     /**
      * @param cacheDir persistent yt-dlp cache, shared with the download request so the
      *   player data fetched here is reused instead of being resolved a second time.
-     * @param cookieFile saved sign-ins to send with the request, or null for none. Without
-     *   it a source that requires an account reports the media as unavailable.
+     * @param access saved sign-ins to read as, or [SiteAccess.NONE]. Without them a source
+     *   that requires an account reports the media as unavailable.
      */
     suspend fun probe(
         url: String,
         cacheDir: File,
-        cookieFile: File? = null,
+        access: SiteAccess = SiteAccess.NONE,
         fetchMode: FetchMode = FetchMode.DEFAULT,
         forceIpv4: Boolean = false,
         processId: String = PROBE_PROCESS_ID
     ): MediaInfo = withContext(Dispatchers.IO) {
+        // Some sites answer a signed-in request with far less than they answer an
+        // anonymous one: the largest of them now serves a signed-in session a single
+        // 360p stream unless the request carries a token the app cannot produce. So the
+        // sign-in is held back until the media turns out to need it, and the ordinary
+        // link keeps the full ladder it has always had.
+        val attempts = signInAttempts(url, access)
+
+        attempts.forEachIndexed { index, attempt ->
+            try {
+                return@withContext readOne(
+                    url, cacheDir, attempt, fetchMode, forceIpv4, processId,
+                    // True when this is the fallback, which only runs because the
+                    // anonymous read was refused.
+                    signedIn = index > 0
+                )
+            } catch (e: Exception) {
+                val last = index == attempts.lastIndex
+                if (last || e is CancellationException || !isSignInRefusal(e.message)) throw e
+            }
+        }
+
+        error("No metadata returned")
+    }
+
+    /** One read, at one level of access. */
+    private suspend fun readOne(
+        url: String,
+        cacheDir: File,
+        access: SiteAccess,
+        fetchMode: FetchMode,
+        forceIpv4: Boolean,
+        processId: String,
+        signedIn: Boolean
+    ): MediaInfo {
         val request = YoutubeDLRequest(url).apply {
-            applySharedOptions(cacheDir, cookieFile, fetchMode, forceIpv4)
+            applySharedOptions(url, cacheDir, access, fetchMode, forceIpv4)
             addOption("--dump-single-json")
         }
 
@@ -54,16 +89,43 @@ object MediaProbe {
             val payload = response.out.trim().takeIf { it.isNotBlank() }
                 ?: throw IllegalStateException("No metadata returned")
 
-            val parsed = parse(url, JSONObject(payload))
+            val parsed = parse(url, JSONObject(payload)).copy(requiresSignIn = signedIn)
 
             // Kept so a repeat of this link needs no read, and so the download can replay
             // the payload instead of extracting the same thing over again.
             InfoCache.put(url, parsed, payload)
-            parsed
+            return parsed
         } finally {
             activeProcessIds.remove(processId)
         }
     }
+
+    /**
+     * The reads to try, in order.
+     *
+     * One for almost everything: a link with no sign-in to offer, and a site that answers
+     * a signed-in request as fully as an anonymous one, both have a single way of being
+     * read. The two-step only exists for the sites that hold formats back from a signed-in
+     * request, and there the second step is what still reaches private, members-only and
+     * age-restricted media.
+     */
+    private fun signInAttempts(url: String, access: SiteAccess): List<SiteAccess> = when {
+        !access.hasCookies -> listOf(SiteAccess.NONE)
+        cookiesNarrowTheFormats(url) -> listOf(SiteAccess.NONE, access)
+        else -> listOf(access)
+    }
+
+    /** Whether a failure reads as the site asking who is calling. */
+    private fun isSignInRefusal(message: String?): Boolean {
+        val text = message?.lowercase() ?: return false
+        return SIGN_IN_REFUSALS.any { it in text }
+    }
+
+    private val SIGN_IN_REFUSALS = listOf(
+        "sign in", "log in", "login", "private video", "members-only", "members only",
+        "age-restricted", "age restricted", "confirm your age", "not a bot",
+        "this video is unavailable", "video unavailable", "account"
+    )
 
     /**
      * Finds out what a link actually holds: one item, or a collection of them.
@@ -82,13 +144,43 @@ object MediaProbe {
     suspend fun listContents(
         url: String,
         cacheDir: File,
-        cookieFile: File? = null,
+        access: SiteAccess = SiteAccess.NONE,
         fetchMode: FetchMode = FetchMode.DEFAULT,
         forceIpv4: Boolean = false,
         processId: String = PROBE_PROCESS_ID
     ): LinkContents = withContext(Dispatchers.IO) {
+        // The same two-step as a single read, and for the same reason: a public list is
+        // read anonymously, and the sign-in is kept for the one that will not open
+        // without it.
+        val attempts = signInAttempts(url, access)
+
+        attempts.forEachIndexed { index, attempt ->
+            try {
+                return@withContext listOne(
+                    url, cacheDir, attempt, fetchMode, forceIpv4, processId,
+                    signedIn = index > 0
+                )
+            } catch (e: Exception) {
+                val last = index == attempts.lastIndex
+                if (last || e is CancellationException || !isSignInRefusal(e.message)) throw e
+            }
+        }
+
+        error("No metadata returned")
+    }
+
+    /** One listing, at one level of access. */
+    private suspend fun listOne(
+        url: String,
+        cacheDir: File,
+        access: SiteAccess,
+        fetchMode: FetchMode,
+        forceIpv4: Boolean,
+        processId: String,
+        signedIn: Boolean
+    ): LinkContents {
         val request = YoutubeDLRequest(url).apply {
-            applySharedOptions(cacheDir, cookieFile, fetchMode, forceIpv4, singleItem = false)
+            applySharedOptions(url, cacheDir, access, fetchMode, forceIpv4, singleItem = false)
             addOption("--flat-playlist")
             // Entries are emitted as they are found rather than after the whole collection
             // has been walked, which is what stops a long playlist stalling on its own tail.
@@ -110,9 +202,9 @@ object MediaProbe {
         val isCollection = root.optString("_type") == "playlist" && entries != null
 
         if (!isCollection) {
-            val info = parse(url, root)
+            val info = parse(url, root).copy(requiresSignIn = signedIn)
             InfoCache.put(url, info, payload)
-            return@withContext LinkContents.Single(info)
+            return LinkContents.Single(info)
         }
 
         val listed = buildList {
@@ -128,15 +220,19 @@ object MediaProbe {
         if (listed.size == 1) {
             val only = listed.first()
             val resolved = runCatching {
-                probe(only.url, cacheDir, cookieFile, fetchMode, forceIpv4, processId)
+                probe(only.url, cacheDir, access, fetchMode, forceIpv4, processId)
             }.getOrNull()
-            if (resolved != null) return@withContext LinkContents.Single(resolved)
+            if (resolved != null) return LinkContents.Single(resolved)
         }
 
-        LinkContents.Many(
+        val many = LinkContents.Many(
             title = firstNonBlank(root.optString("title"), root.optString("playlist_title")),
             entries = listed
         )
+        // Kept so the same collection pasted again opens as the set of cards it opened as
+        // last time, without walking it a second time.
+        InfoCache.putListing(url, many)
+        return many
     }
 
     /** Reads one entry of a flat listing, which carries no formats by design. */
@@ -199,8 +295,9 @@ object MediaProbe {
 
     /** Options every metadata read uses, whether it covers one link or many. */
     private fun YoutubeDLRequest.applySharedOptions(
+        url: String,
         cacheDir: File,
-        cookieFile: File?,
+        access: SiteAccess,
         fetchMode: FetchMode,
         forceIpv4: Boolean,
         singleItem: Boolean = true
@@ -221,7 +318,9 @@ object MediaProbe {
         addOption("-R", fetchMode.retries.toString())
 
         if (forceIpv4) addOption("--force-ipv4")
-        cookieFile?.let { addOption("--cookies", it.absolutePath) }
+
+        // The sign-in, and everything that has to travel with it for the site to honour it.
+        applySiteAccess(access, url)
     }
 
     const val PROBE_PROCESS_ID = "hazel_probe"
@@ -239,14 +338,14 @@ object MediaProbe {
     )
 
     /**
-     * Rows that do not name a format id and let yt-dlp resolve the stream itself. They head
-     * both tabs, so "best" is always the first option, and they are the reason a download can
-     * still go ahead on a source that reports no usable format list.
+     * Rows that do not name a format id and let yt-dlp resolve the stream itself. They are
+     * what a tab holds when the source reported no usable format list, and the reason a
+     * download can still go ahead there.
      */
     private val BEST_VIDEO = MediaFormat(
         formatId = "best",
         selector = "bv*+ba/b",
-        label = "Best available",
+        label = "Best quality",
         ext = "",
         vcodec = null,
         acodec = null,
@@ -262,7 +361,7 @@ object MediaProbe {
     private val BEST_AUDIO = MediaFormat(
         formatId = "bestaudio",
         selector = "ba/b",
-        label = "BEST AUDIO",
+        label = "Best audio",
         ext = "",
         vcodec = null,
         acodec = null,
@@ -341,9 +440,12 @@ object MediaProbe {
             ),
             thumbnail = resolveThumbnail(media) ?: resolveThumbnail(root),
             durationSeconds = duration,
-            // "Best" always heads each tab, whatever the source did or did not report.
-            videoFormats = listOf(BEST_VIDEO) + video,
-            audioFormats = listOf(BEST_AUDIO) + audio
+            // The generic row stands in only where the source named nothing concrete. A
+            // list that already holds real formats does not need it: it says nothing the
+            // first real entry does not, and it cannot show the size, codec and
+            // resolution that entry can.
+            videoFormats = video.ifEmpty { listOf(BEST_VIDEO) },
+            audioFormats = audio.ifEmpty { listOf(BEST_AUDIO) }
         )
     }
 
@@ -434,6 +536,10 @@ object MediaProbe {
             formatId = id,
             selector = id,
             label = buildLabel(json, note, height, fps, hasVideo, id),
+            // Which dubbed track this is. Reported per format by sources that carry more
+            // than one, and absent everywhere else, which is the ordinary case.
+            language = json.optString("language")
+                .takeIf { it.isNotBlank() && it != "null" && it != "none" },
             ext = ext ?: "",
             vcodec = vcodec,
             acodec = acodec,
@@ -459,18 +565,31 @@ object MediaProbe {
         hasVideo: Boolean,
         id: String
     ): String {
+        val resolution = json.optString("resolution")
+            .takeIf { it.isNotBlank() && it != "null" && it != "audio only" }
+
         if (!hasVideo) {
-            return (note ?: json.optPositiveDouble("abr")?.let { "%.0f kbps".format(it) } ?: "Audio")
-                .uppercase()
+            // A note of "medium" says nothing on its own about what it describes, so the
+            // kind of stream is spelled out unless the source already did.
+            val base = note
+                ?: json.optPositiveDouble("abr")?.let { "%.0f kbps".format(it) }
+                ?: "Audio"
+            return if (base.endsWith("audio", ignoreCase = true)) base else "$base audio"
         }
-        val resolution = json.optString("resolution").takeIf { it.isNotBlank() && it != "null" }
+
         val base = when {
-            height > 0 -> "${height}p"
+            // The source's own note leads, because it names the step on the ladder the way
+            // the site does. The height stands in where there is no note.
             !note.isNullOrBlank() -> note
+            height > 0 -> if (fps > 30) "${height}p$fps" else "${height}p"
             resolution != null -> resolution
             else -> "Format $id"
         }
-        return if (height > 0 && fps > 30) "$base$fps" else base
+
+        // The measured resolution goes next to it, since a note like "premium" says which
+        // step it is and nothing at all about how big the picture is.
+        return if (resolution != null && !base.contains(resolution)) "$base ($resolution)"
+        else base
     }
 
     /** Instagram posts have no title; the caption or the post id stands in for one. */

--- a/app/src/main/java/com/hazel/android/download/SiteAccess.kt
+++ b/app/src/main/java/com/hazel/android/download/SiteAccess.kt
@@ -1,0 +1,83 @@
+package com.hazel.android.download
+
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import java.io.File
+
+/**
+ * What a request needs in order to reach a site as the signed-in user rather than as a
+ * stranger.
+ *
+ * Cookies on their own are only half of a session. A site hands them out to a particular
+ * browser and expects them back from that same browser, so the identity they were collected
+ * under travels with them; sending them under a different one is what makes a site treat a
+ * valid sign-in as suspicious and serve the stripped-down media it serves to anyone.
+ *
+ * One of these is built per fetch and used by both the metadata read and the download that
+ * follows it, so the two always ask the site the same question. A download that asked
+ * differently would be offered a different set of formats, and the id the sheet showed
+ * would not exist in it.
+ */
+data class SiteAccess(
+    /** Netscape cookie file to send, or null when there are no sign-ins to use. */
+    val cookieFile: File? = null,
+    /** The browser identity the cookies were collected under, or blank if unknown. */
+    val userAgent: String = ""
+) {
+    val hasCookies: Boolean get() = cookieFile != null
+
+    companion object {
+        /** No sign-ins: every request the app makes without them looks like this. */
+        val NONE = SiteAccess()
+    }
+}
+
+/**
+ * Applies the sign-in to a request.
+ *
+ * Called on the metadata read and on the download alike. Nothing is added when there are no
+ * cookies, so an ordinary fetch carries no extra options.
+ */
+fun YoutubeDLRequest.applySiteAccess(access: SiteAccess, url: String) {
+    val cookies = access.cookieFile ?: return
+
+    addOption("--cookies", cookies.absolutePath)
+
+    if (access.userAgent.isNotBlank()) {
+        addOption("--add-header", "User-Agent:${access.userAgent}")
+    }
+
+    if (cookiesNarrowTheFormats(url)) {
+        addOption("--extractor-args", "youtube:player_client=$SIGNED_IN_PLAYER_CLIENTS")
+    }
+}
+
+/**
+ * The clients to ask for the media when the request carries a sign-in.
+ *
+ * The site serves each of its player clients a different list, and most of them hold back
+ * everything above 360p unless the request carries a proof-of-origin token the app has no
+ * way to produce. These two are the ones that answer a signed-in request with anything
+ * worth having: the first needs no token when account cookies are sent, and the second
+ * answers with streams that need none at all. Naming them also drops the clients that
+ * would be asked and would answer with nothing, which is most of the waiting a signed-in
+ * read used to do.
+ */
+private const val SIGNED_IN_PLAYER_CLIENTS = "tv,web_safari"
+
+/**
+ * Whether sending cookies to [url] costs formats.
+ *
+ * True for the one site that treats a signed-in request as something to be careful with.
+ * Everywhere else a sign-in only ever adds to what is on offer, so it is sent with every
+ * request; here it is held back until the media will not open without it.
+ */
+fun cookiesNarrowTheFormats(url: String): Boolean {
+    val host = runCatching { java.net.URI(url).host.orEmpty() }
+        .getOrDefault("")
+        .removePrefix("www.")
+        .lowercase()
+
+    return host.endsWith("youtube.com") ||
+            host.endsWith("youtu.be") ||
+            host.endsWith("youtube-nocookie.com")
+}

--- a/app/src/main/java/com/hazel/android/download/extractor/LinkResolver.kt
+++ b/app/src/main/java/com/hazel/android/download/extractor/LinkResolver.kt
@@ -2,6 +2,7 @@ package com.hazel.android.download.extractor
 
 import com.hazel.android.download.FetchMode
 import com.hazel.android.download.MediaProbe
+import com.hazel.android.download.SiteAccess
 import java.io.File
 
 /**
@@ -51,7 +52,7 @@ object LinkResolver {
     suspend fun resolve(
         url: String,
         cacheDir: File,
-        cookieFile: File?,
+        access: SiteAccess,
         fetchMode: FetchMode,
         forceIpv4: Boolean,
         source: ListingSource,
@@ -65,6 +66,6 @@ object LinkResolver {
             NewPipeLister.list(url)?.let { return it }
         }
 
-        return MediaProbe.listContents(url, cacheDir, cookieFile, fetchMode, forceIpv4, processId)
+        return MediaProbe.listContents(url, cacheDir, access, fetchMode, forceIpv4, processId)
     }
 }

--- a/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
@@ -258,7 +258,10 @@ fun AppNavigation(
                 FetchSettingsScreen(onBack = { navController.popBackStack() })
             }
             composable("direct_share") {
-                DirectShareScreen(onBack = { navController.popBackStack() })
+                DirectShareScreen(
+                    onBack = { navController.popBackStack() },
+                    onOpenCookies = { navController.navigate("cookies") }
+                )
             }
             composable("storage_locations") {
                 StorageLocationsScreen(onBack = { navController.popBackStack() })

--- a/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/hazel/android/ui/navigation/AppNavigation.kt
@@ -50,6 +50,7 @@ import com.hazel.android.ui.screens.download.openBatterySettings
 import com.hazel.android.ui.screens.history.HistoryScreen
 import com.hazel.android.ui.screens.more.AppearanceScreen
 import com.hazel.android.ui.screens.more.DirectShareScreen
+import com.hazel.android.ui.screens.more.SponsorScreen
 import com.hazel.android.ui.screens.more.FetchSettingsScreen
 import com.hazel.android.ui.screens.more.MoreScreen
 import com.hazel.android.ui.screens.more.StorageCleanupScreen
@@ -94,7 +95,7 @@ fun AppNavigation(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     val isSubScreen = currentRoute in listOf(
-        "storage_locations", "appearance", "tools", "converter", "update", "cookies", "fetch_settings", "storage_cleanup", "direct_share"
+        "storage_locations", "appearance", "tools", "converter", "update", "cookies", "fetch_settings", "storage_cleanup", "direct_share", "sponsor"
     )
 
     Scaffold(
@@ -243,6 +244,7 @@ fun AppNavigation(
                     onNavigateToCookies = { navController.navigate("cookies") },
                     onNavigateToFetchSettings = { navController.navigate("fetch_settings") },
                     onNavigateToDirectShare = { navController.navigate("direct_share") },
+                    onNavigateToSponsor = { navController.navigate("sponsor") },
                     onOpenBatterySettings = { openBatterySettings(context) },
                     onNavigateToStorageCleanup = { navController.navigate("storage_cleanup") },
                     onNavigateToUpdate = { navController.navigate("update") }
@@ -257,6 +259,10 @@ fun AppNavigation(
             composable("fetch_settings") {
                 FetchSettingsScreen(onBack = { navController.popBackStack() })
             }
+            composable("sponsor") {
+                SponsorScreen(onBack = { navController.popBackStack() })
+            }
+
             composable("direct_share") {
                 DirectShareScreen(
                     onBack = { navController.popBackStack() },

--- a/app/src/main/java/com/hazel/android/ui/screens/cookies/CookieWebViewActivity.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/cookies/CookieWebViewActivity.kt
@@ -281,6 +281,13 @@ class CookieWebViewActivity : ComponentActivity() {
                     enabled = true
                 )
             )
+            // Kept with the cookies, because they were issued to this identity and are
+            // only honoured when they come back under it.
+            CookieRepository.setUserAgent(
+                this@CookieWebViewActivity,
+                webView?.settings?.userAgentString.orEmpty()
+            )
+
             // Saving cookies is meaningless while the master switch is off, so confirming
             // here turns it on.
             CookieRepository.setUseCookies(this@CookieWebViewActivity, true)

--- a/app/src/main/java/com/hazel/android/ui/screens/download/AudioLanguageSheet.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/AudioLanguageSheet.kt
@@ -1,0 +1,173 @@
+package com.hazel.android.ui.screens.download
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hazel.android.download.languageLabel
+
+/**
+ * Which soundtrack a download takes.
+ *
+ * Built like the format sheet, because it is the same kind of question asked of the same
+ * media: a list of what the source published, with the current answer marked. Only shown
+ * where there is a choice, which is rare; most media has one soundtrack and this never
+ * appears for it.
+ *
+ * The first entry is the source's own default. It stays selectable rather than being
+ * dropped once a language is picked, since going back to whatever the uploader called the
+ * original is otherwise impossible without knowing which one that was.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AudioLanguageSheet(
+    languages: List<String>,
+    selected: String?,
+    onPick: (String?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    // The tag, the name and whether this is the row that is currently set, worked out once
+    // rather than per frame.
+    val rows = remember(languages, selected) {
+        listOf(LanguageRow(null, "Source default", selected == null)) +
+                languages.map { code -> LanguageRow(code, languageLabel(code), code == selected) }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 12.dp)
+            ) {
+                Text(
+                    "Audio language",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    "Select soundtrack",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                )
+            }
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = false),
+                contentPadding = WindowInsets.navigationBars
+                    .asPaddingValues()
+                    .let { PaddingValues(bottom = it.calculateBottomPadding() + 24.dp) }
+            ) {
+                items(
+                    count = rows.size,
+                    key = { rows[it].code ?: "default" }
+                ) { index ->
+                    val row = rows[index]
+                    LanguageRow(row = row, onClick = { onPick(row.code) })
+                }
+            }
+        }
+    }
+}
+
+/** One line of the sheet: a code, what it is called, and whether it is the current answer. */
+private data class LanguageRow(
+    val code: String?,
+    val label: String,
+    val selected: Boolean
+)
+
+@Composable
+private fun LanguageRow(row: LanguageRow, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = if (row.selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+        else Color.Transparent
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable(onClick = onClick)
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(width = 60.dp, height = 52.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    row.code?.uppercase() ?: "AUTO",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontSize = if ((row.code?.length ?: 4) > 4) 11.sp else 15.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Text(
+                row.label,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                color = if (row.selected) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f)
+            )
+
+            if (row.selected) {
+                Icon(
+                    Icons.Filled.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -702,7 +702,7 @@ fun DownloadScreen(
                 onResetSaveDir = {
                     scope.launch { SettingsRepository.clearDownloadTree(context) }
                 },
-                onDownload = { format, title, author ->
+                onDownload = { format, audioLanguage, title, author ->
                     sheetVisible = false
                     downloadViewModel.startDownload(
                         context = context,
@@ -710,6 +710,7 @@ fun DownloadScreen(
                         options = options,
                         title = title,
                         author = author,
+                        audioLanguage = audioLanguage,
                         treeUri = treeUri
                     )
                 },

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadSheetFooter.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadSheetFooter.kt
@@ -1,0 +1,202 @@
+package com.hazel.android.ui.screens.download
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.hazel.android.R
+import com.hazel.android.data.SettingsRepository
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * The line that closes a download sheet: what is being downloaded, and whether it will be
+ * remembered.
+ *
+ * The address is worth showing because everything above it is about one link and nothing
+ * above it says which. Tapping it copies it and opens it: copied because the address is
+ * often wanted somewhere else, and opened because the other reason to look at a link is to
+ * go and see what is behind it. It opens in the app that owns the site where there is one,
+ * and in the browser otherwise.
+ *
+ * Incognito sits beside it because this is where it applies: the sheet is the last moment
+ * before a download is recorded, and a switch buried in a bar at the top of the app is not
+ * where the decision is made. It is the same setting the rest of the app reads, so turning
+ * it on here turns it on everywhere.
+ */
+@Composable
+fun DownloadSheetFooter(
+    label: String,
+    modifier: Modifier = Modifier,
+    /** Copied when the address is tapped. Blank for a sheet covering more than one link. */
+    copyText: String = label
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val incognito by SettingsRepository.getIncognito(context).collectAsState(initial = false)
+
+    // What the last tap did. It clears itself, so nothing has to be dismissed and the sheet
+    // does not keep an old answer on screen while the user reads the rest of it.
+    var feedback by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(feedback) {
+        if (feedback != null) {
+            delay(FEEDBACK_MS)
+            feedback = null
+        }
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Filled.Link,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(enabled = copyText.isNotBlank()) {
+                        copyToClipboard(context, copyText)
+                        feedback = if (openLink(context, copyText)) {
+                            "Link copied and opened"
+                        } else {
+                            "Link copied"
+                        }
+                    }
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (incognito) MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+                        else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f)
+                    )
+                    .clickable {
+                        val enabled = !incognito
+                        scope.launch { SettingsRepository.setIncognito(context, enabled) }
+                        feedback = if (enabled) "Incognito: Enabled" else "Incognito: Disabled"
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.incognito),
+                    contentDescription = if (incognito) {
+                        "Incognito on, this download is not recorded"
+                    } else {
+                        "Incognito off"
+                    },
+                    modifier = Modifier.size(22.dp),
+                    tint = if (incognito) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                )
+            }
+        }
+
+        AnimatedVisibility(
+            visible = feedback != null,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            Column {
+                Spacer(modifier = Modifier.height(10.dp))
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(28.dp),
+                    color = MaterialTheme.colorScheme.inverseSurface
+                ) {
+                    Text(
+                        feedback.orEmpty(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Long enough to read, short enough that it is gone before it is in the way. */
+private const val FEEDBACK_MS = 2_000L
+
+private fun copyToClipboard(context: Context, text: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+    clipboard?.setPrimaryClip(ClipData.newPlainText("Hazel link", text))
+}
+
+/**
+ * Opens the address where the user would expect to see it.
+ *
+ * The site's own app first, since a link to a video is a video someone wants to watch and
+ * the app is where the account, the history and the controls are. The browser is the answer
+ * when that app is not installed, and a device with neither is left alone: the address is
+ * already on the clipboard by the time this is called.
+ */
+private fun openLink(context: Context, url: String): Boolean {
+    val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return false
+    val host = uri.host.orEmpty().removePrefix("www.").lowercase()
+
+    if (host.endsWith("youtube.com") || host.endsWith("youtu.be")) {
+        val inApp = Intent(Intent.ACTION_VIEW, uri)
+            .setPackage(YOUTUBE_PACKAGE)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (runCatching { context.startActivity(inApp) }.isSuccess) return true
+    }
+
+    val anywhere = Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    return runCatching { context.startActivity(anywhere) }.isSuccess
+}
+
+private const val YOUTUBE_PACKAGE = "com.google.android.youtube"

--- a/app/src/main/java/com/hazel/android/ui/screens/download/FormatSelectionSheet.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/FormatSelectionSheet.kt
@@ -2,10 +2,14 @@ package com.hazel.android.ui.screens.download
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,7 +18,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -26,13 +31,14 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,11 +46,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.hazel.android.download.MediaFormat
 import com.hazel.android.download.MediaInfo
+import com.hazel.android.ui.components.FormatListShimmer
+import com.hazel.android.ui.theme.SizeBadgeContainer
+import com.hazel.android.ui.theme.SizeBadgeContent
 
 /** How the format list is ordered. The default is what the probe already sorted for. */
 enum class FormatSort(val label: String) {
@@ -56,16 +68,18 @@ enum class FormatSort(val label: String) {
 /**
  * The full format list, opened from the quality row in the download sheet.
  *
- * This is a sheet of its own rather than an expanding section inside the download sheet, so
- * the list gets the whole height it needs: it starts part-way up the screen, can be dragged
- * to full height, and scrolls independently. Video and audio are listed under their own
- * headers, and picking an audio entry from a video download is allowed; the caller decides
- * what that means for the rest of the sheet.
+ * It opens half way up the screen and can be dragged to full height. Half is where it is
+ * useful: the rows are large enough to read at a glance, and the media behind the sheet
+ * stays visible while a few of them are already in reach.
+ *
+ * [audioFirst] carries which tab the download sheet is on. The list holds both kinds
+ * either way, since picking an audio stream for a video download is allowed, but the one
+ * being chosen leads and the sheet opens scrolled to the current choice.
  *
  * [isLoadingFormats] covers the case where the sheet is opened on a link that came from a
- * listing and has not been read yet. Only the generic entries are there to show at that
- * point, so the sheet says the rest is still coming rather than letting a one row list look
- * like the whole answer.
+ * listing and has not been read yet. Only the generic entry is there to show at that point,
+ * so the sheet says the rest is still coming rather than letting one row look like the
+ * whole answer.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,17 +88,31 @@ fun FormatSelectionSheet(
     selected: MediaFormat?,
     onConfirm: (MediaFormat) -> Unit,
     onDismiss: () -> Unit,
+    audioFirst: Boolean = false,
     isLoadingFormats: Boolean = false
 ) {
-    // Full height on open, to match the sheet it is opened from.
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    // Half height on open. The sheet is a list, and a list is readable from the top down,
+    // so the whole screen is offered rather than demanded.
+    val sheetState = rememberModalBottomSheetState()
 
     var sort by remember { mutableStateOf(FormatSort.QUALITY) }
     var sortMenuOpen by remember { mutableStateOf(false) }
     var draft by remember { mutableStateOf(selected) }
 
-    val video = remember(info, sort) { info.videoFormats.sortedBy(sort) }
-    val audio = remember(info, sort) { info.audioFormats.sortedBy(sort) }
+    // The rows are laid out once per ordering rather than per frame. Each carries the text
+    // it draws, so scrolling does no formatting work and a fast fling has nothing to do
+    // but draw.
+    val rows = remember(info, sort, audioFirst) { buildRows(info, sort, audioFirst) }
+
+    val listState = rememberLazyListState()
+
+    // Opens on what is currently chosen. A list of forty entries that opens at the top of
+    // the wrong section hides the one row the user came to confirm. The row above it comes
+    // along, so the header saying which kind of stream this is stays in view.
+    LaunchedEffect(rows) {
+        val index = rows.indexOfFirst { it is FormatListRow.Entry && it.format == draft }
+        if (index > 0) listState.scrollToItem((index - 1).coerceAtLeast(0))
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -174,12 +202,6 @@ fun FormatSelectionSheet(
             }
 
             if (isLoadingFormats) {
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     "Reading the rest of the formats",
                     style = MaterialTheme.typography.bodySmall,
@@ -190,35 +212,85 @@ fun FormatSelectionSheet(
             }
 
             LazyColumn(
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                    start = 20.dp, end = 20.dp, bottom = 32.dp
-                ),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                state = listState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = false),
+                // Clears the system's own bar, so the last row can be read and tapped
+                // rather than sitting under it.
+                contentPadding = WindowInsets.navigationBars
+                    .asPaddingValues()
+                    .let { PaddingValues(bottom = it.calculateBottomPadding() + 24.dp) }
             ) {
-                if (video.isNotEmpty()) {
-                    item(key = "header_video") { SectionHeader("Video") }
-                    items(video, key = { "v_${it.formatId}" }) { format ->
-                        FormatRow(
-                            format = format,
-                            selected = format == draft,
-                            onClick = { draft = format }
+                items(
+                    count = rows.size,
+                    key = { rows[it].key },
+                    contentType = { if (rows[it] is FormatListRow.Header) 0 else 1 }
+                ) { index ->
+                    when (val row = rows[index]) {
+                        is FormatListRow.Header -> SectionHeader(row.title)
+                        is FormatListRow.Entry -> FormatRow(
+                            format = row.format,
+                            selected = row.format == draft,
+                            onClick = { draft = row.format }
                         )
                     }
                 }
-                if (audio.isNotEmpty()) {
-                    item(key = "header_audio") { SectionHeader("Audio") }
-                    items(audio, key = { "a_${it.formatId}" }) { format ->
-                        FormatRow(
-                            format = format,
-                            selected = format == draft,
-                            onClick = { draft = format }
+
+                // Skeletons stand where the rows still being read will land, so a list
+                // holding only the generic entry reads as one that is still filling in
+                // rather than as the whole answer.
+                if (isLoadingFormats) {
+                    item(key = "loading", contentType = 2) {
+                        FormatListShimmer(
+                            rows = 4,
+                            modifier = Modifier.padding(horizontal = 14.dp)
                         )
                     }
                 }
             }
         }
     }
+}
+
+/** A header bar or one format, in the order the list draws them. */
+@Immutable
+private sealed interface FormatListRow {
+    val key: String
+
+    data class Header(val title: String) : FormatListRow {
+        override val key get() = "header_$title"
+    }
+
+    data class Entry(val format: MediaFormat, val section: String) : FormatListRow {
+        override val key get() = "${section}_${format.formatId}"
+    }
+}
+
+/**
+ * Flattens the two tabs into the single list the sheet scrolls.
+ *
+ * The kind being chosen leads, and a section with nothing in it is left out rather than
+ * shown as a header with no rows under it.
+ */
+private fun buildRows(
+    info: MediaInfo,
+    sort: FormatSort,
+    audioFirst: Boolean
+): List<FormatListRow> {
+    val video = info.videoFormats.sortedBy(sort)
+    val audio = info.audioFormats.sortedBy(sort)
+
+    fun section(title: String, formats: List<MediaFormat>): List<FormatListRow> =
+        if (formats.isEmpty()) emptyList()
+        else buildList {
+            add(FormatListRow.Header(title))
+            formats.forEach { add(FormatListRow.Entry(it, title)) }
+        }
+
+    val videoRows = section("Video", video)
+    val audioRows = section("Audio", audio)
+    return if (audioFirst) audioRows + videoRows else videoRows + audioRows
 }
 
 /**
@@ -238,25 +310,30 @@ private fun List<MediaFormat>.sortedBy(sort: FormatSort): List<MediaFormat> {
     return generic + ordered
 }
 
+/** Full width bar naming the kind of stream the rows under it hold. */
 @Composable
 private fun SectionHeader(text: String) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-        shape = RoundedCornerShape(8.dp)
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
     ) {
         Text(
             text,
-            style = MaterialTheme.typography.titleSmall,
+            style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)
         )
     }
 }
 
 /**
  * One format, with the badges the source actually reported.
+ *
+ * The container leads as a block the eye can pick out of a long list, the quality is the
+ * headline, and everything measured sits under it as pills that scroll sideways rather
+ * than wrapping the row into different heights. A list whose rows are all the same height
+ * is what keeps a fast fling smooth.
  *
  * Shared with the download sheet, which shows a single instance of this row for whatever is
  * currently selected. [showChevron] marks that instance as the thing you tap to open the
@@ -272,81 +349,74 @@ fun FormatRow(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
-        color = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-        else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+        shape = RoundedCornerShape(14.dp),
+        color = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+        else Color.Transparent
     ) {
         Row(
             modifier = Modifier
                 .clickable(onClick = onClick)
-                .padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.Top
+                .padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            if (format.ext.isNotBlank()) {
-                Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.9f))
-                        .padding(horizontal = 8.dp, vertical = 6.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        format.ext.uppercase(),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
-                }
-                Spacer(modifier = Modifier.width(12.dp))
-            }
+            ContainerBadge(text = format.ext.ifBlank { "DEFAULT" })
+
+            Spacer(modifier = Modifier.width(12.dp))
 
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    format.label,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = if (selected) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.onSurface
-                )
+                Row(verticalAlignment = Alignment.Top) {
+                    val headline = format.label.uppercase()
+                    Text(
+                        headline,
+                        style = MaterialTheme.typography.titleLarge,
+                        // A resolution is short and reads well large. The notes a source
+                        // puts on an audio stream are a sentence, and at the same size they
+                        // take two lines and shout over the rest of the row.
+                        fontSize = if (headline.length > LONG_HEADLINE) 16.sp else 20.sp,
+                        fontWeight = FontWeight.Normal,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        color = if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        "id: ${format.formatId}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+                        maxLines = 1
+                    )
+                }
 
                 // Badges are omitted entirely when the extractor did not report them,
-                // which is common outside YouTube.
-                val badges = listOfNotNull(
-                    format.codecLabel.takeIf { it.isNotBlank() },
-                    format.sizeLabel.takeIf { it.isNotBlank() },
-                    format.bitrateLabel.takeIf { it.isNotBlank() }
-                )
-                if (badges.isNotEmpty() || mergeAudioId != null) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    // Badges wrap onto another line rather than running past the row's
-                    // edge. A plain Row cannot wrap, so a long set of badges would
-                    // overflow the column and stretch the whole row out of shape.
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                // which is common outside the largest sites.
+                val codec = format.codecLabel
+                val size = format.sizeLabel
+                // The bitrate says something the resolution does not only for audio; on a
+                // video row it repeats what the size already showed.
+                val bitrate = format.bitrateLabel.takeIf { !format.hasVideo }.orEmpty()
+
+                if (mergeAudioId != null || codec.isNotBlank() ||
+                    size.isNotBlank() || bitrate.isNotBlank()
+                ) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Row(
+                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
                         if (mergeAudioId != null) {
                             MetaBadge(
                                 text = "id: $mergeAudioId",
                                 icon = Icons.Filled.MusicNote,
-                                emphasised = true
+                                tone = BadgeTone.SOLID
                             )
                         }
-                        badges.forEach { MetaBadge(it) }
+                        if (codec.isNotBlank()) MetaBadge(codec)
+                        if (size.isNotBlank()) MetaBadge(size, tone = BadgeTone.SIZE)
+                        if (bitrate.isNotBlank()) MetaBadge(bitrate, tone = BadgeTone.ACCENT)
                     }
                 }
-            }
-
-            if (!format.isGeneric) {
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    "id: ${format.formatId}",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                    maxLines = 1
-                )
             }
 
             if (showChevron) {
@@ -362,43 +432,89 @@ fun FormatRow(
     }
 }
 
-/**
- * Small pill under a format's headline. [emphasised] marks the audio track that will be
- * muxed in, which is a different kind of fact from the measured badges beside it.
- */
+/** Past this many characters a headline is a sentence rather than a label. */
+private const val LONG_HEADLINE = 22
+
+/** The container block a row leads with, sized the same whatever the word inside it is. */
+@Composable
+private fun ContainerBadge(text: String) {
+    Box(
+        modifier = Modifier
+            .size(width = 60.dp, height = 52.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.primary),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text.uppercase(),
+            style = MaterialTheme.typography.labelLarge,
+            // A container name is three or four letters; "DEFAULT" is the one that is not,
+            // and it is shrunk to fit rather than allowed to widen the block.
+            fontSize = if (text.length > 5) 11.sp else 15.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+    }
+}
+
+/** How loud a badge is, from a plain measurement to the point of the row. */
+enum class BadgeTone {
+    /** Codecs and other facts that are read only when something else has been decided. */
+    NEUTRAL,
+
+    /** The file size, which has a colour of its own because it is what lists are scanned for. */
+    SIZE,
+
+    /** The bitrate, tinted rather than filled so it sits between the two. */
+    ACCENT,
+
+    /** The audio track that will be muxed in, which is the one thing here that is a choice. */
+    SOLID
+}
+
+/** Small pill under a format's headline. */
 @Composable
 fun MetaBadge(
     text: String,
-    icon: androidx.compose.ui.graphics.vector.ImageVector? = null,
-    emphasised: Boolean = false
+    icon: ImageVector? = null,
+    tone: BadgeTone = BadgeTone.NEUTRAL
 ) {
+    val container = when (tone) {
+        BadgeTone.SOLID -> MaterialTheme.colorScheme.primary
+        BadgeTone.SIZE -> SizeBadgeContainer
+        BadgeTone.ACCENT -> MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+        BadgeTone.NEUTRAL -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.10f)
+    }
+    val content = when (tone) {
+        BadgeTone.SOLID -> MaterialTheme.colorScheme.onPrimary
+        BadgeTone.SIZE -> SizeBadgeContent
+        else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
+    }
+
     Row(
         modifier = Modifier
-            .clip(RoundedCornerShape(4.dp))
-            .background(
-                if (emphasised) MaterialTheme.colorScheme.primary.copy(alpha = 0.9f)
-                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.10f)
-            )
-            .padding(horizontal = 6.dp, vertical = 2.dp),
+            .clip(RoundedCornerShape(6.dp))
+            .background(container)
+            .padding(horizontal = 8.dp, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (icon != null) {
             Icon(
                 icon,
                 contentDescription = null,
-                modifier = Modifier.size(11.dp),
-                tint = if (emphasised) MaterialTheme.colorScheme.onPrimary
-                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f)
+                modifier = Modifier.size(12.dp),
+                tint = content
             )
             Spacer(modifier = Modifier.width(3.dp))
         }
         Text(
             text,
-            style = MaterialTheme.typography.labelSmall,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            color = if (emphasised) MaterialTheme.colorScheme.onPrimary
-            else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f)
+            color = content
         )
     }
 }

--- a/app/src/main/java/com/hazel/android/ui/screens/download/FormatSheet.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/FormatSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Paid
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -60,7 +61,7 @@ import com.hazel.android.download.DownloadOptions
 import com.hazel.android.download.MediaFormat
 import com.hazel.android.download.MediaInfo
 import com.hazel.android.download.VIDEO_CONTAINERS
-import com.hazel.android.ui.components.FormatListShimmer
+import com.hazel.android.download.languageLabel
 
 /**
  * Everything you can adjust before a download starts.
@@ -88,6 +89,8 @@ fun FormatSheet(
     isCustomSaveDir: Boolean,
     isLoadingFormats: Boolean = false,
     initialFormat: MediaFormat? = null,
+    /** The soundtrack this link is already set to, for a link being adjusted again. */
+    initialAudioLanguage: String? = null,
     confirmAsApply: Boolean = false,
     /**
      * Set when this media is already downloaded and still on the device, in which case the
@@ -97,7 +100,12 @@ fun FormatSheet(
     onOpenSaveDir: () -> Unit,
     onPickSaveDir: () -> Unit,
     onResetSaveDir: () -> Unit,
-    onDownload: (format: MediaFormat, title: String, author: String) -> Unit,
+    onDownload: (
+        format: MediaFormat,
+        audioLanguage: String?,
+        title: String,
+        author: String
+    ) -> Unit,
     onDismiss: () -> Unit
 ) {
     // Opened at full height. The sheet's own content is a full screen of format rows and
@@ -110,19 +118,28 @@ fun FormatSheet(
         mutableStateOf(initialFormat?.hasVideo ?: info.videoFormats.isNotEmpty())
     }
 
-    // The best concrete format is preselected, so the row shows what will actually be
-    // downloaded rather than a placeholder. The selection is keyed on the link rather than
-    // the tab, so a format picked from the full list survives the tab switch that picking
-    // it may have caused.
+    // What each tab is set to, held apart rather than as one selection. A single slot
+    // meant the audio tab showed whatever the video tab had chosen, so an audio download
+    // was offered at a video resolution.
     //
-    // It is keyed on whether formats have arrived as well, because a card that came from a
-    // listing opens this sheet before they have. Without that, the sheet would keep the
-    // stand-in it was opened with and never show the real one.
-    var selected by remember(info.url, info.hasResolvedFormats) {
-        mutableStateOf(
-            initialFormat
-                ?: if (info.videoFormats.isNotEmpty()) info.bestVideo else info.bestAudio
-        )
+    // Both are keyed on whether the formats have arrived, because a card that came from a
+    // listing opens this sheet before they have. Without that the sheet would keep the
+    // stand-in it was opened with and never move to the real best.
+    var pickedVideo by remember(info.url, info.hasResolvedFormats) {
+        mutableStateOf(initialFormat?.takeIf { it.hasVideo } ?: info.bestVideo)
+    }
+    var pickedAudio by remember(info.url, info.hasResolvedFormats) {
+        mutableStateOf(initialFormat?.takeIf { !it.hasVideo } ?: info.bestAudio)
+    }
+
+    // The best concrete format is preselected on each tab, so the row shows what will
+    // actually be downloaded rather than a placeholder.
+    val selected = if (videoTab) pickedVideo else pickedAudio
+
+    // Which soundtrack the download takes, for the few sources that publish several. Null
+    // means the one the source itself leads with, which is what almost every link gets.
+    var audioLanguage by remember(info.url, info.hasResolvedFormats) {
+        mutableStateOf(initialAudioLanguage)
     }
 
     // Title and author are editable: they name the saved file and, where the value is
@@ -132,6 +149,7 @@ fun FormatSheet(
 
     var openDialog by remember { mutableStateOf(SheetDialog.NONE) }
     var formatSheetVisible by remember { mutableStateOf(false) }
+    var languageSheetVisible by remember { mutableStateOf(false) }
 
     val container = if (videoTab) options.videoContainer else options.audioContainer
     val containerChoices = if (videoTab) VIDEO_CONTAINERS else AUDIO_CONTAINERS
@@ -191,7 +209,9 @@ fun FormatSheet(
 
                 Surface(
                     onClick = {
-                        selected?.let { onDownload(it, title.trim(), author.trim()) }
+                        selected?.let {
+                            onDownload(it, audioLanguage, title.trim(), author.trim())
+                        }
                     },
                     enabled = selected != null,
                     shape = RoundedCornerShape(20.dp),
@@ -231,19 +251,13 @@ fun FormatSheet(
             ) {
                 Tab(
                     selected = !videoTab,
-                    onClick = {
-                        videoTab = false
-                        selected = info.bestAudio
-                    },
+                    onClick = { videoTab = false },
                     enabled = info.audioFormats.isNotEmpty(),
                     text = { Text("Audio", fontWeight = FontWeight.SemiBold) }
                 )
                 Tab(
                     selected = videoTab,
-                    onClick = {
-                        videoTab = true
-                        selected = info.bestVideo
-                    },
+                    onClick = { videoTab = true },
                     enabled = info.videoFormats.isNotEmpty(),
                     text = { Text("Video", fontWeight = FontWeight.SemiBold) }
                 )
@@ -290,11 +304,10 @@ fun FormatSheet(
 
             val current = selected
             when {
-                // The sheet can open before the source has reported its formats, on the
-                // path that goes ahead without metadata. A skeleton stands in until the
-                // real row is known.
-                isLoadingFormats -> FormatRowShimmerCard()
-
+                // A sheet opened before the source has reported its formats shows the
+                // generic best row, which is what the download would use if it started
+                // now. It is replaced by the real best the moment the formats land, so
+                // the row always names something that can be downloaded.
                 current == null -> Text(
                     "This source has no separate ${if (videoTab) "video" else "audio"} stream.",
                     style = MaterialTheme.typography.bodySmall,
@@ -310,11 +323,21 @@ fun FormatSheet(
                         showChevron = true,
                         // A video-only stream is muxed with an audio track, so the track
                         // that will be used is named alongside it.
-                        mergeAudioId = info.mergeAudio
+                        mergeAudioId = info.mergeAudioFor(audioLanguage)
                             ?.formatId
                             ?.takeIf { videoTab && current.hasVideo && !current.hasAudio }
                     )
                 }
+            }
+
+            // Only where there is a choice. A source with one soundtrack has nothing to
+            // ask about, which is nearly all of them.
+            if (info.audioLanguages.size > 1) {
+                Spacer(modifier = Modifier.height(10.dp))
+                LanguageField(
+                    value = audioLanguage?.let(::languageLabel) ?: "Source default",
+                    onClick = { languageSheetVisible = true }
+                )
             }
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -376,6 +399,10 @@ fun FormatSheet(
                 }
             }
 
+            Spacer(modifier = Modifier.height(20.dp))
+
+            DownloadSheetFooter(label = info.url)
+
             Spacer(modifier = Modifier.height(28.dp))
         }
     }
@@ -384,14 +411,31 @@ fun FormatSheet(
         FormatSelectionSheet(
             info = info,
             selected = selected,
+            audioFirst = !videoTab,
+            isLoadingFormats = isLoadingFormats,
             onConfirm = { format ->
-                selected = format
+                if (format.hasVideo) pickedVideo = format else pickedAudio = format
                 // Picking an audio stream from the video tab, or the other way round,
                 // moves the sheet to the tab that entry belongs to.
                 videoTab = format.hasVideo
                 formatSheetVisible = false
             },
             onDismiss = { formatSheetVisible = false }
+        )
+    }
+
+    if (languageSheetVisible) {
+        AudioLanguageSheet(
+            languages = info.audioLanguages,
+            selected = audioLanguage,
+            onPick = { code ->
+                audioLanguage = code
+                // The tab's audio moves to the new soundtrack, since the row above is
+                // what the download will use and it would otherwise still name the old one.
+                pickedAudio = info.bestAudioFor(code)
+                languageSheetVisible = false
+            },
+            onDismiss = { languageSheetVisible = false }
         )
     }
 
@@ -543,6 +587,40 @@ private fun DropdownField(
     }
 }
 
+/** The soundtrack row, shown only for a source that published more than one. */
+@Composable
+private fun LanguageField(value: String, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f)
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable(onClick = onClick)
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "Audio language",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(value, style = MaterialTheme.typography.bodyMedium, maxLines = 1)
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Icon(
+                Icons.Filled.Translate,
+                contentDescription = "Change audio language",
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+
 /** The destination row. Tapping it leads to opening or changing the folder. */
 @Composable
 private fun SaveDirField(label: String, onClick: () -> Unit) {
@@ -647,17 +725,5 @@ private fun OptionChip(
         BadgedBox(badge = { Badge { Text("$badge") } }) { chip() }
     } else {
         chip()
-    }
-}
-
-/** Skeleton shown in place of the quality row while the format list is still resolving. */
-@Composable
-private fun FormatRowShimmerCard() {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
-    ) {
-        FormatListShimmer(rows = 1, modifier = Modifier.padding(horizontal = 12.dp))
     }
 }

--- a/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchActionBar.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchActionBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.HighQuality
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Paid
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -75,7 +76,11 @@ fun BatchActionBar(
     onChapters: () -> Unit,
     onSubtitles: () -> Unit,
     onSponsorBlock: () -> Unit,
-    onFilename: () -> Unit
+    onFilename: () -> Unit,
+    /** Only the sets holding a source with several soundtracks have this to offer. */
+    showAudioLanguage: Boolean = false,
+    audioLanguageLabel: String = "",
+    onAudioLanguage: () -> Unit = {}
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -114,6 +119,13 @@ fun BatchActionBar(
                         icon = Icons.Filled.ClosedCaption,
                         badge = options.subtitleBadge,
                         onClick = onSubtitles
+                    )
+                }
+                if (showAudioLanguage) {
+                    BarChip(
+                        label = audioLanguageLabel,
+                        icon = Icons.Filled.Translate,
+                        onClick = onAudioLanguage
                     )
                 }
                 BarChip(

--- a/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchDownloadCard.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchDownloadCard.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.hazel.android.download.MediaInfo
 import com.hazel.android.download.formatDuration
+import com.hazel.android.ui.screens.download.BadgeTone
 import com.hazel.android.ui.screens.download.MetaBadge
 
 /**
@@ -168,9 +169,12 @@ fun BatchDownloadCard(
                         if (formatLabel.isNotBlank()) {
                             // Marked when the link carries a choice of its own, so a set
                             // where one link was changed does not look uniform.
-                            MetaBadge(formatLabel.uppercase(), emphasised = isAdjusted)
+                            MetaBadge(
+                                formatLabel.uppercase(),
+                                tone = if (isAdjusted) BadgeTone.SOLID else BadgeTone.NEUTRAL
+                            )
                         }
-                        if (sizeLabel.isNotBlank()) MetaBadge(sizeLabel)
+                        if (sizeLabel.isNotBlank()) MetaBadge(sizeLabel, tone = BadgeTone.SIZE)
                     }
                 }
 

--- a/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchDownloadSheet.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchDownloadSheet.kt
@@ -42,7 +42,10 @@ import com.hazel.android.download.DownloadOptions
 import com.hazel.android.download.DownloadPlan
 import com.hazel.android.download.MediaInfo
 import com.hazel.android.download.formatFileSize
+import com.hazel.android.download.languageLabel
+import com.hazel.android.ui.screens.download.AudioLanguageSheet
 import com.hazel.android.ui.screens.download.ChaptersDialog
+import com.hazel.android.ui.screens.download.DownloadSheetFooter
 import com.hazel.android.ui.screens.download.FilenameTemplateDialog
 import com.hazel.android.ui.screens.download.FormatSheet
 import com.hazel.android.ui.screens.download.SponsorBlockDialog
@@ -264,7 +267,7 @@ fun BatchDownloadSheet(
                     val format = state.formatOf(info)
                     BatchDownloadCard(
                         info = info,
-                        formatLabel = format?.label.orEmpty(),
+                        formatLabel = format?.shortLabel.orEmpty(),
                         sizeLabel = format?.sizeLabel.orEmpty(),
                         isVideo = state.isVideo(info),
                         isAdjusted = state.isAdjusted(info),
@@ -311,7 +314,20 @@ fun BatchDownloadSheet(
                 onChapters = { openSheet = BatchSheet.CHAPTERS },
                 onSubtitles = { openSheet = BatchSheet.SUBTITLES },
                 onSponsorBlock = { openSheet = BatchSheet.SPONSORBLOCK },
-                onFilename = { openSheet = BatchSheet.FILENAME }
+                onFilename = { openSheet = BatchSheet.FILENAME },
+                showAudioLanguage = state.audioLanguages.size > 1,
+                audioLanguageLabel = state.audioLanguage?.let(::languageLabel) ?: "Default",
+                onAudioLanguage = { openSheet = BatchSheet.AUDIO_LANGUAGE }
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // A set has no single address, so the one link it holds is named and a larger
+            // set is counted. Incognito applies to the whole run either way.
+            DownloadSheetFooter(
+                label = results.singleOrNull()?.url ?: "${results.size} links",
+                copyText = results.singleOrNull()?.url.orEmpty(),
+                modifier = Modifier.padding(horizontal = 20.dp)
             )
 
             Spacer(modifier = Modifier.navigationBarsPadding())
@@ -332,12 +348,13 @@ fun BatchDownloadSheet(
             isCustomSaveDir = isCustomSaveDir,
             isLoadingFormats = !focused.hasResolvedFormats,
             initialFormat = state.formatOf(focused),
+            initialAudioLanguage = state.languageOf(focused),
             confirmAsApply = true,
             onOpenSaveDir = onOpenSaveDir,
             onPickSaveDir = onPickSaveDir,
             onResetSaveDir = onResetSaveDir,
-            onDownload = { format, title, author ->
-                state.setChoice(focused, format, title, author)
+            onDownload = { format, audioLanguage, title, author ->
+                state.setChoice(focused, format, title, author, audioLanguage)
                 focusedUrl = null
             },
             onDismiss = { focusedUrl = null }
@@ -378,6 +395,17 @@ fun BatchDownloadSheet(
                 )
             }
         }
+
+        // Every soundtrack the set offers, applied to whatever the action bar is aimed at.
+        BatchSheet.AUDIO_LANGUAGE -> AudioLanguageSheet(
+            languages = state.audioLanguages,
+            selected = state.audioLanguage,
+            onPick = {
+                state.applyAudioLanguage(it)
+                openSheet = BatchSheet.NONE
+            },
+            onDismiss = { openSheet = BatchSheet.NONE }
+        )
 
         BatchSheet.QUALITY -> BatchQualitySheet(
             maxHeight = state.maxHeight,
@@ -451,7 +479,7 @@ fun BatchDownloadSheet(
 
 /** Which sheet the action bar or a row's type button has opened, if any. */
 private enum class BatchSheet {
-    NONE, TYPE, ITEM_TYPE, QUALITY, CONTAINER, SAVE_DIR,
+    NONE, TYPE, ITEM_TYPE, QUALITY, CONTAINER, SAVE_DIR, AUDIO_LANGUAGE,
     CHAPTERS, SUBTITLES, SPONSORBLOCK, FILENAME
 }
 

--- a/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchDownloadState.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/batch/BatchDownloadState.kt
@@ -52,6 +52,9 @@ class BatchDownloadState {
             if (authorFor.keys.any { it !in urls }) {
                 authorFor = authorFor.filterKeys { it in urls }
             }
+            if (languageFor.keys.any { it !in urls }) {
+                languageFor = languageFor.filterKeys { it in urls }
+            }
             if (selected.any { it !in urls }) {
                 selected = selected.filterTo(mutableSetOf()) { it in urls }
             }
@@ -67,6 +70,18 @@ class BatchDownloadState {
 
     /** Links the user has adjusted on their own, keyed by url. */
     var formatFor by mutableStateOf(emptyMap<String, MediaFormat>())
+        private set
+
+    /**
+     * The soundtrack a link takes, keyed by url, for the sources that publish several.
+     * A link with no entry follows [audioLanguage], and null there means the one the
+     * source itself leads with.
+     */
+    var languageFor by mutableStateOf(emptyMap<String, String?>())
+        private set
+
+    /** The batch default soundtrack. Null is whatever each source leads with. */
+    var audioLanguage by mutableStateOf<String?>(null)
         private set
 
     /** Titles and authors edited on one link, which name the file it is saved as. */
@@ -94,7 +109,15 @@ class BatchDownloadState {
 
     /** The format a link will actually download with. */
     fun formatOf(info: MediaInfo): MediaFormat? =
-        formatFor[info.url] ?: info.autoPick(videoTab, maxHeight)
+        formatFor[info.url] ?: info.autoPick(videoTab, maxHeight, languageOf(info))
+
+    /** The soundtrack a link will actually download with. */
+    fun languageOf(info: MediaInfo): String? =
+        if (info.url in languageFor) languageFor[info.url] else audioLanguage
+
+    /** Every soundtrack any link in the set offers, which is what there is to choose from. */
+    val audioLanguages: List<String>
+        get() = results.flatMap { it.audioLanguages }.distinct()
 
     /** What the file will be called, which the link's own sheet can change. */
     fun titleOf(info: MediaInfo): String = titleFor[info.url] ?: info.title
@@ -116,7 +139,9 @@ class BatchDownloadState {
      */
     private val plansState = derivedStateOf {
         results.mapNotNull { info ->
-            formatOf(info)?.let { DownloadPlan(info, it, titleOf(info), authorOf(info)) }
+            formatOf(info)?.let {
+                DownloadPlan(info, it, titleOf(info), authorOf(info), languageOf(info))
+            }
         }
     }
 
@@ -139,6 +164,25 @@ class BatchDownloadState {
     fun setDownloadType(isVideo: Boolean) {
         videoTab = isVideo
         applyToTargets { it.autoPick(isVideo, maxHeight) }
+    }
+
+    /**
+     * Applies one soundtrack to every target.
+     *
+     * An audio download follows it straight away, since the format itself is the
+     * soundtrack; a video download carries it as the track that will be muxed in.
+     */
+    fun applyAudioLanguage(language: String?) {
+        val scope = targets
+        if (scope.size == results.size) {
+            // The whole set follows the new answer, so the per-link entries that were
+            // overriding it have nothing left to override.
+            audioLanguage = language
+            languageFor = emptyMap()
+        } else {
+            languageFor = languageFor + scope.associate { it.url to language }
+        }
+        applyToTargets { it.autoPick(videoTab, maxHeight, language) }
     }
 
     fun setQualityCeiling(height: Int) {
@@ -173,10 +217,17 @@ class BatchDownloadState {
     }
 
     /** Everything one link's own sheet decided, applied together when it is confirmed. */
-    fun setChoice(info: MediaInfo, format: MediaFormat, title: String, author: String) {
+    fun setChoice(
+        info: MediaInfo,
+        format: MediaFormat,
+        title: String,
+        author: String,
+        audioLanguage: String?
+    ) {
         formatFor = formatFor + (info.url to format)
         titleFor = titleFor + (info.url to title.ifBlank { info.title })
         authorFor = authorFor + (info.url to author)
+        languageFor = languageFor + (info.url to audioLanguage)
     }
 
     // ── Selection ──

--- a/app/src/main/java/com/hazel/android/ui/screens/more/DirectShareScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/DirectShareScreen.kt
@@ -1,6 +1,8 @@
 package com.hazel.android.ui.screens.more
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,46 +10,92 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ClosedCaption
+import androidx.compose.material.icons.filled.Cookie
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Paid
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.hazel.android.data.CookieRepository
 import com.hazel.android.data.SettingsRepository
+import com.hazel.android.download.AUDIO_CONTAINERS
+import com.hazel.android.download.DownloadOptions
+import com.hazel.android.download.VIDEO_CONTAINERS
+import com.hazel.android.download.languageLabel
+import com.hazel.android.ui.screens.download.AudioLanguageSheet
+import com.hazel.android.ui.screens.download.ChaptersDialog
+import com.hazel.android.ui.screens.download.FilenameTemplateDialog
+import com.hazel.android.ui.screens.download.SponsorBlockDialog
+import com.hazel.android.ui.screens.download.SubtitlesDialog
 import kotlinx.coroutines.launch
 
 /**
  * What the direct share target does, since it does it without asking.
  *
  * The ordinary share target opens the sheet and every choice is made there. The direct one
- * makes none, so the choices have to exist somewhere, and this is that somewhere. Only the
- * two that change what file lands on the device are here; container, naming and destination
- * are already settings of their own and are shared with every other download.
+ * makes none, so the choices have to exist somewhere, and this is that somewhere. Every
+ * answer on this screen belongs to this target alone: the sheet keeps its own, so turning
+ * off cover art for one download being watched cannot quietly change what the next
+ * unattended share writes.
+ *
+ * Nothing here is a demand on the source. A ceiling no format clears, subtitles a video
+ * does not have, chapters nobody wrote: each is dropped for that download and the rest goes
+ * ahead, because a share that asks no questions cannot come back with one.
  */
 @Composable
-fun DirectShareScreen(onBack: () -> Unit) {
+fun DirectShareScreen(onBack: () -> Unit, onOpenCookies: () -> Unit = {}) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     val isVideo by SettingsRepository.getQuickIsVideo(context).collectAsState(initial = true)
     val maxHeight by SettingsRepository.getQuickMaxHeight(context).collectAsState(initial = 0)
+
+    val options by SettingsRepository.getInstantOptions(context)
+        .collectAsState(initial = DownloadOptions())
+    val useCookies by CookieRepository.getUseCookies(context).collectAsState(initial = false)
+    val audioLanguage by SettingsRepository.getInstantAudioLanguage(context)
+        .collectAsState(initial = "")
+
+    var languageSheetVisible by remember { mutableStateOf(false) }
+
+    fun update(changed: DownloadOptions) {
+        scope.launch { SettingsRepository.setInstantOptions(context, changed) }
+    }
+
+    var openDialog by remember { mutableStateOf(InstantDialog.NONE) }
 
     Column(
         modifier = Modifier
@@ -99,17 +147,11 @@ fun DirectShareScreen(onBack: () -> Unit) {
         if (isVideo) {
             Spacer(modifier = Modifier.height(24.dp))
 
-            Text(
-                "Quality limit",
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold
-            )
-            Text(
-                "A ceiling, not an exact size. Sources do not all offer the same heights, " +
-                        "so the tallest that fits under this is taken.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
-                modifier = Modifier.padding(bottom = 16.dp)
+            SectionTitle(
+                title = "Quality limit",
+                description = "A ceiling, not an exact size. Sources do not all offer the " +
+                        "same heights, so the tallest that fits under this is taken, and " +
+                        "the smallest available when nothing does."
             )
 
             Card(
@@ -132,8 +174,209 @@ fun DirectShareScreen(onBack: () -> Unit) {
             }
         }
 
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // ── Output ──
+
+        SectionTitle(
+            title = "Output",
+            description = "The file that lands on the device. Default keeps whatever the " +
+                    "source already provides, which is the fastest of the options because " +
+                    "nothing is re-encoded."
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                ContainerRow(
+                    label = if (isVideo) "Video container" else "Audio container",
+                    value = (if (isVideo) options.videoContainer else options.audioContainer)
+                        .ifBlank { "Default" },
+                    choices = if (isVideo) VIDEO_CONTAINERS else AUDIO_CONTAINERS,
+                    onSelect = { choice ->
+                        val stored = if (choice == "Default") "" else choice
+                        update(
+                            if (isVideo) options.copy(videoContainer = stored)
+                            else options.copy(audioContainer = stored)
+                        )
+                    }
+                )
+                ActionRow(
+                    icon = Icons.Filled.Edit,
+                    label = "Filename template",
+                    value = options.filenameTemplate,
+                    onClick = { openDialog = InstantDialog.FILENAME }
+                )
+                ActionRow(
+                    icon = Icons.Filled.Translate,
+                    label = "Audio language",
+                    value = audioLanguage.takeIf { it.isNotBlank() }?.let(::languageLabel)
+                        ?: "Source default",
+                    onClick = { languageSheetVisible = true }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // ── Extras ──
+
+        SectionTitle(
+            title = "Extras",
+            description = "Applied when the source has them. Anything it does not have is " +
+                    "skipped for that download rather than failing it."
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                SwitchRow(
+                    icon = Icons.Filled.Image,
+                    label = "Cover art",
+                    description = "Writes the thumbnail into the file, where the container " +
+                            "can carry one.",
+                    checked = options.embedThumbnail,
+                    onCheckedChange = { update(options.copy(embedThumbnail = it)) }
+                )
+                ActionRow(
+                    icon = Icons.Filled.Book,
+                    label = "Chapters",
+                    value = chapterSummary(options, isVideo),
+                    onClick = { openDialog = InstantDialog.CHAPTERS }
+                )
+                if (isVideo) {
+                    ActionRow(
+                        icon = Icons.Filled.ClosedCaption,
+                        label = "Subtitles",
+                        value = subtitleSummary(options),
+                        onClick = { openDialog = InstantDialog.SUBTITLES }
+                    )
+                }
+                ActionRow(
+                    icon = Icons.Filled.Paid,
+                    label = "SponsorBlock",
+                    value = if (options.sponsorBlockFilters.isEmpty()) "Off"
+                    else "${options.sponsorBlockFilters.size} categories cut",
+                    onClick = { openDialog = InstantDialog.SPONSORBLOCK }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // ── Sign-ins ──
+
+        SectionTitle(
+            title = "Sign-ins",
+            description = "An instant share uses the saved cookies for whatever site the " +
+                    "link belongs to, the same as a download started from the sheet. " +
+                    "Nothing is asked at share time, so a link behind a login only works " +
+                    "if the sign-in is already saved and switched on."
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            ActionRow(
+                icon = Icons.Filled.Cookie,
+                label = "Cookies",
+                value = if (useCookies) "On, used for every instant share" else "Off",
+                onClick = onOpenCookies
+            )
+        }
+
         Spacer(modifier = Modifier.height(32.dp))
     }
+
+    if (languageSheetVisible) {
+        AudioLanguageSheet(
+            // Nothing is known about the link until it is shared, so the list is the
+            // languages media commonly carries rather than one source's own.
+            languages = COMMON_AUDIO_LANGUAGES,
+            selected = audioLanguage.takeIf { it.isNotBlank() },
+            onPick = { code ->
+                scope.launch {
+                    SettingsRepository.setInstantAudioLanguage(context, code.orEmpty())
+                }
+                languageSheetVisible = false
+            },
+            onDismiss = { languageSheetVisible = false }
+        )
+    }
+
+    when (openDialog) {
+        InstantDialog.NONE -> Unit
+
+        InstantDialog.CHAPTERS -> ChaptersDialog(
+            options = options,
+            isVideo = isVideo,
+            onChange = ::update,
+            onDismiss = { openDialog = InstantDialog.NONE }
+        )
+
+        InstantDialog.SUBTITLES -> SubtitlesDialog(
+            options = options,
+            onChange = ::update,
+            onDismiss = { openDialog = InstantDialog.NONE }
+        )
+
+        InstantDialog.SPONSORBLOCK -> SponsorBlockDialog(
+            options = options,
+            onConfirm = {
+                update(it)
+                openDialog = InstantDialog.NONE
+            },
+            onDismiss = { openDialog = InstantDialog.NONE }
+        )
+
+        InstantDialog.FILENAME -> FilenameTemplateDialog(
+            template = options.filenameTemplate,
+            onConfirm = {
+                update(options.copy(filenameTemplate = it))
+                openDialog = InstantDialog.NONE
+            },
+            onDismiss = { openDialog = InstantDialog.NONE }
+        )
+    }
+}
+
+/** Which of the screen's dialogs is open. Only one can be at a time. */
+private enum class InstantDialog { NONE, CHAPTERS, SUBTITLES, SPONSORBLOCK, FILENAME }
+
+private fun chapterSummary(options: DownloadOptions, isVideo: Boolean): String {
+    val parts = buildList {
+        if (isVideo && options.addChapters) add("Embedded")
+        if (options.splitByChapters) add("Split into files")
+    }
+    return parts.joinToString(", ").ifBlank { "Off" }
+}
+
+private fun subtitleSummary(options: DownloadOptions): String {
+    val parts = buildList {
+        if (options.embedSubs) add("Embedded")
+        if (options.writeSubs) add("Saved beside")
+        if (options.writeAutoSubs) add("Automatic")
+    }
+    return parts.joinToString(", ").ifBlank { "Off" }
+}
+
+@Composable
+private fun SectionTitle(title: String, description: String) {
+    Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+    Text(
+        description,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
+        modifier = Modifier.padding(top = 2.dp, bottom = 14.dp)
+    )
 }
 
 @Composable
@@ -177,6 +420,138 @@ private fun ChoiceRow(
         }
     }
 }
+
+/** Row that opens one of the option dialogs, showing what it is currently set to. */
+@Composable
+private fun ActionRow(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, fontWeight = FontWeight.Medium)
+            Text(
+                value,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
+                maxLines = 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun SwitchRow(
+    icon: ImageVector,
+    label: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, fontWeight = FontWeight.Medium)
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+/** Row whose value is picked from a fixed list, used for the container. */
+@Composable
+private fun ContainerRow(
+    label: String,
+    value: String,
+    choices: List<String>,
+    onSelect: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = true }
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(label, fontWeight = FontWeight.Medium)
+                Text(
+                    value,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+                )
+            }
+            Icon(
+                Icons.Filled.ArrowDropDown,
+                contentDescription = "Change $label",
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            choices.forEach { choice ->
+                DropdownMenuItem(
+                    text = { Text(choice) },
+                    onClick = {
+                        onSelect(choice)
+                        expanded = false
+                    },
+                    trailingIcon = if (choice == value) {
+                        { Icon(Icons.Filled.Check, null, Modifier.size(18.dp)) }
+                    } else null
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Soundtracks worth offering for a link nobody has read yet.
+ *
+ * A source names its own languages, and this screen never sees one, so the list is of the
+ * languages media is commonly published in. Anything picked here is a preference: a source
+ * that does not carry it is downloaded with what it does.
+ */
+private val COMMON_AUDIO_LANGUAGES = listOf(
+    "en", "hi", "es", "pt", "fr", "de", "it", "ru",
+    "ja", "ko", "zh", "ar", "id", "tr", "bn", "ta", "te", "vi", "th", "pl", "nl", "uk"
+)
 
 /** Height ceilings offered, coarsest first. 0 means whatever the source calls best. */
 private val HEIGHT_CHOICES = listOf(

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -3,6 +3,7 @@ package com.hazel.android.ui.screens.more
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -69,7 +70,8 @@ fun MoreScreen(
     onNavigateToDirectShare: () -> Unit = {},
     onOpenBatterySettings: () -> Unit = {},
     onNavigateToStorageCleanup: () -> Unit = {},
-    onNavigateToUpdate: () -> Unit = {}
+    onNavigateToUpdate: () -> Unit = {},
+    onNavigateToSponsor: () -> Unit = {}
 ) {
     val context = LocalContext.current
 
@@ -354,6 +356,29 @@ fun MoreScreen(
                 },
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                 modifier = Modifier.clickable { onNavigateToUpdate() }
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant
+            )
+
+            // Above the two lines that leave the app, since this one is a screen of its
+            // own and the ones under it are addresses.
+            ListItem(
+                headlineContent = { Text("Support Hazel") },
+                leadingContent = {
+                    Icon(Icons.Filled.Favorite, null, tint = MaterialTheme.colorScheme.primary)
+                },
+                trailingContent = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowForwardIos, null,
+                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        modifier = Modifier.size(16.dp)
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                modifier = Modifier.clickable { onNavigateToSponsor() }
             )
 
             HorizontalDivider(

--- a/app/src/main/java/com/hazel/android/ui/screens/more/SponsorScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/SponsorScreen.kt
@@ -1,0 +1,384 @@
+package com.hazel.android.ui.screens.more
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Coffee
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hazel.android.util.openInAppBrowser
+
+/**
+ * Where the app asks for support, and says what it is asking for.
+ *
+ * Hazel takes nothing from anyone: no advertisement, no measurement of what people
+ * download, and no part of it kept back for a paying tier. That is a decision rather than a
+ * stage on the way to something else, and this screen exists because a decision like that
+ * only holds if the people who value it are given a way to say so.
+ *
+ * Nothing here is a wall. Everything the app does is available to everyone whether or not
+ * anybody ever opens this screen, and the ways of helping that cost nothing sit next to the
+ * ones that cost money because they are worth as much.
+ */
+@Composable
+fun SponsorScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                "Support Hazel",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        HeroCard()
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        SectionLabel("Ways to support")
+
+        SupportCard(
+            icon = Icons.Filled.Favorite,
+            title = "GitHub Sponsors",
+            subtitle = "Monthly or one off, cancel whenever. Handled entirely by GitHub.",
+            enabled = SPONSORS_URL.isNotBlank(),
+            onClick = { openLink(context, SPONSORS_URL) }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SupportCard(
+            icon = Icons.Filled.Coffee,
+            title = "Ko-fi",
+            // The address is not published yet. The card says so rather than being hidden,
+            // since a support option that appears later looks like an afterthought and one
+            // that is coming reads as a plan.
+            subtitle = if (KOFI_URL.isBlank()) "Opening soon" else "A one off, no account needed.",
+            enabled = KOFI_URL.isNotBlank(),
+            onClick = { openLink(context, KOFI_URL) }
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        SectionLabel("Costs nothing, helps as much")
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                HelpRow(
+                    icon = Icons.Filled.Star,
+                    title = "Star the project",
+                    subtitle = "The one number people look at before trying an app.",
+                    onClick = { openLink(context, SOURCE_URL) }
+                )
+                HelpRow(
+                    icon = Icons.Filled.Share,
+                    title = "Tell someone about it",
+                    subtitle = "Word of mouth is the whole of this app's marketing.",
+                    onClick = { shareApp(context) }
+                )
+                HelpRow(
+                    icon = Icons.Filled.BugReport,
+                    title = "Report what breaks",
+                    subtitle = "A site that stopped working is a fix nobody else can write.",
+                    onClick = { openLink(context, ISSUES_URL) }
+                )
+                HelpRow(
+                    icon = Icons.Filled.Code,
+                    title = "Read the source",
+                    subtitle = "Every line of it is public, and pull requests are welcome.",
+                    onClick = { openLink(context, SOURCE_URL) }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            "No advertisements, nothing measured about what you download, and no feature " +
+                    "held back for anyone. Support changes how much time goes into Hazel, " +
+                    "not what it will do for you.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+        )
+
+        Spacer(modifier = Modifier.height(40.dp))
+    }
+}
+
+/** The block at the top, which is the part that has something to say. */
+@Composable
+private fun HeroCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Column(
+            modifier = Modifier
+                .background(
+                    // A wash rather than a fill. The accent is the only colour in the app,
+                    // and at this strength it reads as light falling on the card instead of
+                    // as a second surface competing with everything under it.
+                    Brush.linearGradient(
+                        listOf(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.18f),
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.04f)
+                        )
+                    )
+                )
+                .padding(24.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Filled.Favorite,
+                    contentDescription = null,
+                    modifier = Modifier.size(26.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            Text(
+                "Free, and staying that way",
+                style = MaterialTheme.typography.headlineSmall,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                "Hazel is built in evenings and weekends, and it is given away because a " +
+                        "downloader that charges for the download is a worse downloader. " +
+                        "Sites change constantly, and keeping up with them is the work.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                "If the app saved you an afternoon, anything below puts that time back " +
+                        "into it. If it did not, the ways that cost nothing help just as much.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 12.dp)
+    )
+}
+
+/** One place money can go, drawn large enough to be the point of the screen. */
+@Composable
+private fun SupportCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = if (enabled) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+        else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(horizontal = 18.dp, vertical = 18.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(
+                        if (enabled) MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(22.dp),
+                    tint = if (enabled) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (enabled) MaterialTheme.colorScheme.onSurface
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
+            }
+
+            if (enabled) {
+                Spacer(modifier = Modifier.width(12.dp))
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowForwardIos,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+/** One of the ways of helping that costs nothing. */
+@Composable
+private fun HelpRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, fontWeight = FontWeight.Medium)
+            Text(
+                subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+            )
+        }
+    }
+}
+
+/** Hands the app's address to whatever the user shares with. */
+private fun shareApp(context: Context) {
+    val share = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, "$SHARE_MESSAGE\n$SOURCE_URL")
+    }
+    runCatching {
+        context.startActivity(
+            Intent.createChooser(share, "Share Hazel").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+    }
+}
+
+/**
+ * Opens an address without leaving the app.
+ *
+ * A sponsor page, an issue tracker and a source listing are all things people glance at and
+ * come straight back from, and a full app switch for each of them turns a glance into a
+ * journey. The in-app browser keeps the app underneath and falls back to a real browser on
+ * a device that has no support for it.
+ */
+private fun openLink(context: Context, url: String) {
+    if (url.isBlank()) return
+    openInAppBrowser(context, url)
+}
+
+private const val SHARE_MESSAGE = "Hazel, a downloader with no ads and nothing held back:"
+
+private const val SOURCE_URL = "https://github.com/SibtainOcn/Hazel"
+private const val ISSUES_URL = "https://github.com/SibtainOcn/Hazel/issues"
+private const val SPONSORS_URL = "https://github.com/sponsors/SibtainOcn"
+
+/** Filled in when the page exists. Blank keeps the card on screen and out of reach. */
+private const val KOFI_URL = ""

--- a/app/src/main/java/com/hazel/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/hazel/android/ui/theme/Color.kt
@@ -19,6 +19,18 @@ val DarkOnSurface = Color(0xFFCCCCCC)
  */
 val DarkOnSurfaceVariant = Color(0xFFAFAFAF)
 
+// Container tones for the dark theme, lightest last. Named one by one rather than left to
+// Material, whose dark defaults derive their container tones from a violet neutral: the
+// search field took the highest of them and read as a lilac bar across the top of an
+// otherwise black screen.
+val DarkSurfaceContainerLowest = Color(0xFF070707)
+val DarkSurfaceContainerLow = Color(0xFF101010)
+val DarkSurfaceContainer = Color(0xFF151515)
+val DarkSurfaceContainerHigh = Color(0xFF1A1A1A)
+val DarkSurfaceContainerHighest = Color(0xFF1F1F1F)
+val DarkOutline = Color(0xFF3A3A3A)
+val DarkOutlineVariant = Color(0xFF242424)
+
 // Light Theme — a warm paper ground rather than a neutral white.
 //
 // A pure white background under a full-bleed thumbnail reads as glare, and Material's own
@@ -66,6 +78,15 @@ val ErrorRed = Color(0xFFCF6679)
 val ErrorRedLight = Color(0xFFB00020)
 val WarningAmber = Color(0xFFFFB74D)
 val InfoBlue = Color(0xFF64B5F6)
+
+// Format badges
+//
+// The size is the figure a format list is scanned for, so it carries a colour of its own
+// rather than another tone of the accent, which the codec and the bitrate beside it already
+// use. Fixed rather than themed on purpose: the accent is a personal choice and this is a
+// piece of information, and it should read the same whichever colour the app is set to.
+val SizeBadgeContainer = Color(0xFF4A4458)
+val SizeBadgeContent = Color(0xFFEADDFF)
 
 // Progress
 val ProgressTrackDark = Color(0xFF1A1A1A)

--- a/app/src/main/java/com/hazel/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hazel/android/ui/theme/Theme.kt
@@ -33,6 +33,13 @@ fun HazelTheme(
             onSurface = DarkOnSurface,
             surfaceVariant = DarkSurfaceVariant,
             onSurfaceVariant = DarkOnSurfaceVariant,
+            outline = DarkOutline,
+            outlineVariant = DarkOutlineVariant,
+            surfaceContainerLowest = DarkSurfaceContainerLowest,
+            surfaceContainerLow = DarkSurfaceContainerLow,
+            surfaceContainer = DarkSurfaceContainer,
+            surfaceContainerHigh = DarkSurfaceContainerHigh,
+            surfaceContainerHighest = DarkSurfaceContainerHighest,
             error = ErrorRed,
             onError = DarkBackground,
         )

--- a/app/src/main/java/com/hazel/android/util/MediaStoreHelper.kt
+++ b/app/src/main/java/com/hazel/android/util/MediaStoreHelper.kt
@@ -45,18 +45,27 @@ object MediaStoreHelper {
     ): File {
         val files = tempDir.listFiles()?.filter { it.isFile } ?: return tempDir
 
+        var leftBehind = false
         for (file in files) {
-            try {
-                if (Build.VERSION.SDK_INT >= 30) {
-                    moveViaMediaStore(context, file, relativePath, isMusic)?.let(onMoved)
-                } else {
-                    moveViaDirect(context, file, relativePath).let(onMoved)
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to move ${file.name}: ${e.message}")
-                // File stays in temp dir, still accessible, just not in public storage
+            val moved = movedUri(context, file, relativePath, isMusic)
+            if (moved != null) {
+                onMoved(moved)
+                continue
             }
+
+            // The move failed, which on older versions usually means the permission that
+            // writes into the user's own folders was refused. The file is finished and
+            // readable where it is, so it is handed back from there rather than reported
+            // as a download that produced nothing.
+            leftBehind = true
+            Log.w(TAG, "Kept ${file.name} in app storage: public move failed")
+            shareableUri(context, file)?.let(onMoved)
         }
+
+        // A run that could not publish everything says where the files actually are, since
+        // the caller writes that into the history and a record pointing at a folder the
+        // file never reached is what makes a finished download look missing.
+        if (leftBehind) return tempDir
 
         // Return the final public directory
         return if (Build.VERSION.SDK_INT >= 30) {
@@ -72,6 +81,47 @@ object MediaStoreHelper {
             File(Environment.getExternalStorageDirectory(), relativePath)
         }
     }
+
+    /**
+     * Publishes one file, by whichever route the platform allows.
+     *
+     * Up to Android 10 a direct write is the quick path and the one that keeps the file
+     * where a file manager expects it. It is not guaranteed: the permission it needs can be
+     * refused, and from Android 10 it depends on legacy storage still being granted. When
+     * it does not work, MediaStore does the same job through the index instead, which needs
+     * no permission at all. Returns null when neither route worked.
+     */
+    private fun movedUri(
+        context: Context,
+        file: File,
+        relativePath: String,
+        isMusic: Boolean
+    ): Uri? {
+        if (Build.VERSION.SDK_INT < 30) {
+            runCatching { moveViaDirect(context, file, relativePath) }
+                .onFailure { Log.w(TAG, "Direct move of ${file.name} failed: ${it.message}") }
+                .getOrNull()
+                ?.let { return it }
+        }
+
+        return runCatching { moveViaMediaStore(context, file, relativePath, isMusic) }
+            .onFailure { Log.w(TAG, "MediaStore move of ${file.name} failed: ${it.message}") }
+            .getOrNull()
+    }
+
+    /**
+     * An address other apps can actually open.
+     *
+     * A `file://` address is refused by the system from Android 7 onwards the moment it
+     * leaves the app, so a download handed to a player that way fails as though the file
+     * were not there. The provider gives out a content address with read access attached,
+     * which is what makes a finished download openable from the history on every version.
+     */
+    private fun shareableUri(context: Context, file: File): Uri? = runCatching {
+        androidx.core.content.FileProvider.getUriForFile(
+            context, "${context.packageName}.fileprovider", file
+        )
+    }.getOrNull()
 
     /**
      * API 30+: Insert file via MediaStore (no MANAGE_EXTERNAL_STORAGE needed).
@@ -180,7 +230,7 @@ object MediaStoreHelper {
                 context, arrayOf(file.absolutePath), arrayOf(getMimeType(file)), null
             )
         }
-        return Uri.fromFile(file)
+        return shareableUri(context, file) ?: Uri.fromFile(file)
     }
 
     /**

--- a/app/src/main/java/com/hazel/android/util/TempStorage.kt
+++ b/app/src/main/java/com/hazel/android/util/TempStorage.kt
@@ -107,24 +107,27 @@ object TempStorage {
                 wipe(File(cache, ENGINE_DIR))
             }
             "other_cache" -> {
-                val preserved = setOf(
-                    CookieRepository.cookieFile(context).name,
-                    "yt-dlp",
-                    ENGINE_DIR
-                )
+                val preserved = setOf("yt-dlp", ENGINE_DIR)
                 cache.listFiles()?.forEach { entry ->
-                    if (entry.name !in preserved) entry.deleteRecursively()
+                    // Saved sign-ins live here too, one file per site, and clearing the
+                    // cache is not a request to sign out of everything.
+                    if (entry.name !in preserved && !entry.isCookieFile()) {
+                        entry.deleteRecursively()
+                    }
                 }
             }
         }
         Unit
     }
 
+    /** The whole cookie file and the per-site ones written beside it. */
+    private fun java.io.File.isCookieFile(): Boolean = name.startsWith("cookies")
+
     /** Everything in the cache that is not already counted under its own category. */
     private fun otherCacheSize(context: Context): Long {
-        val counted = setOf("yt-dlp", ENGINE_DIR, CookieRepository.cookieFile(context).name)
+        val counted = setOf("yt-dlp", ENGINE_DIR)
         return context.cacheDir.listFiles()
-            ?.filterNot { it.name in counted }
+            ?.filterNot { it.name in counted || it.isCookieFile() }
             ?.sumOf { sizeOf(it) }
             ?: 0L
     }

--- a/app/src/test/java/com/hazel/android/download/MediaProbeParseTest.kt
+++ b/app/src/test/java/com/hazel/android/download/MediaProbeParseTest.kt
@@ -107,15 +107,19 @@ class MediaProbeParseTest {
     }
 
     @Test
-    fun `every tab is headed by a best row whatever the source reported`() {
+    fun `a best row stands in only where the source named no formats of that kind`() {
+        // One direct stream and no format list: the video tab has a real entry, and the
+        // audio tab has nothing of its own, so the generic row is what makes an audio
+        // download of it possible at all.
         val bare = parse("""{"title": "Bare", "url": "https://cdn/clip.mp4"}""")
-        val full = parse(complete)
+        assertTrue(bare.videoFormats.none { it.isGeneric })
+        assertTrue(bare.audioFormats.single().isGeneric)
+        assertTrue(bare.audioFormats.single().selector.isNotBlank())
 
-        for (info in listOf(bare, full)) {
-            assertTrue(info.videoFormats.first().isGeneric)
-            assertTrue(info.audioFormats.first().isGeneric)
-            assertTrue(info.videoFormats.first().selector.isNotBlank())
-        }
+        // A source that reported both kinds is left as it reported them.
+        val full = parse(complete)
+        assertTrue(full.videoFormats.none { it.isGeneric })
+        assertTrue(full.audioFormats.none { it.isGeneric })
     }
 
     @Test


### PR DESCRIPTION
## Format list and download sheet
- Format list rebuilt: opens at half height, a container block per row, the quality as headline with the format id beside it, measured pills that scroll sideways, rows laid out once per ordering, list opens scrolled to the current choice, shimmer rows while formats are still arriving.
- Generic "best" rows removed from lists that already hold real formats; the generic entry now appears only where a source reported nothing of that kind. The sheet shows the best concrete format from the moment it opens, including during a fetch.
- Each tab holds its own selection, so the audio tab no longer shows a video format; opening the list from the audio tab leads with the Audio section.
- Format labels follow the source's note plus the measured resolution (`1080P60 (1920X1080)`); set cards use the short form so the size chip is not pushed off the row.
- Both sheets close with the link (tap copies and opens it, site app first, browser otherwise) and an incognito toggle with inline feedback.

## Soundtracks
- `MediaFormat.language` parsed from the payload; `MediaInfo.audioLanguages`, `bestAudioFor`, `mergeAudioFor` added.
- Audio language sheet on the single sheet, on the set sheet (whole run or per link), and as a standing preference in Hazel Instant.
- The choice reaches yt-dlp as `<video>+<track id>/<video>+ba[language^=xx]/<video>+bestaudio/<video>`, and the queue records the chosen track so a queued item no longer falls back to the source default.

## Cookies
- Scoped per site: cookies are written to a per-site file and sent only for the site they were collected on.
- Anonymous read first, sign-in used only when the media will not open without it, which restores the full format ladder on the site that answers a signed-in request with a single 360p stream. The download asks the way the read did.
- The browser identity used at capture is sent with them, and a signed-in YouTube read names the player clients that serve a full list.

## Hazel Instant
- Settings screen rebuilt: save as, quality ceiling, container, filename template, cover art, chapters, subtitles, SponsorBlock, audio language, cookie state.
- Instant keeps its own option set, stored separately from the sheet's.

## Caching
- Last 10 links kept and rebuilt from the payload on disk, so a repeat opens instantly after a restart; collections are cached too.

## Storage and compatibility
- Saved files handed over as content URIs. A `file://` address is refused from Android 7 onwards, which is why a finished download read as missing on Android 10.
- A refused direct write falls back to MediaStore; files that cannot be published are kept and offered from app storage rather than recorded as saved somewhere they never reached.
- Queue records `requiresSignIn` and the audio language.

## Other
- Support screen reached from More, with GitHub Sponsors and a Ko-fi card held disabled until the address is filled in, plus the no-cost ways to help. Links open in the in-app browser.
- Dark theme gets its own container tones, which fixes the lilac search field.
- Changelog also carries the startup work merged earlier.

Tested on device: single link, set of links, playlist, cookies on and off, soundtrack selection verified through the logged format expression, and the metadata cache across a restart.
