### PR TITLE
Judge a download by the file, not by the record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subtitles and SponsorBlock are set for the share target itself and kept apart from the
   sheet's, so a choice made for a download being watched cannot change what an unattended
   share does with the next link. The screen also says whether saved sign-ins are in use.
+- **Properties, for a finished download.** Held down on a row, or picked from its menu, it
+  says everything the app knows: whether the file is still there, what quality was asked
+  for, how long it runs, its bitrate, resolution, size, container, type, what was written
+  into it besides the media, the name it was saved under, where it landed and when. Two
+  sources feed it and neither is expensive: what was asked for comes from the record, and
+  what arrived is read once from the file's own header, on a background thread, only for a
+  file that is still there. A fact neither source has is left out rather than shown as
+  blank, so an entry made before any of this was recorded is short rather than empty. The
+  sheet closes with the address, which copies and opens the same way the download sheet's
+  does, and for a download whose file has gone that is the way back to the thing itself.
 
 ### Changed
 - **The format list was rebuilt.** It opens half way up the screen, each row leads with its
@@ -58,6 +68,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   app was still drawing its first screen and took CPU and disk from it. It now starts once
   that screen is up, and still starts on its own for a launch with no UI, such as a
   notification action resuming a download after the process was killed.
+- **The link entry screen has a paste control.** A link is nearly always copied somewhere
+  else first, so the opening move on that screen was a paste and then a confirm. The control
+  in the corner is the two of them at once, and it rides above the keyboard rather than
+  under it. It goes through the same submit the field does, so a paste holding several links
+  is split the way a typed one is.
+- **The source is offered in one place.** It was on the More list and on the Support screen,
+  the same address by two routes, and the one that stayed is the one that says why anyone
+  would follow it.
+- **The results layout switch is offered from the first link.** It was held back until there
+  were two, so it was a control that came and went and nobody learned it was there. The
+  count beside it says "1 link" rather than "1 links".
+- **The downloads list dropped a glyph from its rows.** A play or note mark sat in front of
+  the size and the date, saying what the artwork beside it already said and spending the
+  width the date needed to finish.
 
 ### Fixed
 - **Signing in cut the format list down to 360p.** The largest site now answers a signed-in
@@ -80,6 +104,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default, so the file arrived in the original language whatever the sheet had said.
 - **The set card showed a resolution twice.** The measured size was pushed off the end of
   the row by a headline that repeated what the quality already said.
+- **A download deleted from the phone still counted as downloaded.** The record of a
+  download was taken as proof the file was there, and where it was checked at all, opening
+  the address was the whole test. From Android 11 a gallery delete moves the row to the
+  system bin, which the app that owns it can still open, so a file the user had deleted read
+  as present until they emptied the bin as well. The index is now asked whether the row is
+  binned or half written before the file behind it is opened, the answer is thrown away and
+  taken again every time a screen returns to the foreground, and the downloads list asks
+  once more at the moment of the tap rather than handing a missing file to a player that
+  opens on nothing and comes straight back. A link whose file has gone is offered as
+  something to fetch again: no repeat warning, and no marker on the card.
+- **Download all appeared for a single link, and offered to fetch what was already saved.**
+  Reading a new link added it to what was already on screen, so one new video beside one
+  already downloaded read as a set of two, and the sheet behind the action held both. What
+  has finished downloading is now taken off the list when the next link is read, with a line
+  at the foot of the results saying where it went, and the action itself is offered on what
+  is actually left to fetch rather than on how long the list is. Neither is offered while a
+  run is in hand, including one sitting paused.
+- **A row in the downloads list broke apart once its file was deleted.** The size, the date
+  and the deleted marker shared a row in which neither was allowed to give way, so the text
+  took the full width and the marker beside it was measured into nothing: it collapsed to a
+  red thread down the side and its label wrapped one letter at a time, dragging the row to
+  several times its height. The line is what shortens now. The row was rebuilt around it
+  with larger artwork, room between the title, the author and what the file cost, and the
+  same word for a missing file that the card form uses.
+- **The single-line layout lost every download control.** Pause, resume and the options
+  behind them were on the card form alone, so switching layout mid-download left the row
+  with nothing but a cancel button, and a paused item showed no sign of being paused. The
+  row now carries the same menu in the same order, the artwork holds resume while it is
+  paused, and the progress line stays put with what is already down beside it.
+- **The run summary sat above the links it was about.** A line reporting how a set of
+  downloads went was the first thing on the screen, before any of the cards it counted.
 
 ## [1.0.2] - 2026-08-31
 

--- a/app/src/main/java/com/hazel/android/data/DownloadHistoryRepository.kt
+++ b/app/src/main/java/com/hazel/android/data/DownloadHistoryRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.hazel.android.util.MediaPresence
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -26,12 +27,33 @@ data class HistoryEntry(
     val savedPath: String,
     val isVideo: Boolean,
     val sizeBytes: Long,
-    val completedAt: Long
+    val completedAt: Long,
+    /**
+     * The quality that was asked for, as the sheet named it, with the stream's own codec
+     * and bitrate behind it. Read off the download rather than off the file, because a
+     * container reports what it holds and not what was chosen.
+     */
+    val formatLabel: String = "",
+    val codec: String = "",
+    val bitrateKbps: Double = 0.0,
+    /**
+     * What was written into the file besides the media: subtitles, chapters, cover art. A
+     * comma separated list, empty for a download that carried none of it.
+     *
+     * Recorded at the time, because none of it can be recovered afterwards without opening
+     * the file and reading its streams, and a record that was never written cannot be
+     * filled in later. Entries made before this existed simply have nothing to say.
+     */
+    val embedded: String = ""
 ) {
     val site: String
         get() = runCatching {
             java.net.URL(url).host.removePrefix("www.")
         }.getOrNull().orEmpty()
+
+    /** The output container, taken off the name it was saved under. */
+    val container: String
+        get() = fileName.substringAfterLast('.', "").uppercase()
 }
 
 /** How the history list is ordered. */
@@ -86,18 +108,12 @@ object DownloadHistoryRepository {
      * Whether the file behind an entry is still on the device.
      *
      * A download can be deleted from a file manager or a gallery app long after it was
-     * made, so the record on its own says nothing about what is there now. The address is
-     * opened rather than merely inspected, because a MediaStore row can outlive the file
-     * it points at.
+     * made, so the record on its own says nothing about what is there now. The reading
+     * itself lives in [MediaPresence], which is also what the screens ask, so a row on the
+     * downloads list and the marker on a link that was fetched again cannot disagree.
      */
     suspend fun fileExists(context: Context, entry: HistoryEntry): Boolean =
-        withContext(Dispatchers.IO) {
-            if (entry.fileUri.isBlank()) return@withContext false
-            runCatching {
-                context.contentResolver.openFileDescriptor(Uri.parse(entry.fileUri), "r")
-                    ?.use { true } ?: false
-            }.getOrDefault(false)
-        }
+        MediaPresence.refresh(context, entry.fileUri)
 
     /** Deletes the file an entry points at, and the entry with it. */
     suspend fun deleteFile(context: Context, entry: HistoryEntry): Boolean =
@@ -107,6 +123,8 @@ object DownloadHistoryRepository {
                         context.contentResolver.delete(Uri.parse(entry.fileUri), null, null) > 0
             }.getOrDefault(false)
             remove(context, entry.id)
+            // What was held about this address described a file that is no longer there.
+            MediaPresence.forget()
             deleted
         }
 
@@ -127,6 +145,10 @@ object DownloadHistoryRepository {
                     put("isVideo", entry.isVideo)
                     put("size", entry.sizeBytes)
                     put("completedAt", entry.completedAt)
+                    put("formatLabel", entry.formatLabel)
+                    put("codec", entry.codec)
+                    put("bitrate", entry.bitrateKbps)
+                    put("embedded", entry.embedded)
                 }
             )
         }
@@ -151,7 +173,11 @@ object DownloadHistoryRepository {
                         savedPath = json.optString("savedPath"),
                         isVideo = json.optBoolean("isVideo", true),
                         sizeBytes = json.optLong("size"),
-                        completedAt = json.optLong("completedAt")
+                        completedAt = json.optLong("completedAt"),
+                        formatLabel = json.optString("formatLabel"),
+                        codec = json.optString("codec"),
+                        bitrateKbps = json.optDouble("bitrate", 0.0),
+                        embedded = json.optString("embedded")
                     )
                 }
             }

--- a/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/hazel/android/download/DownloadViewModel.kt
@@ -112,7 +112,15 @@ data class DownloadState(
      * screen says during it, and it names the source because "reading a link" is less
      * reassuring than naming the one the user just came from.
      */
-    val instantSource: String = ""
+    val instantSource: String = "",
+    /**
+     * True once a read has taken a finished download off the list.
+     *
+     * It is not lost, and the line at the foot of the results says where it went. Kept for
+     * the rest of the session rather than only for the read that did it, since the cards
+     * stay absent for that long; clearing the results is what puts it back to false.
+     */
+    val savedAside: Boolean = false
 ) {
     /** True once more than one link resolved, which is what turns the screen into a list. */
     val isMultiple: Boolean get() = results.size > 1
@@ -499,15 +507,22 @@ class DownloadViewModel : ViewModel() {
         // A fresh read is a fresh answer, so the sheet is allowed to open on its own again.
         clearAutoOpened()
 
+        // Read before the batch is emptied below, since that is the record of what this
+        // session finished and the merge at the end of the read needs it.
+        val finished = _state.value.batch
+            .filter { it.state == BatchState.DONE }
+            .map { it.url }
+            .toSet()
+
         _state.value = _state.value.copy(
             url = valid.first(),
             isFetching = true,
             error = null,
             errorLog = null,
-            // What is already listed stays. A run's downloads, its queue and its finished
-            // items are all worth keeping in view, and a search is another thing asked for
-            // rather than a reason to forget the last one. The search screen's own clear
-            // action is what empties the list.
+            // What is already listed stays, apart from what has finished downloading:
+            // a run's queue and its failures are worth keeping in view, and a search is
+            // another thing asked for rather than a reason to forget the last one. The
+            // search screen's own clear action is what empties the list.
             info = null,
             batch = emptyList(),
             isComplete = false,
@@ -594,16 +609,29 @@ class DownloadViewModel : ViewModel() {
                     errorLog = lastFailure.ifBlank { "Could not read this link" }
                 )
             } else {
+                // A link that finished downloading is not carried into the new answer. The
+                // list is what the set action acts on, so ten links pasted beside two
+                // already saved read as twelve waiting, and Download all offered to fetch
+                // the saved two a second time. Worse, it turned a single new link into a
+                // set, because the list was two long even though only one of them was
+                // anything to download.
+                //
+                // Nothing is thrown away: they are on the downloads list, and the line at
+                // the foot of the results says so.
+                val kept = _state.value.results.filterNot { existing ->
+                    resolved.any { it.url == existing.url } || existing.url in finished
+                }
+
                 // Newest first, and a link read again keeps its new reading rather than
                 // appearing twice.
-                val merged = resolved + _state.value.results.filterNot { existing ->
-                    resolved.any { it.url == existing.url }
-                }
                 _state.value.copy(
                     isFetching = false,
                     fetchProgress = "",
-                    results = merged,
-                    info = resolved.singleOrNull()
+                    results = resolved + kept,
+                    info = resolved.singleOrNull(),
+                    savedAside = _state.value.savedAside || _state.value.results.any { existing ->
+                        existing.url in finished && resolved.none { it.url == existing.url }
+                    }
                 )
             }
         }
@@ -979,19 +1007,19 @@ class DownloadViewModel : ViewModel() {
                     }
 
                     if (isCancelled || isBatchCancelled) {
-                        finishDownload(app)
+                        finishDownload(app, plan, options)
                         markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
                         break
                     }
 
-                    finishDownload(app)
+                    finishDownload(app, plan, options)
                     markBatch(plan.info.url, BatchState.DONE)
                 } catch (_: CancellationException) {
                     if (isPaused) {
                         holdForResume(next)
                         break
                     }
-                    finishDownload(app)
+                    finishDownload(app, plan, options)
                     markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
                     break
                 } catch (e: Exception) {
@@ -1001,7 +1029,7 @@ class DownloadViewModel : ViewModel() {
                     }
 
                     if (isCancelled || isBatchCancelled) {
-                        finishDownload(app)
+                        finishDownload(app, plan, options)
                         markBatch(plan.info.url, BatchState.FAILED, "Cancelled")
                         break
                     }
@@ -1499,7 +1527,11 @@ class DownloadViewModel : ViewModel() {
      * Whether the run as a whole is finished is not decided here, because this is called
      * once per item in a batch. [finishBatch] owns that.
      */
-    private fun finishDownload(context: Context) {
+    private fun finishDownload(
+        context: Context,
+        plan: DownloadPlan,
+        options: DownloadOptions
+    ) {
         // Purge fragments first: the move publishes every file it finds, so a leftover
         // .part from a cancelled or failed run would otherwise land in Downloads.
         purgeFragments()
@@ -1567,7 +1599,7 @@ class DownloadViewModel : ViewModel() {
             fileUri = savedUri
         )
 
-        recordHistory(context, fileName, savedPath, savedUri, finalSizeBytes)
+        recordHistory(context, fileName, savedPath, savedUri, finalSizeBytes, plan, options)
     }
 
     /**
@@ -1582,7 +1614,9 @@ class DownloadViewModel : ViewModel() {
         fileName: String,
         savedPath: String,
         savedUri: android.net.Uri?,
-        sizeBytes: Long
+        sizeBytes: Long,
+        plan: DownloadPlan,
+        options: DownloadOptions
     ) {
         val info = _state.value.info ?: return
 
@@ -1605,11 +1639,33 @@ class DownloadViewModel : ViewModel() {
                     savedPath = savedPath,
                     isVideo = downloadIsVideo,
                     sizeBytes = sizeBytes,
-                    completedAt = System.currentTimeMillis()
+                    completedAt = System.currentTimeMillis(),
+                    // Taken from what was asked for rather than from the file. A container
+                    // reports the streams it ended up holding, which after a merge and a
+                    // conversion is not the same thing as the quality that was chosen.
+                    formatLabel = plan.format.shortLabel,
+                    codec = plan.format.codecLabel,
+                    bitrateKbps = plan.format.bitrateKbps,
+                    embedded = embeddedExtras(options, plan.format.hasVideo)
                 )
             )
         }
     }
+
+    /**
+     * What was written into the file alongside the media.
+     *
+     * None of this can be recovered from the file afterwards without opening it and reading
+     * its streams, so it is written down at the moment it is true. Chapters are only asked
+     * for on a video download, which is why the kind is part of the question.
+     */
+    private fun embeddedExtras(options: DownloadOptions, isVideo: Boolean): String =
+        buildList {
+            if (options.embedSubs) add("Subtitles")
+            if (options.addChapters && isVideo) add("Chapters")
+            if (options.embedThumbnail) add("Cover art")
+            if (options.sponsorBlockFilters.isNotEmpty()) add("SponsorBlock")
+        }.joinToString(", ")
 
     /**
      * What fraction of the expected file is sitting in the temp directory right now.

--- a/app/src/main/java/com/hazel/android/ui/components/DownloadPresence.kt
+++ b/app/src/main/java/com/hazel/android/ui/components/DownloadPresence.kt
@@ -1,0 +1,59 @@
+package com.hazel.android.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.hazel.android.data.HistoryEntry
+import com.hazel.android.util.MediaPresence
+
+/**
+ * Which of [entries] still have their file on the device, kept current while the screen is
+ * open.
+ *
+ * The answer was previously worked out once, the first time a row appeared, and then never
+ * again for as long as the app ran. Deleting a download happens in another app, so the one
+ * moment the answer is certain to be stale is the moment the user comes back, which is
+ * exactly when it was not being re-read. Every held answer is dropped on each return to the
+ * foreground and the list is asked again.
+ *
+ * The map is returned as it is written to, so a screen that discovers a file is gone while
+ * acting on it can say so here rather than waiting for the next return.
+ */
+@Composable
+fun rememberPresence(entries: List<HistoryEntry>): SnapshotStateMap<Long, Boolean> {
+    val context = LocalContext.current
+    val presence = remember { mutableStateMapOf<Long, Boolean>() }
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Counted up rather than observed directly, so the read below has something to key on.
+    var round by remember { mutableIntStateOf(0) }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                MediaPresence.forget()
+                round++
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(entries, round) {
+        entries.forEach { entry ->
+            presence[entry.id] = MediaPresence.exists(context, entry.fileUri)
+        }
+    }
+
+    return presence
+}

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -88,6 +89,7 @@ import com.hazel.android.download.MediaInfo
 import com.hazel.android.download.formatDuration
 import com.hazel.android.download.formatFileSize
 import com.hazel.android.ui.components.MediaCardShimmer
+import com.hazel.android.ui.components.rememberPresence
 import com.hazel.android.ui.components.ProcessingShimmer
 import com.hazel.android.ui.motion.M3Motion
 import com.hazel.android.ui.screens.cookies.CookieWebViewActivity
@@ -209,22 +211,51 @@ fun DownloadScreen(
     val history by DownloadHistoryRepository.getHistory(context)
         .collectAsState(initial = emptyList())
 
+    // The records behind the links on screen, so each one can be asked whether the file it
+    // produced is still on the device. Only the links being shown are looked up, rather
+    // than the whole history, which can run to hundreds of rows.
+    val listedEntries = remember(state.results, history) {
+        state.results.mapNotNull { info ->
+            history.firstOrNull { LinkKey.sameMedia(it.url, info.url) }
+        }
+    }
+    val presence = rememberPresence(listedEntries)
+
+    /**
+     * Links in the list that were downloaded before and whose file is still on the device.
+     *
+     * The record on its own was taken as proof, so a link whose file the user had since
+     * deleted came back marked as downloaded and was left out of the set action. The record
+     * is a record of what happened, not of what is there, and a file that has gone is a
+     * link worth fetching again.
+     */
+    val savedUrls by remember(state.results, listedEntries) {
+        derivedStateOf {
+            state.results.filter { info ->
+                listedEntries.firstOrNull { LinkKey.sameMedia(it.url, info.url) }
+                    ?.let { presence[it.id] == true } == true
+            }.map { it.url }.toSet()
+        }
+    }
+
     /**
      * The links the set action still owes a download on.
-     *
-     * A link that has already been fetched keeps its place in the list, marked, because
-     * seeing what arrived is the point of the list. It is not something to fetch a second
-     * time. Reading a new link used to add it to what was already on screen and offer to
-     * download the lot, so one new video alongside one already saved read as two waiting,
-     * and Download all fetched the saved one again.
      *
      * Both records are consulted. The batch says what finished in this run, and the history
      * says what finished in any run, which is what a link read after a restart turns on.
      */
-    val pendingResults = remember(state.results, state.batch, history) {
+    // Whether a run is going on, counting one that is sitting paused. The run's own flag
+    // goes false the moment a pause stops the queue, which is how a paused set came to offer
+    // the action that would start it over, alongside controls for dropping links out of a
+    // queue that is still holding them.
+    val runInHand = state.isDownloading || state.batch.any {
+        it.state == BatchState.DOWNLOADING || it.state == BatchState.PAUSED
+    }
+
+    val pendingResults = remember(state.results, state.batch, savedUrls) {
         state.results.filterNot { info ->
             state.batch.any { item -> item.url == info.url && item.state == BatchState.DONE } ||
-                history.any { entry -> LinkKey.sameMedia(entry.url, info.url) }
+                info.url in savedUrls
         }
     }
 
@@ -346,9 +377,11 @@ fun DownloadScreen(
             // holds and switches how it is drawn, and both of those are worth reaching
             // without scrolling back to the top of a hundred links first.
             //
-            // Shown from two links up. A single card is not a list: there is no count worth
-            // stating and nothing for a layout to change, and "1 links" reads as a bug.
-            if (state.results.size > 1) {
+            // Shown from the first link. It was held back until there were two, on the
+            // grounds that a single card is not a list, but that made the layout switch a
+            // control which comes and goes, so nobody learns it is there and a single card
+            // cannot be read as a line. The count says "1 link" for one of them.
+            if (state.results.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(16.dp))
                 Row(
                     modifier = Modifier
@@ -357,7 +390,8 @@ fun DownloadScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        "${state.results.size} links",
+                        if (state.results.size == 1) "1 link"
+                        else "${state.results.size} links",
                         style = MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -430,27 +464,11 @@ fun DownloadScreen(
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(
                     start = 20.dp,
                     end = 20.dp,
-                    // Room for the action that floats over the list.
-                    bottom = if (state.isMultiple) 96.dp else 32.dp
+                    // Room for the action that floats over the list, on the same terms as
+                    // the action itself.
+                    bottom = if (pendingResults.size > 1) 96.dp else 32.dp
                 )
             ) {
-                item(key = "error") {
-                    AnimatedVisibility(
-                        visible = state.error != null,
-                        enter = M3Motion.contentEnter(),
-                        exit = M3Motion.contentExit()
-                    ) {
-                        state.error?.let {
-                            Text(
-                                it,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.padding(top = 10.dp, start = 4.dp)
-                            )
-                        }
-                    }
-                }
-
                 // An instant share reads with nothing on screen to show for it, so the
                 // same skeleton stands in, named after where the link came from.
                 item(key = "instant") {
@@ -527,7 +545,7 @@ fun DownloadScreen(
                         downloadViewModel.resolveFormats(info)
                         sheetVisible = true
                     }
-                    val remove = if (state.isMultiple && !state.isDownloading) {
+                    val remove = if (state.isMultiple && !runInHand) {
                         { downloadViewModel.removeResult(info) }
                     } else null
 
@@ -548,10 +566,11 @@ fun DownloadScreen(
                                     (!state.isMultiple && state.isComplete),
                             batchItem = batchItem,
                             waitingForWifi = state.waitingForWifi,
-                            alreadyDownloaded = state.isMultiple &&
-                                    history.any { LinkKey.sameMedia(it.url, info.url) },
+                            alreadyDownloaded = info.url in savedUrls,
                             onOpenSheet = openSheet,
                             onCancel = downloadViewModel::cancelDownload,
+                            onPause = downloadViewModel::pauseDownload,
+                            onResume = downloadViewModel::resumeDownload,
                             onRemove = remove
                         )
                     } else {
@@ -565,8 +584,7 @@ fun DownloadScreen(
                                     (!state.isMultiple && state.isComplete),
                             batchItem = batchItem,
                             waitingForWifi = state.waitingForWifi,
-                            alreadyDownloaded = state.isMultiple &&
-                                    history.any { LinkKey.sameMedia(it.url, info.url) },
+                            alreadyDownloaded = info.url in savedUrls,
                             onOpenSheet = openSheet,
                             onCancel = downloadViewModel::cancelDownload,
                             onPause = downloadViewModel::pauseDownload,
@@ -574,6 +592,54 @@ fun DownloadScreen(
                             onRemove = remove
                         )
                     }
+                    }
+                }
+
+                // How the run as a whole went, under the list rather than over it. It
+                // reports on what the cards above say one by one, so it belongs after them:
+                // above the list it was the first thing read, before there was anything for
+                // it to be about.
+                item(key = "error") {
+                    AnimatedVisibility(
+                        visible = state.error != null,
+                        enter = M3Motion.contentEnter(),
+                        exit = M3Motion.contentExit()
+                    ) {
+                        state.error?.let {
+                            Text(
+                                it,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.padding(top = 16.dp, start = 4.dp)
+                            )
+                        }
+                    }
+                }
+
+                // Says where the downloads that used to sit here have gone. Reading a new
+                // link takes what has finished off the list, so without this the cards a
+                // user watched arrive would simply be absent the next time they pasted
+                // something, which reads as the app having lost them.
+                if (state.savedAside && !state.isFetching) {
+                    item(key = "savedAside") {
+                        Spacer(modifier = Modifier.height(20.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                Icons.Filled.CheckCircle,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                "Your downloads are saved. Find them in the Downloads tab.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
 
@@ -613,8 +679,12 @@ fun DownloadScreen(
         }
 
         // One action for the whole set, which is the point of collecting links together.
-        // Hidden once there is nothing left in the set to fetch.
-        if (state.isMultiple && !state.isDownloading && pendingResults.isNotEmpty()) {
+        //
+        // Offered on what is actually left to fetch rather than on how long the list is. A
+        // list of two where one is already saved is one download, and a set action that
+        // opens a sheet holding a single card is a set action that should not have been
+        // there at all.
+        if (pendingResults.size > 1 && !runInHand) {
             DownloadAllButton(
                 onClick = { batchSheetVisible = true },
                 modifier = Modifier
@@ -1080,8 +1150,11 @@ private fun MediaCard(
                     }
                 }
 
-                // Removing a link from the set, offered only while the set is idle.
-                if (onRemove != null) {
+                // Removing a link from the set, offered only while the set is idle. A
+                // paused item counts as busy: the run as a whole has stopped, so the set is
+                // idle by the only measure this screen has, and the remove control was
+                // being drawn straight on top of the menu that resumes it.
+                if (onRemove != null && !isDownloading && !isPaused) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
@@ -1204,6 +1277,8 @@ private fun MediaRow(
     alreadyDownloaded: Boolean,
     onOpenSheet: () -> Unit,
     onCancel: () -> Unit,
+    onPause: () -> Unit = {},
+    onResume: () -> Unit = {},
     onRemove: (() -> Unit)?
 ) {
     val animatedProgress by animateFloatAsState(
@@ -1212,13 +1287,17 @@ private fun MediaRow(
         label = "rowProgress"
     )
 
+    var menuOpen by remember { mutableStateOf(false) }
+    val isPaused = batchItem?.state == BatchState.PAUSED
+    val inHand = isDownloading || isPaused
+
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
     ) {
         Column(
-            modifier = if (isDownloading) Modifier else Modifier.clickable(onClick = onOpenSheet)
+            modifier = if (inHand) Modifier else Modifier.clickable(onClick = onOpenSheet)
         ) {
             Row(
                 modifier = Modifier
@@ -1249,13 +1328,16 @@ private fun MediaRow(
                         )
                     }
 
-                    if (isDownloading) {
+                    // A paused item keeps the treatment that says it is in hand, exactly as
+                    // the card does. Only the control in the middle changes: there is
+                    // nothing to stop any more, and the thing to do is start it again.
+                    if (inHand) {
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .background(Color.Black.copy(alpha = 0.4f))
                         )
-                        if (isProcessing) {
+                        if (isProcessing && !isPaused) {
                             ProcessingShimmer(modifier = Modifier.fillMaxSize())
                         } else {
                             Box(
@@ -1263,12 +1345,13 @@ private fun MediaRow(
                                     .size(34.dp)
                                     .clip(CircleShape)
                                     .background(Color.Black.copy(alpha = 0.55f))
-                                    .clickable(onClick = onCancel),
+                                    .clickable(onClick = if (isPaused) onResume else onCancel),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    Icons.Filled.Close,
-                                    contentDescription = "Cancel download",
+                                    if (isPaused) Icons.Filled.PlayArrow else Icons.Filled.Close,
+                                    contentDescription =
+                                        if (isPaused) "Resume download" else "Cancel download",
                                     modifier = Modifier.size(16.dp),
                                     tint = Color.White
                                 )
@@ -1317,7 +1400,16 @@ private fun MediaRow(
                     }
 
                     val state = when {
-                        batchItem?.state == BatchState.PAUSED -> "Paused"
+                        isPaused -> buildString {
+                            append("Paused")
+                            if (totalBytes > 0) {
+                                val done = (totalBytes * animatedProgress).toLong()
+                                append("  ")
+                                append(formatFileSize(done))
+                                append(" / ")
+                                append(formatFileSize(totalBytes))
+                            }
+                        }
                         waitingForWifi && !isDownloading -> "Waiting for Wi-Fi"
                         isProcessing -> "Processing"
                         // The same line the card shows: how far along, and how far there is
@@ -1356,8 +1448,56 @@ private fun MediaRow(
                     }
                 }
 
-                if (onRemove != null) {
-                    IconButton(onClick = onRemove) {
+                // The same options the card offers, in the same order. They used to be on
+                // the card alone, so switching to this layout mid-download took away every
+                // way of pausing or resuming the thing being watched. They sit at the end
+                // of the line rather than over the artwork, which at this size is too small
+                // to hold a control on top of the one already in the middle of it.
+                when {
+                    inHand -> Box {
+                        IconButton(onClick = { menuOpen = true }) {
+                            Icon(
+                                Icons.Filled.MoreVert,
+                                contentDescription = "Download options",
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = menuOpen,
+                            onDismissRequest = { menuOpen = false }
+                        ) {
+                            if (isPaused) {
+                                DropdownMenuItem(
+                                    text = { Text("Resume") },
+                                    onClick = {
+                                        menuOpen = false
+                                        onResume()
+                                    }
+                                )
+                            } else {
+                                DropdownMenuItem(
+                                    text = { Text("Pause") },
+                                    // Nothing to pause once the transfer is done and the
+                                    // engine has moved on to merging or tagging.
+                                    enabled = !isProcessing,
+                                    onClick = {
+                                        menuOpen = false
+                                        onPause()
+                                    }
+                                )
+                            }
+                            DropdownMenuItem(
+                                text = { Text("Cancel") },
+                                onClick = {
+                                    menuOpen = false
+                                    onCancel()
+                                }
+                            )
+                        }
+                    }
+
+                    onRemove != null -> IconButton(onClick = onRemove) {
                         Icon(
                             Icons.Filled.Close,
                             contentDescription = "Remove link",
@@ -1368,8 +1508,10 @@ private fun MediaRow(
                 }
             }
 
-            if (isDownloading) {
-                if (isProcessing) {
+            // Drawn while the item is paused as well, because a bar that vanishes on a
+            // pause takes with it the only sign of how much of the file is already down.
+            if (inHand) {
+                if (isProcessing && !isPaused) {
                     LinearProgressIndicator(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -1383,7 +1525,11 @@ private fun MediaRow(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(3.dp),
-                        color = MaterialTheme.colorScheme.primary,
+                        color = if (isPaused) {
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                        } else {
+                            MaterialTheme.colorScheme.primary
+                        },
                         trackColor = Color.Transparent,
                         drawStopIndicator = {}
                     )

--- a/app/src/main/java/com/hazel/android/ui/screens/download/DownloadSheetFooter.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/DownloadSheetFooter.kt
@@ -103,8 +103,8 @@ fun DownloadSheetFooter(
                 modifier = Modifier
                     .weight(1f)
                     .clickable(enabled = copyText.isNotBlank()) {
-                        copyToClipboard(context, copyText)
-                        feedback = if (openLink(context, copyText)) {
+                        copySheetLink(context, copyText)
+                        feedback = if (openSheetLink(context, copyText)) {
                             "Link copied and opened"
                         } else {
                             "Link copied"
@@ -169,9 +169,9 @@ fun DownloadSheetFooter(
 }
 
 /** Long enough to read, short enough that it is gone before it is in the way. */
-private const val FEEDBACK_MS = 2_000L
+internal const val FEEDBACK_MS = 2_000L
 
-private fun copyToClipboard(context: Context, text: String) {
+internal fun copySheetLink(context: Context, text: String) {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
     clipboard?.setPrimaryClip(ClipData.newPlainText("Hazel link", text))
 }
@@ -184,7 +184,7 @@ private fun copyToClipboard(context: Context, text: String) {
  * when that app is not installed, and a device with neither is left alone: the address is
  * already on the clipboard by the time this is called.
  */
-private fun openLink(context: Context, url: String): Boolean {
+internal fun openSheetLink(context: Context, url: String): Boolean {
     val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return false
     val host = uri.host.orEmpty().removePrefix("www.").lowercase()
 

--- a/app/src/main/java/com/hazel/android/ui/screens/download/SearchScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/download/SearchScreen.kt
@@ -1,5 +1,6 @@
 package com.hazel.android.ui.screens.download
 
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -11,11 +12,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -23,6 +27,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.CallMade
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
@@ -52,6 +57,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
@@ -90,6 +96,7 @@ fun SearchScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val keyboard = LocalSoftwareKeyboardController.current
+    val clipboard = LocalClipboardManager.current
     val focusRequester = remember { FocusRequester() }
 
     val history by SearchHistoryRepository.getHistory(context).collectAsState(initial = emptyList())
@@ -166,6 +173,24 @@ fun SearchScreen(
         }
     }
 
+    /**
+     * Takes whatever is on the clipboard and reads it straight away.
+     *
+     * A link almost always arrives by being copied somewhere else, so the field's first act
+     * is nearly always a paste followed by a confirm. This is those two steps as one. It
+     * goes through [submit], so a paste of several links is split the same way a typed one
+     * is and a link already downloaded still raises the same warning.
+     */
+    fun pasteAndSearch() {
+        val pasted = clipboard.getText()?.text.orEmpty().trim()
+        if (pasted.isBlank()) {
+            Toast.makeText(context, "Nothing to paste", Toast.LENGTH_SHORT).show()
+            return
+        }
+        text = pasted
+        submit()
+    }
+
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
     // Shown as a dialog rather than as screen content so it covers the app bar and the
@@ -174,7 +199,13 @@ fun SearchScreen(
         onDismissRequest = onDismiss,
         properties = DialogProperties(
             usePlatformDefaultWidth = false,
-            dismissOnClickOutside = false
+            dismissOnClickOutside = false,
+            // The dialog is told to lay itself out against the real window rather than
+            // inside what the system leaves over. Without it the keyboard's height is
+            // reported as nothing, which is fine for a screen that only stacks downwards
+            // and wrong for the paste control, which hangs off the bottom corner and was
+            // being drawn underneath the keyboard. The bars are paid for below instead.
+            decorFitsSystemWindows = false
         )
     ) {
         BackHandler(enabled = true) { onDismiss() }
@@ -195,6 +226,14 @@ fun SearchScreen(
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background
+        ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                // What the window no longer does for itself. The screen keeps clear of the
+                // status bar at the top and the navigation bar at the foot exactly as it
+                // did, and the keyboard is now something the layout can see.
+                .systemBarsPadding()
         ) {
         Column(modifier = Modifier.fillMaxSize()) {
 
@@ -357,6 +396,39 @@ fun SearchScreen(
                     }
                 }
             }
+
+            // ── Paste ──
+            //
+            // A link is nearly always copied somewhere else first, so the opening move on
+            // this screen is a paste and then a confirm. This is the two of them at once.
+            // It goes through the same submit the field does, so a paste holding several
+            // links is split the way a typed one is and a link already downloaded still
+            // raises the same warning.
+            //
+            // Offered only with nothing entered, which is the moment it stands for, and
+            // held clear of the keyboard that is up for as long as this screen is.
+            if (text.isBlank() && queued.isEmpty()) {
+                Surface(
+                    onClick = { pasteAndSearch() },
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .imePadding()
+                        .padding(20.dp)
+                        .size(56.dp),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primary
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            Icons.Filled.ContentPaste,
+                            contentDescription = "Paste and fetch",
+                            modifier = Modifier.size(22.dp),
+                            tint = MaterialTheme.colorScheme.onPrimary
+                        )
+                    }
+                }
+            }
+        }
         }
     }
 }

--- a/app/src/main/java/com/hazel/android/ui/screens/history/DownloadPropertiesSheet.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/history/DownloadPropertiesSheet.kt
@@ -1,0 +1,361 @@
+package com.hazel.android.ui.screens.history
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.hazel.android.data.HistoryEntry
+import com.hazel.android.download.formatDuration
+import com.hazel.android.download.formatFileSize
+import com.hazel.android.ui.screens.download.FEEDBACK_MS
+import com.hazel.android.ui.screens.download.copySheetLink
+import com.hazel.android.ui.screens.download.openSheetLink
+import com.hazel.android.util.MediaFacts
+import com.hazel.android.util.MediaProbeFacts
+import kotlinx.coroutines.delay
+
+/**
+ * Everything the app knows about one finished download.
+ *
+ * The list says as much as a row has space for: a title, a size and a date. The rest was
+ * either recorded and never shown, or sits in the file itself. This is where it lives,
+ * reached from the row's own menu and from holding the row down.
+ *
+ * Two sources, neither of them expensive. What was asked for comes from the record, which
+ * is already in memory. What arrived is read once from the file's header, on a background
+ * thread, and only for a file that is still there. Anything either source has nothing to
+ * say about is left out rather than shown as blank or zero, so the sheet is exactly as long
+ * as there are facts to fill it.
+ *
+ * The address closes the sheet the way it closes a download sheet, and behaves the same:
+ * tapping it copies it and opens it, in the site's own app where that is installed. It is
+ * the one line here worth acting on rather than only reading, and for a download whose file
+ * has gone it is the way back to the thing itself.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DownloadPropertiesSheet(
+    entry: HistoryEntry,
+    present: Boolean,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // One header read per opening, and none at all for a file that is not there. Keyed on
+    // the entry, so reopening the same sheet does not read again while it stays composed.
+    var facts by remember(entry.id) { mutableStateOf(MediaFacts()) }
+    LaunchedEffect(entry.id, present) {
+        if (present) facts = MediaProbeFacts.read(context, entry.fileUri)
+    }
+
+    // What the last tap on the address did. It clears itself, so nothing has to be
+    // dismissed and an old answer does not sit under the details being read.
+    var feedback by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(feedback) {
+        if (feedback != null) {
+            delay(FEEDBACK_MS)
+            feedback = null
+        }
+    }
+
+    // The screen's own ground rather than the raised surface a sheet takes by default. A
+    // sheet is the whole foreground while it is up, and the raised tone read as a grey
+    // panel floating on the black behind it. Taken from the theme, so it is the near black
+    // in the dark scheme and the warm off white in the light one, and it follows the accent
+    // the user picked rather than pinning a colour of its own.
+    val sheetColor = MaterialTheme.colorScheme.background
+    val panelColor = MaterialTheme.colorScheme.surfaceContainerHigh
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = sheetColor
+    ) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+        ) {
+            Text(
+                "Properties",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // The download itself, so the details underneath are read against the thing
+            // they describe rather than against a filename.
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(width = 120.dp, height = 72.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(panelColor),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (entry.thumbnail != null) {
+                        AsyncImage(
+                            model = entry.thumbnail,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            alpha = if (present) 1f else 0.55f,
+                            colorFilter = if (present) null else ColorFilter.colorMatrix(
+                                ColorMatrix().apply { setToSaturation(0f) }
+                            ),
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else {
+                        Icon(
+                            if (entry.isVideo) Icons.Filled.PlayArrow
+                            else Icons.Filled.MusicNote,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(14.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        entry.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (entry.author.isNotBlank()) {
+                        Spacer(modifier = Modifier.height(3.dp))
+                        Text(
+                            entry.author,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(22.dp))
+
+            // Gathered first, then drawn, so a section with nothing in it does not leave a
+            // heading and an empty panel behind.
+            val media = buildList {
+                add("Status" to if (present) "On this device" else "Deleted from this device")
+                add("Kind" to if (entry.isVideo) "Video" else "Audio")
+                entry.formatLabel.ifBlank { null }?.let { add("Quality" to it) }
+                facts.resolution.ifBlank { null }?.let { add("Resolution" to it) }
+                val length = formatDuration(
+                    entry.durationSeconds.takeIf { it > 0 } ?: facts.durationSeconds
+                )
+                length.ifBlank { null }?.let { add("Length" to it) }
+                entry.codec.ifBlank { null }?.let { add("Codec" to it) }
+
+                // The file's own figure first: it describes what is on disk, where the
+                // recorded one describes the stream that was asked for.
+                val bitrate = facts.bitrateKbps.takeIf { it > 0 }
+                    ?: entry.bitrateKbps.takeIf { it > 0 }?.toInt()
+                bitrate?.let { add("Bitrate" to "$it kbps") }
+            }
+
+            val file = buildList {
+                if (entry.sizeBytes > 0) add("Size" to formatFileSize(entry.sizeBytes))
+                entry.container.ifBlank { null }?.let { add("Container" to it) }
+                facts.mimeType.ifBlank { null }?.let { add("Type" to it) }
+                entry.embedded.ifBlank { null }?.let { add("Embedded" to it) }
+                entry.fileName.ifBlank { null }?.let { add("File" to it) }
+                entry.savedPath.ifBlank { null }?.let { add("Saved to" to it) }
+            }
+
+            val origin = buildList {
+                add("Downloaded" to formatStamp(entry.completedAt))
+                entry.site.ifBlank { null }?.let { add("Source" to it) }
+            }
+
+            DetailPanel(media, panelColor, missing = !present)
+            Spacer(modifier = Modifier.height(12.dp))
+            DetailPanel(file, panelColor)
+            Spacer(modifier = Modifier.height(12.dp))
+            DetailPanel(origin, panelColor)
+
+            Spacer(modifier = Modifier.height(22.dp))
+
+            // The line that closes the sheet, as the download sheet closes with the same
+            // thing. Copied because the address is often wanted somewhere else, opened
+            // because the other reason to look at a link is to go and see what is behind it.
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Link,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    entry.url,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable(enabled = entry.url.isNotBlank()) {
+                            copySheetLink(context, entry.url)
+                            feedback = if (openSheetLink(context, entry.url)) {
+                                "Link copied and opened"
+                            } else {
+                                "Link copied"
+                            }
+                        }
+                )
+            }
+
+            AnimatedVisibility(
+                visible = feedback != null,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                Column {
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(28.dp),
+                        color = MaterialTheme.colorScheme.inverseSurface
+                    ) {
+                        Text(
+                            feedback.orEmpty(),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.inverseOnSurface,
+                            modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+        }
+    }
+}
+
+/**
+ * A group of facts, hairline separated. Draws nothing at all when the group is empty, which
+ * is what keeps a sheet about an old entry from being mostly headings.
+ */
+@Composable
+private fun DetailPanel(
+    rows: List<Pair<String, String>>,
+    color: Color,
+    missing: Boolean = false
+) {
+    if (rows.isEmpty()) return
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        color = color
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 6.dp),
+            verticalArrangement = Arrangement.spacedBy(0.dp)
+        ) {
+            rows.forEachIndexed { index, (label, value) ->
+                if (index > 0) {
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f)
+                    )
+                }
+                DetailRow(
+                    label = label,
+                    value = value,
+                    emphasis = missing && label == "Status"
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One fact, named on the left and given on the right.
+ *
+ * The value is the part that gives way when the row runs out of width: a label is one word
+ * and a filename is forty, so weighting the label would shorten the wrong half.
+ */
+@Composable
+private fun DetailRow(label: String, value: String, emphasis: Boolean = false) {
+    Row(
+        modifier = Modifier.padding(vertical = 11.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(94.dp)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            value,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = if (emphasis) MaterialTheme.colorScheme.error
+            else MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+/** The date and the time, since two downloads of the same thing differ only by the hour. */
+private fun formatStamp(millis: Long): String = runCatching {
+    java.text.SimpleDateFormat("d MMMM yyyy, HH:mm", java.util.Locale.getDefault())
+        .format(java.util.Date(millis))
+}.getOrDefault("")

--- a/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/history/HistoryScreen.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -52,7 +53,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -78,6 +78,8 @@ import com.hazel.android.data.HistoryFilter
 import com.hazel.android.data.HistorySort
 import com.hazel.android.download.formatDuration
 import com.hazel.android.download.formatFileSize
+import com.hazel.android.ui.components.rememberPresence
+import com.hazel.android.util.MediaPresence
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -113,17 +115,12 @@ fun HistoryScreen() {
     var menuOpen by remember { mutableStateOf(false) }
     var confirmClear by remember { mutableStateOf(false) }
     var pendingDelete by remember { mutableStateOf<HistoryEntry?>(null) }
+    var properties by remember { mutableStateOf<HistoryEntry?>(null) }
 
-    // Checked once per entry as it appears, rather than on every recomposition, since it
-    // touches the filesystem.
-    val presence = remember { mutableStateMapOf<Long, Boolean>() }
-    LaunchedEffect(history) {
-        history.forEach { entry ->
-            if (entry.id !in presence) {
-                presence[entry.id] = DownloadHistoryRepository.fileExists(context, entry)
-            }
-        }
-    }
+    // Asked once per entry and then asked again on every return to the foreground, since
+    // deleting a download happens in another app and that is when the answer held here
+    // stops being true.
+    val presence = rememberPresence(history)
 
     val visible = remember(history, sort, filter, query) {
         history
@@ -344,7 +341,26 @@ fun HistoryScreen() {
             ) {
                 items(visible, key = { it.id }) { entry ->
                     val present = presence[entry.id] ?: true
-                    val open = { openEntry(context, entry) }
+
+                    // Asked again at the moment of the tap rather than trusted from the
+                    // last sweep. A file deleted since then handed the address to a player,
+                    // which opened on nothing and came straight back, leaving the row still
+                    // claiming the file was there. The row is corrected here instead.
+                    val open = {
+                        scope.launch {
+                            if (MediaPresence.refresh(context, entry.fileUri)) {
+                                openEntry(context, entry)
+                            } else {
+                                presence[entry.id] = false
+                                Toast.makeText(
+                                    context,
+                                    "This file is no longer on your device",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                        Unit
+                    }
                     val remove = {
                         scope.launch { DownloadHistoryRepository.remove(context, entry.id) }
                         Unit
@@ -356,7 +372,8 @@ fun HistoryScreen() {
                             present = present,
                             onOpen = open,
                             onRemove = remove,
-                            onDeleteFile = { pendingDelete = entry }
+                            onDeleteFile = { pendingDelete = entry },
+                            onProperties = { properties = entry }
                         )
                     } else {
                         HistoryCard(
@@ -364,7 +381,8 @@ fun HistoryScreen() {
                             present = present,
                             onOpen = open,
                             onRemove = remove,
-                            onDeleteFile = { pendingDelete = entry }
+                            onDeleteFile = { pendingDelete = entry },
+                            onProperties = { properties = entry }
                         )
                     }
                 }
@@ -386,6 +404,14 @@ fun HistoryScreen() {
             dismissButton = {
                 TextButton(onClick = { confirmClear = false }) { Text("Cancel") }
             }
+        )
+    }
+
+    properties?.let { entry ->
+        DownloadPropertiesSheet(
+            entry = entry,
+            present = presence[entry.id] ?: true,
+            onDismiss = { properties = null }
         )
     }
 
@@ -420,7 +446,8 @@ private fun HistoryCard(
     present: Boolean,
     onOpen: () -> Unit,
     onRemove: () -> Unit,
-    onDeleteFile: () -> Unit
+    onDeleteFile: () -> Unit,
+    onProperties: () -> Unit
 ) {
     var menuOpen by remember { mutableStateOf(false) }
 
@@ -433,7 +460,14 @@ private fun HistoryCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(16f / 9f)
-                .clickable(enabled = present, onClick = onOpen)
+                // Holding an entry down asks what it is. A tap plays it, which is what the
+                // list is for, so the details cannot have the tap; a long press is where a
+                // thing's properties live everywhere else on the platform. It answers for a
+                // deleted entry too, where it is the only thing left that can.
+                .combinedClickable(
+                    onClick = { if (present) onOpen() },
+                    onLongClick = onProperties
+                )
         ) {
             if (entry.thumbnail != null) {
                 // A row whose file has been deleted elsewhere keeps its place in the list,
@@ -505,6 +539,13 @@ private fun HistoryCard(
                         onDismissRequest = { menuOpen = false }
                     ) {
                         DropdownMenuItem(
+                            text = { Text("Properties") },
+                            onClick = {
+                                menuOpen = false
+                                onProperties()
+                            }
+                        )
+                        DropdownMenuItem(
                             text = { Text("Remove from list") },
                             onClick = {
                                 menuOpen = false
@@ -564,12 +605,19 @@ private fun HistoryCard(
 
 
 /**
- * One download as a single line: small artwork, then what it is.
+ * One download as a single line: artwork, then what it is, then what it cost.
  *
  * The card form leads with the artwork, which is right for browsing but wasteful once the
  * list is long, since four entries fill a screen. This form fits several times as many by
  * moving the text out from over the image onto its own column, where it also stops
  * competing with the picture for contrast.
+ *
+ * The three facts under the title are laid out as a line that gives way and a marker that
+ * does not. They used to share a row where neither was allowed to yield, so the text took
+ * the whole width and the marker beside it was measured into nothing: on a deleted download
+ * it collapsed to a red thread down the side of the row and its label wrapped a letter at a
+ * time, dragging the row to several times its height. The line is what shortens now, and
+ * the marker keeps the width its own words need.
  */
 @Composable
 private fun HistoryRow(
@@ -577,26 +625,31 @@ private fun HistoryRow(
     present: Boolean,
     onOpen: () -> Unit,
     onRemove: () -> Unit,
-    onDeleteFile: () -> Unit
+    onDeleteFile: () -> Unit,
+    onProperties: () -> Unit
 ) {
     var menuOpen by remember { mutableStateOf(false) }
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(20.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(enabled = present, onClick = onOpen)
-                .padding(8.dp),
+                // As on the card: a tap plays it, holding it down says what it is.
+                .combinedClickable(
+                    onClick = { if (present) onOpen() },
+                    onLongClick = onProperties
+                )
+                .padding(start = 12.dp, top = 12.dp, bottom = 12.dp, end = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
-                    .size(width = 104.dp, height = 60.dp)
-                    .clip(RoundedCornerShape(8.dp))
+                    .size(width = 128.dp, height = 78.dp)
+                    .clip(RoundedCornerShape(14.dp))
                     .background(MaterialTheme.colorScheme.surfaceVariant),
                 contentAlignment = Alignment.Center
             ) {
@@ -605,7 +658,7 @@ private fun HistoryRow(
                         model = entry.thumbnail,
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
-                        alpha = if (present) 1f else 0.7f,
+                        alpha = if (present) 1f else 0.55f,
                         colorFilter = if (present) null else ColorFilter.colorMatrix(
                             ColorMatrix().apply { setToSaturation(0f) }
                         ),
@@ -615,7 +668,7 @@ private fun HistoryRow(
                     Icon(
                         if (entry.isVideo) Icons.Filled.PlayArrow else Icons.Filled.MusicNote,
                         contentDescription = null,
-                        modifier = Modifier.size(20.dp),
+                        modifier = Modifier.size(24.dp),
                         tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
                     )
                 }
@@ -625,31 +678,36 @@ private fun HistoryRow(
                     Surface(
                         modifier = Modifier
                             .align(Alignment.BottomEnd)
-                            .padding(3.dp),
-                        shape = RoundedCornerShape(4.dp),
-                        color = Color.Black.copy(alpha = 0.7f)
+                            .padding(5.dp),
+                        shape = RoundedCornerShape(6.dp),
+                        color = Color.Black.copy(alpha = 0.72f)
                     ) {
                         Text(
                             duration,
                             style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
                             color = Color.White,
-                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp)
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
                         )
                     }
                 }
             }
 
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(14.dp))
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     entry.title,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
+                    color = if (present) MaterialTheme.colorScheme.onSurface
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
+
                 if (entry.author.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(3.dp))
                     Text(
                         entry.author,
                         style = MaterialTheme.typography.bodySmall,
@@ -659,18 +717,15 @@ private fun HistoryRow(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
+                // No type glyph in front of the figures. The artwork beside them already
+                // says what this is, and on a narrow row the glyph was spending width the
+                // date needed to finish.
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        if (entry.isVideo) Icons.Filled.PlayArrow else Icons.Filled.MusicNote,
-                        contentDescription = null,
-                        modifier = Modifier.size(13.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
                     Text(
                         buildString {
                             if (entry.sizeBytes > 0) {
@@ -682,11 +737,16 @@ private fun HistoryRow(
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        // Weighted, so this is the part that gives when the row is narrow.
+                        // Anything unweighted beside it is measured first and in full.
+                        modifier = Modifier.weight(1f, fill = false)
                     )
                     if (!present) {
+                        // The same word the card uses. The file is not mislaid, it is gone,
+                        // and almost always because the user removed it themselves.
                         Tag(
-                            "Missing",
+                            "Deleted",
                             background = MaterialTheme.colorScheme.error,
                             foreground = MaterialTheme.colorScheme.onError
                         )
@@ -703,6 +763,13 @@ private fun HistoryRow(
                     )
                 }
                 DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text("Properties") },
+                        onClick = {
+                            menuOpen = false
+                            onProperties()
+                        }
+                    )
                     DropdownMenuItem(
                         text = { Text("Remove from list") },
                         onClick = {

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -2,7 +2,6 @@ package com.hazel.android.ui.screens.more
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.foundation.clickable
@@ -386,22 +385,10 @@ fun MoreScreen(
                 color = MaterialTheme.colorScheme.surfaceVariant
             )
 
-            // Sits at the end, under everything the app can do for itself. No mark on the
-            // right: the line under it already says where it goes, and the chevrons above
-            // mean "another screen in here", which this is not.
-            ListItem(
-                headlineContent = { Text("Source code") },
-                leadingContent = {
-                    Icon(Icons.Filled.Code, null, tint = MaterialTheme.colorScheme.primary)
-                },
-                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                modifier = Modifier.clickable { openExternally(context, SOURCE_URL) }
-            )
-
-            HorizontalDivider(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                color = MaterialTheme.colorScheme.surfaceVariant
-            )
+            // The source is offered on the Support screen above, where it sits among the
+            // other ways of helping that cost nothing. It was here as well, so the same
+            // address was reachable by two routes that behaved differently, and the one
+            // that stayed is the one with something to say about why anyone would follow it.
 
             // Opened in the user's own browser rather than in the app's, because a licence
             // is a thing people save, share and read next to something else, and none of
@@ -436,5 +423,4 @@ private fun openExternally(context: android.content.Context, url: String) {
     }
 }
 
-private const val SOURCE_URL = "https://github.com/SibtainOcn/Hazel"
 private const val LICENSE_URL = "https://github.com/SibtainOcn/Hazel/blob/main/LICENSE"

--- a/app/src/main/java/com/hazel/android/util/MediaFacts.kt
+++ b/app/src/main/java/com/hazel/android/util/MediaFacts.kt
@@ -1,0 +1,78 @@
+package com.hazel.android.util
+
+import android.content.Context
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * What the saved file itself says it is.
+ *
+ * The download record holds what was asked for. This holds what arrived, read out of the
+ * file's own header: the two differ whenever a merge, a conversion or a container change
+ * sat between them, and for anything downloaded before the record started carrying those
+ * details it is the only account there is.
+ *
+ * Everything is optional, because a file can be gone, unreadable, or of a kind the platform
+ * extractor has nothing to say about. A blank field is left out of the sheet rather than
+ * shown as zero.
+ */
+data class MediaFacts(
+    val bitrateKbps: Int = 0,
+    val width: Int = 0,
+    val height: Int = 0,
+    val mimeType: String = "",
+    val durationSeconds: Int = 0
+) {
+    val resolution: String
+        get() = if (width > 0 && height > 0) "${width}x$height" else ""
+
+    val hasAnything: Boolean
+        get() = bitrateKbps > 0 || resolution.isNotBlank() || mimeType.isNotBlank()
+}
+
+object MediaProbeFacts {
+
+    /**
+     * Reads [fileUri]'s header. Returns an empty answer for anything that cannot be opened,
+     * which is the ordinary case for a download the user has since deleted.
+     */
+    suspend fun read(context: Context, fileUri: String): MediaFacts =
+        withContext(Dispatchers.IO) {
+            if (fileUri.isBlank()) return@withContext MediaFacts()
+
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(context, Uri.parse(fileUri))
+
+                MediaFacts(
+                    // Reported in bits per second, and shown in the thousands the rest of
+                    // the app talks in.
+                    bitrateKbps = retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)
+                        ?.toIntOrNull()
+                        ?.let { it / 1000 }
+                        ?: 0,
+                    width = retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+                        ?.toIntOrNull() ?: 0,
+                    height = retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+                        ?.toIntOrNull() ?: 0,
+                    mimeType = retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_MIMETYPE)
+                        .orEmpty(),
+                    durationSeconds = retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                        ?.toLongOrNull()
+                        ?.let { (it / 1000).toInt() }
+                        ?: 0
+                )
+            } catch (_: Exception) {
+                MediaFacts()
+            } finally {
+                runCatching { retriever.release() }
+            }
+        }
+}

--- a/app/src/main/java/com/hazel/android/util/MediaPresence.kt
+++ b/app/src/main/java/com/hazel/android/util/MediaPresence.kt
@@ -1,0 +1,95 @@
+package com.hazel.android.util
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.MediaStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Whether the file a finished download produced is still on the device.
+ *
+ * A download record says what happened, not what is there now: the file can be moved or
+ * deleted from a gallery or a file manager at any point afterwards. Opening the address is
+ * not enough to tell the difference. From Android 11 a gallery delete moves the row to the
+ * system bin rather than removing it, and the app that owns the row can still open it from
+ * in there, so a file the user deleted read as present right up until they emptied the bin
+ * as well. The index is asked whether the row is binned or half written before the file
+ * behind it is opened at all.
+ *
+ * Answers are held, because this touches storage and is asked once per row on a list that
+ * can run to hundreds. [forget] drops them, which is what a screen returning to the
+ * foreground does: coming back is exactly when a held answer is most likely to be stale.
+ */
+object MediaPresence {
+
+    private val known = ConcurrentHashMap<String, Boolean>()
+
+    /** Answers for [fileUri], reading storage only when no answer is held for it. */
+    suspend fun exists(context: Context, fileUri: String): Boolean =
+        known[fileUri] ?: refresh(context, fileUri)
+
+    /** Asks storage again, whatever was held before, and keeps what it finds. */
+    suspend fun refresh(context: Context, fileUri: String): Boolean =
+        withContext(Dispatchers.IO) {
+            val present = fileUri.isNotBlank() &&
+                    runCatching { check(context, Uri.parse(fileUri)) }.getOrDefault(false)
+            known[fileUri] = present
+            present
+        }
+
+    /** Throws away every held answer, so the next ask reads storage. */
+    fun forget() {
+        known.clear()
+    }
+
+    private fun check(context: Context, uri: Uri): Boolean {
+        if (uri.scheme == ContentResolver.SCHEME_FILE) {
+            return uri.path?.let { File(it).exists() } == true
+        }
+
+        // A row the index reports as binned or still being written opens exactly as a
+        // finished one does, so that has to be settled before the address is tried.
+        if (indexSaysGone(context, uri) == true) return false
+
+        return runCatching {
+            context.contentResolver.openFileDescriptor(uri, "r")?.use { true } ?: false
+        }.getOrDefault(false)
+    }
+
+    /**
+     * What the media index says about the row, or null where it has nothing to say: an
+     * address that is not its own, or a version without the columns to answer with.
+     *
+     * True means binned or half written, both of which are the file not being there as far
+     * as anything that wants to play it is concerned.
+     */
+    private fun indexSaysGone(context: Context, uri: Uri): Boolean? {
+        if (Build.VERSION.SDK_INT < 30) return null
+        if (uri.authority != MediaStore.AUTHORITY) return null
+
+        // Binned rows are left out of an ordinary query, so a missing row would be
+        // indistinguishable from a binned one. Asking for them explicitly is what makes an
+        // empty answer mean the row is genuinely gone.
+        val args = Bundle().apply {
+            putInt(MediaStore.QUERY_ARG_MATCH_TRASHED, MediaStore.MATCH_INCLUDE)
+        }
+
+        return runCatching {
+            context.contentResolver.query(
+                uri,
+                arrayOf(MediaStore.MediaColumns.IS_TRASHED, MediaStore.MediaColumns.IS_PENDING),
+                args,
+                null
+            )?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use true
+                cursor.getInt(0) != 0 || cursor.getInt(1) != 0
+            }
+        }.getOrNull()
+    }
+}


### PR DESCRIPTION
The record of a download was being treated as proof the file was still there, and the
results list was being treated as the set of things left to fetch. Neither held, and most
of what follows comes from fixing those two.

## Presence

`MediaPresence` asks the media index whether a row is binned or still being written before
opening the file behind it. From Android 11 a gallery delete moves the row to the system
bin, which the owning app can still open, so `openFileDescriptor` alone reported a deleted
download as present until the bin was emptied too. Answers are cached and dropped on every
`ON_RESUME`, since deletion happens in another app.

`rememberPresence` drives both screens off that, so the downloads list and the marker on a
fetched link cannot disagree. The downloads list also re-checks at the moment of a tap
rather than handing a missing file to a player that opens on nothing and returns.

A link whose file has gone now raises no repeat warning and carries no "Downloaded" tag.

## Set actions

`fetchAll` drops results whose batch state is `DONE` when merging a new read, and sets
`savedAside` so the results footer says where they went. `Download all` is gated on
`pendingResults.size > 1` rather than `state.isMultiple`, and both it and the per-card
remove control are gated on `runInHand`, which counts a paused run as in hand.

Previously one new link beside one already downloaded read as a set of two, and the sheet
behind the action held both.

## Layouts

- `MediaRow` gains the pause/resume/cancel menu, the paused artwork control and a progress
  bar that survives a pause. Switching layout mid-download previously left only a cancel
  button.
- `HistoryRow` was rebuilt. The meta text is weighted so the deleted marker beside it is
  measured first; with neither weighted the text took the full width and the marker
  collapsed to a red thread whose label wrapped one letter per line, several times the row
  height. Larger artwork, more spacing, no type glyph in front of the figures.
- The run summary moved below the cards it counts.
- The results layout switch is offered from the first link; the count reads "1 link".

## Properties sheet

`DownloadPropertiesSheet`, from the row menu or a long press. Fed by two sources: the
record, extended with `formatLabel`, `codec`, `bitrateKbps` and `embedded` written at
download time, and `MediaProbeFacts`, one `MediaMetadataRetriever` header read on IO, only
for a file that is present. Rows with nothing behind them are omitted, so entries predating
the new fields render short rather than empty. Closes with the address, copying and opening
it as the download sheet does.

## Also

- Link entry gains a paste control in the corner. The dialog declares
  `decorFitsSystemWindows = false` so the IME inset is visible to the layout and the control
  rides above the keyboard; the content takes `systemBarsPadding()` in exchange.
- The duplicate source-code row is gone from More; the Support screen keeps it.

## Testing

Verified on a physical device (Android 16, RMX3151) against a single link and a three-item
playlist: set action and sheet scope, a file deleted outside the app, a re-fetch of a
deleted download, pause and resume in both layouts, the properties sheet for a present
entry, a deleted entry and a freshly recorded one. `assembleDebug` and `testDebugUnitTest`
pass.
