### PR TITLE
Speak six languages, and let the app be set to one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Hazel are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Hazel speaks six languages.** Spanish, Hindi, Simplified Chinese, Brazilian Portuguese,
+  French and German, alongside English. Nothing has to be chosen: with no answer stored
+  Android already resolves every string against the device language, so a phone set to
+  Spanish opens a Spanish app on first launch.
+- **A language picker, under More.** For the person whose phone is in one language and who
+  wants the app in another, which is common on a shared or a work device. It opens as a
+  sheet of cards, two to a row, each naming the language in itself with the English
+  underneath: somebody hunting for their own language is looking for the word they would
+  write. Choosing a card does not change anything on its own. The heading says what the app
+  is in now and switches to what has been picked, and only Confirm commits it, because a
+  language is the one setting where a mis-tap leaves you unable to read the screen you would
+  use to undo it. A short note follows in the language just chosen.
+- **The app appears in the system language settings.** From Android 13 the platform owns the
+  per-app language, so the choice is stored by the system, sits beside every other app's,
+  and survives clearing the app's data. Below that the choice is kept by the app itself and
+  applied as each screen is built.
+
 ## [1.0.3] - 2026-09-02
 
 ### Added

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,11 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <!--
-         A download is minutes of network work the user has already asked for and walked
-         away from. Without a foreground service the system suspends it once the app stops
-         being visible, and kills it outright when the task is swiped away.
-    -->
+    
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
@@ -56,6 +52,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
+            android:configChanges="locale|layoutDirection"
             android:theme="@style/Theme.Hazel.Splash">
 
             <!-- Normal launcher -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
         android:label="@string/app_name"
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
+        android:localeConfig="@xml/locales_config"
         android:theme="@style/Theme.Hazel">
 
         <activity

--- a/app/src/main/java/com/hazel/android/MainActivity.kt
+++ b/app/src/main/java/com/hazel/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.hazel.android
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Process
@@ -24,6 +25,7 @@ import com.hazel.android.download.DownloadNotificationHelper
 import com.hazel.android.ui.navigation.AppNavigation
 import com.hazel.android.ui.screens.SplashScreen
 import com.hazel.android.ui.theme.HazelTheme
+import com.hazel.android.util.AppLocale
 import com.hazel.android.util.PermissionHelper
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -54,6 +56,17 @@ class MainActivity : ComponentActivity() {
     /** A failure the user tapped a notification to come back to, or null. */
     var pendingFailure by mutableStateOf<String?>(null)
         private set
+
+    /**
+     * Applies the chosen language before anything is inflated.
+     *
+     * Only Android 12 and earlier need this. From 13 the platform owns the per-app language
+     * and hands the activity a context that already has it, so [AppLocale.wrap] gives that
+     * one straight back rather than arguing with it.
+     */
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/hazel/android/ui/screens/more/LanguageDialog.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/LanguageDialog.kt
@@ -1,0 +1,180 @@
+package com.hazel.android.ui.screens.more
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.hazel.android.R
+import com.hazel.android.util.AppLocale
+
+/**
+ * The language picker.
+ *
+ * Each language is named in itself. Somebody hunting for their own language is looking for
+ * the word they would write, not the English for it, and a list of English names is no use
+ * to the person who most needs this screen. The English name sits underneath in smaller
+ * type, so anyone who arrived here by accident can find their way back.
+ *
+ * The list leads with the device's own choice, which is what the app does when nothing has
+ * been picked and the thing most people want if they ever come back to undo a decision.
+ *
+ * It scrolls rather than growing: the dialog is capped at roughly six rows so it stays a
+ * dialog on a small screen instead of running off the bottom of it.
+ */
+@Composable
+fun LanguageDialog(
+    current: String,
+    onPick: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                stringResource(R.string.language_title),
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            LazyColumn(
+                modifier = Modifier.heightIn(max = 420.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                item {
+                    LanguageRow(
+                        endonym = stringResource(R.string.language_system),
+                        english = stringResource(R.string.language_system_description),
+                        selected = current.isBlank(),
+                        onClick = { onPick(AppLocale.SYSTEM) }
+                    )
+                }
+                items(AppLocale.LANGUAGES, key = { it.tag }) { language ->
+                    LanguageRow(
+                        endonym = language.endonym,
+                        english = language.english,
+                        selected = current.equals(language.tag, ignoreCase = true),
+                        onClick = { onPick(language.tag) }
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.language_close))
+            }
+        }
+    )
+}
+
+@Composable
+private fun LanguageRow(
+    endonym: String,
+    english: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                endonym,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                color = if (selected) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            // Left out where it would only repeat the line above it, which is English and
+            // the device's own entry.
+            if (english != endonym) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    english,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        if (selected) {
+            Spacer(modifier = Modifier.width(12.dp))
+            Box(
+                modifier = Modifier
+                    .size(22.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Filled.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(15.dp),
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Said after the language is changed.
+ *
+ * On Android 13 and later the platform has already redrawn everything by the time this
+ * appears, so it confirms rather than warns. Below that the activity is rebuilt behind it,
+ * which is the same outcome by a different route, and either way a screen full of unfamiliar
+ * words is worth one sentence of explanation in the language just chosen.
+ */
+@Composable
+fun LanguageChangedDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                stringResource(R.string.language_changed_title),
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = { Text(stringResource(R.string.language_changed_body)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.language_changed_ok))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/hazel/android/ui/screens/more/LanguageDialog.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/LanguageDialog.kt
@@ -13,20 +13,29 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Icon
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -37,119 +46,185 @@ import com.hazel.android.util.AppLocale
 /**
  * The language picker.
  *
- * Each language is named in itself. Somebody hunting for their own language is looking for
- * the word they would write, not the English for it, and a list of English names is no use
- * to the person who most needs this screen. The English name sits underneath in smaller
- * type, so anyone who arrived here by accident can find their way back.
+ * A sheet rather than a dialog, and a grid of cards rather than a list of rows, because ten
+ * languages in one column is a scroll for something that fits on one screen in two. Each
+ * card names the language in itself with the English underneath: somebody hunting for their
+ * own language is looking for the word they would write, and a list of English names is no
+ * use to exactly the person who most needs this screen.
  *
- * The list leads with the device's own choice, which is what the app does when nothing has
- * been picked and the thing most people want if they ever come back to undo a decision.
- *
- * It scrolls rather than growing: the dialog is capped at roughly six rows so it stays a
- * dialog on a small screen instead of running off the bottom of it.
+ * Choosing a card does not change anything. The heading says what the app is in now, and
+ * switches to what has been picked, and only Confirm applies it. A language is the one
+ * setting where a mis-tap leaves you unable to read the screen you would use to undo it, so
+ * it is worth the extra tap.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LanguageDialog(
+fun LanguageSheet(
     current: String,
-    onPick: (String) -> Unit,
+    onConfirm: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
-    AlertDialog(
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // What is picked but not yet applied. It starts on whatever is in force, so opening the
+    // sheet and confirming without touching anything changes nothing.
+    var draft by remember(current) { mutableStateOf(current) }
+
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        title = {
-            Text(
-                stringResource(R.string.language_title),
-                fontWeight = FontWeight.Bold
-            )
-        },
-        text = {
-            LazyColumn(
-                modifier = Modifier.heightIn(max = 420.dp),
-                verticalArrangement = Arrangement.spacedBy(2.dp)
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Column {
+            // ── Heading, with the actions on the right ──
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 20.dp, end = 8.dp, top = 2.dp, bottom = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                item {
-                    LanguageRow(
-                        endonym = stringResource(R.string.language_system),
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        stringResource(R.string.language_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        if (draft == current) {
+                            stringResource(R.string.language_current, labelFor(current))
+                        } else {
+                            stringResource(R.string.language_selected, labelFor(draft))
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                TextButton(onClick = onDismiss) {
+                    Text(
+                        stringResource(R.string.language_cancel),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(2.dp))
+
+                Surface(
+                    onClick = { onConfirm(draft) },
+                    shape = RoundedCornerShape(10.dp),
+                    color = MaterialTheme.colorScheme.primary
+                ) {
+                    Text(
+                        stringResource(R.string.language_confirm),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
+                    )
+                }
+            }
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+
+            // ── The languages, two to a row ──
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                modifier = Modifier.heightIn(max = 460.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                    start = 18.dp, end = 18.dp, top = 16.dp, bottom = 28.dp
+                ),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item(key = AppLocale.SYSTEM) {
+                    LanguageCard(
+                        native = stringResource(R.string.language_system),
                         english = stringResource(R.string.language_system_description),
-                        selected = current.isBlank(),
-                        onClick = { onPick(AppLocale.SYSTEM) }
+                        selected = draft.isBlank(),
+                        onClick = { draft = AppLocale.SYSTEM }
                     )
                 }
                 items(AppLocale.LANGUAGES, key = { it.tag }) { language ->
-                    LanguageRow(
-                        endonym = language.endonym,
+                    LanguageCard(
+                        native = language.endonym,
                         english = language.english,
-                        selected = current.equals(language.tag, ignoreCase = true),
-                        onClick = { onPick(language.tag) }
+                        selected = draft.equals(language.tag, ignoreCase = true),
+                        onClick = { draft = language.tag }
                     )
                 }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.language_close))
-            }
         }
-    )
+    }
 }
 
+/**
+ * One language.
+ *
+ * The mark for the chosen one is a dot in the corner rather than a tick across the card: at
+ * this size a tick competes with the two lines of text, and the border and fill are already
+ * carrying the state. The dot is there for the case where a card is read on its own.
+ */
 @Composable
-private fun LanguageRow(
-    endonym: String,
+private fun LanguageCard(
+    native: String,
     english: String,
     selected: Boolean,
     onClick: () -> Unit
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.medium)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = if (selected) MaterialTheme.colorScheme.surfaceContainerHighest
+        else Color.Transparent,
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            if (selected) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.outlineVariant
+        ),
+        onClick = onClick
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                endonym,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                color = if (selected) MaterialTheme.colorScheme.primary
-                else MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            // Left out where it would only repeat the line above it, which is English and
-            // the device's own entry.
-            if (english != endonym) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(12.dp)) {
+                Text(
+                    native,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     english,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
             }
-        }
 
-        if (selected) {
-            Spacer(modifier = Modifier.width(12.dp))
-            Box(
-                modifier = Modifier
-                    .size(22.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    Icons.Filled.Check,
-                    contentDescription = null,
-                    modifier = Modifier.size(15.dp),
-                    tint = MaterialTheme.colorScheme.onPrimary
+            if (selected) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(10.dp)
+                        .size(7.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary)
                 )
             }
         }
     }
+}
+
+/** The name to show for a tag in the heading, which is the language in itself. */
+@Composable
+private fun labelFor(tag: String): String {
+    if (tag.isBlank()) return stringResource(R.string.language_system)
+    return AppLocale.LANGUAGES.firstOrNull { it.tag.equals(tag, ignoreCase = true) }?.endonym
+        ?: tag
 }
 
 /**

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -1,7 +1,10 @@
 package com.hazel.android.ui.screens.more
 
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.foundation.clickable
@@ -58,6 +61,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.compose.ui.text.font.FontWeight
 import com.hazel.android.download.formatFileSize
 import com.hazel.android.update.YtDlpUpdater
+import com.hazel.android.util.AppLocale
 import com.hazel.android.util.TempStorage
 
 @Composable
@@ -98,6 +102,43 @@ fun MoreScreen(
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // The language picker, and the note that follows a change. The label is read back from
+    // wherever the choice actually lives, which on Android 13 and later is the system rather
+    // than the app, so a change made in the system settings shows here too.
+    var languageDialogOpen by remember { mutableStateOf(false) }
+    var languageChanged by remember { mutableStateOf(false) }
+    var languageTag by remember { mutableStateOf(AppLocale.tag(context)) }
+    val languageLabel = AppLocale.label(context)
+
+    if (languageDialogOpen) {
+        LanguageDialog(
+            current = languageTag,
+            onPick = { tag ->
+                languageDialogOpen = false
+                if (tag != languageTag) {
+                    AppLocale.set(context, tag)
+                    languageTag = tag
+                    languageChanged = true
+                }
+            },
+            onDismiss = { languageDialogOpen = false }
+        )
+    }
+
+    if (languageChanged) {
+        LanguageChangedDialog(
+            onDismiss = {
+                languageChanged = false
+                // Android 13 and later has already redrawn everything in the new language.
+                // Below that nothing has changed yet, and rebuilding the activity is what
+                // makes the wrapped context take effect.
+                if (Build.VERSION.SDK_INT < 33) {
+                    (context as? Activity)?.recreate()
+                }
+            }
+        )
     }
 
     // yt-dlp engine version, as recorded by the last in-app engine update
@@ -204,6 +245,30 @@ fun MoreScreen(
                 },
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                 modifier = Modifier.clickable { onNavigateToAppearance() }
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant
+            )
+
+            // Language. It sits beside Appearance because both are about how the app looks
+            // rather than what it does, and it says the current choice on the right the way
+            // the temporary files row says its size.
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.more_language)) },
+                leadingContent = {
+                    Icon(Icons.Filled.Language, null, tint = MaterialTheme.colorScheme.primary)
+                },
+                trailingContent = {
+                    Text(
+                        languageLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                modifier = Modifier.clickable { languageDialogOpen = true }
             )
 
             HorizontalDivider(

--- a/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
+++ b/app/src/main/java/com/hazel/android/ui/screens/more/MoreScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.LaunchedEffect
@@ -108,15 +109,21 @@ fun MoreScreen(
     // wherever the choice actually lives, which on Android 13 and later is the system rather
     // than the app, so a change made in the system settings shows here too.
     var languageDialogOpen by remember { mutableStateOf(false) }
-    var languageChanged by remember { mutableStateOf(false) }
+    // Saved rather than merely remembered. Setting the language on Android 13 and later
+    // hands the work to the platform, which rebuilds the activity on the spot; a flag held
+    // only in composition dies with it, and the note that explains the change never
+    // appeared on exactly the versions where the change is most abrupt.
+    var languageChanged by rememberSaveable { mutableStateOf(false) }
     var languageTag by remember { mutableStateOf(AppLocale.tag(context)) }
     val languageLabel = AppLocale.label(context)
 
     if (languageDialogOpen) {
-        LanguageDialog(
+        LanguageSheet(
             current = languageTag,
-            onPick = { tag ->
+            onConfirm = { tag ->
                 languageDialogOpen = false
+                // Confirming without having picked anything different is a no-op, so the
+                // note that follows a change is not shown for a sheet that was only opened.
                 if (tag != languageTag) {
                     AppLocale.set(context, tag)
                     languageTag = tag

--- a/app/src/main/java/com/hazel/android/util/AppLocale.kt
+++ b/app/src/main/java/com/hazel/android/util/AppLocale.kt
@@ -1,0 +1,120 @@
+package com.hazel.android.util
+
+import android.app.LocaleManager
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Build
+import android.os.LocaleList
+import java.util.Locale
+
+/**
+ * Which language the app is shown in.
+ *
+ * Nothing has to be chosen. With no answer stored, Android resolves every string against the
+ * device language and picks the closest `values-xx` folder there is, falling back to English
+ * where there is none. The picker exists for the person whose phone is in one language and
+ * who wants the app in another, which is common enough on a shared or a work device.
+ *
+ * From Android 13 the platform owns this: the choice is stored by the system, appears in the
+ * system settings beside every other app, and survives an uninstall of the app's own data.
+ * Below that there is nowhere to put it but here, so the tag is written to preferences and
+ * the activity's context is wrapped with it as it is built.
+ *
+ * Preferences rather than the DataStore the rest of the settings use, and deliberately so:
+ * this is read in `attachBaseContext`, before anything can suspend, and DataStore has no
+ * answer to give at that point. One value, read once per activity, is what SharedPreferences
+ * is for.
+ */
+object AppLocale {
+
+    private const val PREFS = "hazel_locale"
+    private const val KEY_TAG = "language_tag"
+
+    /** The empty tag, which means the device decides. */
+    const val SYSTEM = ""
+
+    /**
+     * Every language the app ships, in the order the picker lists them.
+     *
+     * [endonym] is the language's name in itself, because a person looking for their own
+     * language is looking for the word they would write, not the English for it. [english]
+     * sits under it for anyone who arrived here by accident and needs to get back.
+     */
+    data class Language(val tag: String, val endonym: String, val english: String)
+
+    val LANGUAGES: List<Language> = listOf(
+        Language("en", "English", "English"),
+        Language("es", "Español", "Spanish"),
+        Language("zh-CN", "简体中文", "Chinese, Simplified"),
+        Language("hi", "हिन्दी", "Hindi"),
+        Language("pt-BR", "Português (Brasil)", "Portuguese, Brazil"),
+        Language("fr", "Français", "French"),
+        Language("ru", "Русский", "Russian"),
+        Language("de", "Deutsch", "German"),
+        Language("ja", "日本語", "Japanese"),
+        Language("in", "Bahasa Indonesia", "Indonesian")
+    )
+
+    /** The stored tag, or [SYSTEM] when the device is deciding. */
+    fun tag(context: Context): String {
+        if (Build.VERSION.SDK_INT >= 33) {
+            val system = context.getSystemService(LocaleManager::class.java)
+                ?.applicationLocales
+            if (system != null && !system.isEmpty) return system[0]?.toLanguageTag().orEmpty()
+            return SYSTEM
+        }
+        return prefs(context).getString(KEY_TAG, SYSTEM).orEmpty()
+    }
+
+    /**
+     * Records the choice.
+     *
+     * On Android 13 and later that is the whole of it: the platform re-creates what is on
+     * screen in the new language by itself. Below that the caller re-creates the activity,
+     * which is what makes the wrapping in [wrap] happen again.
+     */
+    fun set(context: Context, tag: String) {
+        if (Build.VERSION.SDK_INT >= 33) {
+            context.getSystemService(LocaleManager::class.java)?.applicationLocales =
+                if (tag.isBlank()) LocaleList.getEmptyLocaleList()
+                else LocaleList.forLanguageTags(tag)
+            return
+        }
+        prefs(context).edit().putString(KEY_TAG, tag).apply()
+    }
+
+    /**
+     * The context an activity should actually use, which below Android 13 is the given one
+     * with the chosen language applied.
+     *
+     * On 13 and later the platform has already done this, so the context arrives correct and
+     * is handed straight back. Wrapping it again there would only fight the system over which
+     * of two answers is the real one.
+     */
+    fun wrap(base: Context): Context {
+        if (Build.VERSION.SDK_INT >= 33) return base
+
+        val tag = prefs(base).getString(KEY_TAG, SYSTEM).orEmpty()
+        if (tag.isBlank()) return base
+
+        val locale = Locale.forLanguageTag(tag)
+        Locale.setDefault(locale)
+
+        val config = android.content.res.Configuration(base.resources.configuration)
+        config.setLocale(locale)
+        config.setLayoutDirection(locale)
+        return ContextWrapper(base.createConfigurationContext(config))
+    }
+
+    /** What to show as the current choice, for the row that opens the picker. */
+    fun label(context: Context): String {
+        val tag = tag(context)
+        if (tag.isBlank()) return context.getString(com.hazel.android.R.string.language_system)
+        return LANGUAGES.firstOrNull { it.tag.equals(tag, ignoreCase = true) }?.endonym
+        // A tag the app does not ship, which the system settings can still produce.
+            ?: Locale.forLanguageTag(tag).getDisplayName(Locale.forLanguageTag(tag))
+    }
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,559 @@
+<resources>
+    <string name="direct_share_label">Sofort</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">Start</string>
+    <string name="nav_history">Downloads</string>
+    <string name="nav_more">Mehr</string>
+    <string name="nav_incognito_on">Inkognito an, Downloads werden nicht aufgezeichnet</string>
+    <string name="nav_incognito_off">Inkognito aus</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">Suchen oder Link einfügen</string>
+    <string name="download_clear">Leeren</string>
+    <string name="download_show_large_artwork">Große Bilder zeigen</string>
+    <string name="download_show_list">Als Liste zeigen</string>
+    <string name="download_instant_source">Sofort · liest von %1$s</string>
+    <string name="download_incognito_title">Du bist inkognito</string>
+    <string name="download_incognito_body">Downloads landen nicht in deinem Verlauf und Links werden nicht gemerkt. Die Dateien werden wie gewohnt gespeichert.</string>
+    <string name="download_download_all">Alle herunterladen</string>
+    <string name="download_saved_aside">Deine Downloads sind gespeichert. Du findest sie im Tab Downloads.</string>
+    <string name="download_options">Download-Optionen</string>
+    <string name="download_pause">Pausieren</string>
+    <string name="download_resume">Fortsetzen</string>
+    <string name="download_cancel">Abbrechen</string>
+    <string name="download_paused">Pausiert</string>
+    <string name="download_processing">Wird verarbeitet</string>
+    <string name="download_waiting_wifi">Wartet auf WLAN</string>
+    <string name="download_saved">Gespeichert</string>
+    <string name="download_queued">In der Warteschlange</string>
+    <string name="download_downloaded">Heruntergeladen</string>
+    <string name="download_failed">Fehlgeschlagen</string>
+    <string name="download_remove_link">Link entfernen</string>
+    <string name="download_cancel_action">Download abbrechen</string>
+    <string name="download_resume_action">Download fortsetzen</string>
+    <plurals name="download_links">
+        <item quantity="one">%d Link</item>
+        <item quantity="other">%d Links</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">Suchen oder Link einfügen</string>
+    <string name="search_back">Zurück</string>
+    <string name="search_more">Mehr</string>
+    <string name="search_add_link">Noch einen Link hinzufügen</string>
+    <string name="search_clear">Löschen</string>
+    <string name="search_clear_results">Ergebnisse leeren</string>
+    <string name="search_clear_history">Suchverlauf löschen</string>
+    <string name="search_empty_history">Links, die du benutzt, erscheinen hier</string>
+    <string name="search_no_matches">Kein Link passt dazu</string>
+    <string name="search_remove">Entfernen</string>
+    <string name="search_all">Alle suchen</string>
+    <string name="search_forget">Vergessen</string>
+    <string name="search_edit_before">Vor dem Suchen bearbeiten</string>
+    <string name="search_paste_and_fetch">Einfügen und laden</string>
+    <string name="search_nothing_to_paste">Nichts zum Einfügen da</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">Schon heruntergeladen</string>
+    <string name="already_downloaded_body">Dieser Link ist bereits auf diesem Gerät gespeichert.</string>
+    <string name="already_downloaded_video">Video</string>
+    <string name="already_downloaded_audio">Audio</string>
+    <string name="already_downloaded_keep">Behalten</string>
+    <string name="already_downloaded_play">Abspielen</string>
+    <string name="already_downloaded_download_again">Noch einmal herunterladen</string>
+    <string name="already_downloaded_just_now">Gerade eben</string>
+    <string name="already_downloaded_yesterday">Gestern</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="one">%d Min.</item>
+        <item quantity="other">%d Min.</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="one">%d Std.</item>
+        <item quantity="other">%d Std.</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="one">%d Tag</item>
+        <item quantity="other">%d Tage</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="one">%d Mon.</item>
+        <item quantity="other">%d Mon.</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">Anmeldung nötig</string>
+    <string name="no_results_error_title">Dieser Link ließ sich nicht lesen</string>
+    <string name="no_results_sign_in_body">Die Quelle verlangt ein Konto, bevor sie das herausgibt. Beim Anmelden werden die Cookies der Seite gespeichert und es wird erneut versucht.</string>
+    <string name="no_results_continue_body">Die Details ließen sich nicht lesen, der Download selbst kann aber trotzdem klappen. Wer weitermacht, bekommt die beste verfügbare Qualität.</string>
+    <string name="no_results_refused_body">Die Quelle hat die Anfrage abgelehnt.</string>
+    <string name="no_results_engine_report">Was die Engine gemeldet hat</string>
+    <string name="no_results_copy_log">Protokoll kopieren</string>
+    <string name="no_results_sign_in">Anmelden</string>
+    <string name="no_results_try_anyway">Trotzdem versuchen</string>
+    <string name="no_results_close">Schließen</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">Erste Schritte</string>
+    <string name="guide_step_paste_link">Füge einen Link ins Suchfeld ein, um ihn herunterzuladen. Du kannst mehrere Links und Playlists hinzufügen</string>
+    <string name="guide_step_pick_format">Tippe eine Karte an, um das genaue Format zu wählen. Alle verfügbaren Qualitäten stehen mit Größe und Codec dabei.</string>
+    <string name="guide_step_share_instant">Teile aus jeder App einen Link mit Hazel Sofort, um ihn gleich in der von dir eingestellten Qualität herunterzuladen.</string>
+    <string name="guide_step_finished_downloads">Fertige Dateien erscheinen unter Downloads. Tippe eine Zeile an, um sie im Standardplayer des Geräts zu öffnen.</string>
+    <string name="guide_step_battery_unrestricted">Stelle die Akkunutzung auf uneingeschränkt, sonst kann Android Downloads stoppen, sobald du die App verlässt.</string>
+    <string name="guide_battery_settings">Akku-Einstellungen</string>
+    <string name="guide_close">Schließen</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">Herunterladen</string>
+    <string name="format_sheet_subtitle">Download anpassen</string>
+    <string name="format_sheet_play">Abspielen</string>
+    <string name="format_sheet_ok">OK</string>
+    <string name="format_sheet_download">Herunterladen</string>
+    <string name="format_sheet_tab_audio">Audio</string>
+    <string name="format_sheet_tab_video">Video</string>
+    <string name="format_sheet_label_title">Titel</string>
+    <string name="format_sheet_label_author">Urheber</string>
+    <string name="format_sheet_label_container">Container</string>
+    <string name="format_sheet_video_quality">Videoqualität</string>
+    <string name="format_sheet_audio_quality">Audioqualität</string>
+    <string name="format_sheet_no_video_stream">Diese Quelle hat keine eigene Videospur.</string>
+    <string name="format_sheet_no_audio_stream">Diese Quelle hat keine eigene Audiospur.</string>
+    <string name="format_sheet_adjust_video">Video anpassen</string>
+    <string name="format_sheet_adjust_audio">Audio anpassen</string>
+    <string name="format_sheet_thumbnail">Vorschaubild</string>
+    <string name="format_sheet_chapters">Kapitel</string>
+    <string name="format_sheet_subtitles">Untertitel</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">Audiosprache</string>
+    <string name="format_sheet_change_audio_language">Audiosprache ändern</string>
+    <string name="format_sheet_filename_template">Dateinamen-Vorlage</string>
+    <string name="format_sheet_change_field">Ändern</string>
+    <string name="format_sheet_save_dir">Ordner</string>
+    <string name="format_sheet_save_location">Speicherort</string>
+    <string name="format_sheet_save_location_title">Speicherort</string>
+    <string name="format_sheet_save_location_body">Öffne diesen Ordner in deinem Dateimanager, oder wähle einen anderen für deine Downloads.</string>
+    <string name="format_sheet_open_folder">Ordner öffnen</string>
+    <string name="format_sheet_reset">Zurücksetzen</string>
+    <string name="format_sheet_change">Ändern</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">Umwandeln in</string>
+    <string name="converter_label_saved_to">Gespeichert in</string>
+    <string name="converter_hazel_storage">Hazels eigener Speicher</string>
+    <string name="converter_storage_warning">Ohne Speicherzugriff bleibt die Datei in Hazel, wo andere Apps sie nicht sehen können.</string>
+    <string name="converter_back">Zurück</string>
+    <string name="converter_title">Offline-Konverter</string>
+    <string name="converter_subtitle">Video zu Audio, nichts verlässt das Telefon</string>
+    <string name="converter_choose_video">Wähle eine Videodatei</string>
+    <string name="converter_ready">Bereit</string>
+    <string name="converter_choose_video_hint">Alles vom Telefon oder von einer SD-Karte</string>
+    <string name="converter_change">Ändern</string>
+    <string name="converter_converting">Wird umgewandelt</string>
+    <string name="converter_convert">Umwandeln</string>
+    <string name="converter_saved">Gespeichert</string>
+    <string name="converter_open_folder">Ordner öffnen</string>
+    <string name="converter_convert_another">Noch eins umwandeln</string>
+    <string name="converter_error_title">Das ließ sich nicht umwandeln</string>
+    <string name="converter_dismiss">Schließen</string>
+    <string name="converter_save_as_title">Speichern unter</string>
+    <string name="converter_save_as_body">Benennt die Datei, und wird auch in ihr Titel-Tag geschrieben.</string>
+    <string name="converter_label_name">Name</string>
+    <string name="converter_start">Starten</string>
+    <string name="converter_format_sheet_title">Umwandeln in</string>
+    <string name="converter_heading_common">Die drei, die sich lohnen</string>
+    <string name="converter_heading_other">Alles andere</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">Mehr</string>
+    <string name="more_battery_title">Downloads im Hintergrund</string>
+    <string name="more_battery_body">Downloads laufen im Hintergrund von allein weiter. Manche Telefone brechen sie trotzdem ab, um Akku zu sparen. Erlaube uneingeschränkte Nutzung, um das auszuschließen.</string>
+    <string name="more_downloads">Downloads</string>
+    <string name="more_appearance">Erscheinungsbild</string>
+    <string name="more_language">Sprache</string>
+    <string name="more_cookies">Cookies</string>
+    <string name="more_link_reading">Links lesen</string>
+    <string name="more_hazel_instant">Hazel Sofort</string>
+    <string name="more_temporary_files">Temporäre Dateien</string>
+    <string name="more_converter">Video offline in Audio umwandeln</string>
+    <string name="more_engine_update">yt-dlp-Engine aktualisieren</string>
+    <string name="more_support">Hazel unterstützen</string>
+    <string name="more_license">Lizenz</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">Zurück</string>
+    <string name="sponsor_title">Hazel unterstützen</string>
+    <string name="sponsor_hero_title">Kostenlos, und das bleibt so</string>
+    <string name="sponsor_hero_body">Hazel entsteht an Abenden und Wochenenden und wird verschenkt, weil ein Downloader, der für das Herunterladen Geld nimmt, ein schlechterer Downloader ist. Seiten ändern sich ständig, und mit ihnen Schritt zu halten ist die eigentliche Arbeit.</string>
+    <string name="sponsor_hero_closing">Wenn dir die App einen Nachmittag gespart hat, gibt jede der Möglichkeiten unten diese Zeit zurück. Wenn nicht, helfen die kostenlosen Wege genauso viel.</string>
+    <string name="sponsor_section_ways">Möglichkeiten zu unterstützen</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">Monatlich oder einmalig, jederzeit kündbar. Wird komplett von GitHub abgewickelt.</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">Einmalig, ganz ohne Konto.</string>
+    <string name="sponsor_kofi_soon">Öffnet bald</string>
+    <string name="sponsor_section_free">Kostet nichts, hilft genauso</string>
+    <string name="sponsor_star_title">Gib dem Projekt einen Stern</string>
+    <string name="sponsor_star_subtitle">Die eine Zahl, auf die Leute schauen, bevor sie eine App ausprobieren.</string>
+    <string name="sponsor_share_title">Erzähl jemandem davon</string>
+    <string name="sponsor_share_subtitle">Mundpropaganda ist das gesamte Marketing dieser App.</string>
+    <string name="sponsor_issues_title">Melde, was kaputtgeht</string>
+    <string name="sponsor_issues_subtitle">Eine Seite, die nicht mehr funktioniert, ist ein Fix, den sonst niemand schreiben kann.</string>
+    <string name="sponsor_source_title">Lies den Quellcode</string>
+    <string name="sponsor_source_subtitle">Jede Zeile davon ist öffentlich, und Pull Requests sind willkommen.</string>
+    <string name="sponsor_footer">Keine Werbung, nichts wird darüber gemessen, was du herunterlädst, und keine Funktion bleibt jemandem vorbehalten. Unterstützung ändert, wie viel Zeit in Hazel fließt, nicht was es für dich tut.</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">yt-dlp-Update</string>
+    <string name="update_back">Zurück</string>
+    <string name="update_check_action">Nach Updates suchen</string>
+    <string name="update_status_up_to_date">Du bist auf dem neuesten Stand</string>
+    <string name="update_status_checking">Suche nach Updates...</string>
+    <string name="update_status_available">Update verfügbar</string>
+    <string name="update_status_installing">yt-dlp wird installiert...</string>
+    <string name="update_status_installed">Engine aktualisiert</string>
+    <string name="update_status_failed">Update fehlgeschlagen</string>
+    <string name="update_subtitle_idle">Hazel nutzt den neuesten yt-dlp-Build</string>
+    <string name="update_subtitle_checking">Verbinde mit GitHub...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s ist verfügbar</string>
+    <string name="update_subtitle_updating">yt-dlp %1$s wird geladen</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s ist jetzt im Einsatz</string>
+    <string name="update_installed_version">Installierte Version</string>
+    <string name="update_version_unknown">Unbekannt</string>
+    <string name="update_new_version">Neue Version</string>
+    <string name="update_installing_binary">Binary wird installiert</string>
+    <string name="update_installing_body">Wird von GitHub geladen und ersetzt die Engine. Lass die App offen.</string>
+    <string name="update_action_update_now">Jetzt aktualisieren</string>
+    <string name="update_action_installing">Wird installiert...</string>
+    <string name="update_action_done">Fertig</string>
+    <string name="update_action_retry">Erneut versuchen</string>
+    <string name="update_action_check">Nach Updates suchen</string>
+    <string name="update_action_checking">Suche läuft...</string>
+    <string name="update_info_heading">Informationen</string>
+    <string name="update_info_component">Komponente</string>
+    <string name="update_info_repository">Repository</string>
+    <string name="update_info_binary_size">Größe des Binaries</string>
+    <string name="update_info_distribution">Vertrieb</string>
+    <string name="update_info_github_releases">GitHub Releases</string>
+    <string name="update_release_channel">Release-Kanal</string>
+    <string name="update_view_changelog">Änderungsprotokoll ansehen</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">SponsorBlock-Filterung wählen</string>
+    <string name="options_sponsorblock_ok">OK</string>
+    <string name="options_sponsorblock_cancel">Abbrechen</string>
+    <string name="options_chapters_title">Kapitel</string>
+    <string name="options_chapters_in_videos">Kapitel in Videos</string>
+    <string name="options_chapters_split">Nach Kapiteln aufteilen</string>
+    <string name="options_chapters_split_body">Beim Aufteilen wird pro Kapitel eine Datei geschrieben statt einer einzigen.</string>
+    <string name="options_chapters_dismiss">Schließen</string>
+    <string name="options_subtitles_title">Untertitel</string>
+    <string name="options_subtitles_embed">Untertitel einbetten</string>
+    <string name="options_subtitles_save">Untertitel speichern</string>
+    <string name="options_subtitles_save_auto">Automatische Untertitel speichern</string>
+    <string name="options_subtitles_languages_label">Untertitelsprachen</string>
+    <string name="options_subtitles_dismiss">Schließen</string>
+    <string name="options_subtitles_languages_title">Untertitelsprachen</string>
+    <string name="options_subtitles_languages_hint">Ein yt-dlp-Sprachfilter, zum Beispiel en.*,.*-orig für Englisch plus die Originalspur. Nimm all für jede Sprache, die die Quelle anbietet.</string>
+    <string name="options_filename_title">Dateinamen-Vorlage</string>
+    <string name="options_filename_hint">yt-dlp-Ausgabevorlage. Nutze %(title)s, %(uploader)s, %(id)s und %(ext)s.</string>
+    <string name="options_text_input_save">Speichern</string>
+    <string name="options_text_input_cancel">Abbrechen</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">Zurück</string>
+    <string name="cleanup_title">Temporäre Dateien</string>
+    <string name="cleanup_header_description">Arbeitsdateien, die die App behält. Deine Downloads gehören nicht dazu und werden von hier nie entfernt.</string>
+    <string name="cleanup_action_clear_everything">Alles löschen</string>
+    <string name="cleanup_category_link_data_label">Cache der Linkdaten</string>
+    <string name="cleanup_category_link_data_description">Player-Daten, die yt-dlp behält, damit ein zweites Lesen desselben Links schneller geht. Kann bedenkenlos gelöscht werden.</string>
+    <string name="cleanup_category_partial_downloads_label">Unfertige Downloads</string>
+    <string name="cleanup_category_partial_downloads_description">Bruchstücke von Downloads, die abgebrochen sind oder fehlschlugen, bevor die Datei gespeichert war.</string>
+    <string name="cleanup_category_conversions_label">Unfertige Umwandlungen</string>
+    <string name="cleanup_category_conversions_description">Arbeitsdateien des Audio-Konverters, die es nie in deinen Musikordner geschafft haben.</string>
+    <string name="cleanup_category_engine_label">Dateien der yt-dlp-Engine</string>
+    <string name="cleanup_category_engine_description">Der Downloader und seine Laufzeitumgebung. Löschen bringt am meisten Platz, aber der nächste Download muss sie erneut entpacken.</string>
+    <string name="cleanup_category_other_cache_label">Andere zwischengespeicherte Dateien</string>
+    <string name="cleanup_category_other_cache_description">Vorschaubilder und alles andere, was beim Durchsehen von Links zwischengespeichert wurde.</string>
+    <string name="cleanup_confirm_category_title">Diese Dateien löschen?</string>
+    <string name="cleanup_confirm_category_safe">%1$s werden frei. Nichts von dem, was du gespeichert hast, ist betroffen.</string>
+    <string name="cleanup_confirm_category_unsafe">%1$s werden frei, und der nächste Download dauert länger, während sie erneut entpackt werden.</string>
+    <string name="cleanup_confirm_clear">Löschen</string>
+    <string name="cleanup_confirm_cancel">Abbrechen</string>
+    <string name="cleanup_confirm_all_title">Alles löschen?</string>
+    <string name="cleanup_confirm_all_body">%1$s werden frei. Deine Downloads und gespeicherten Anmeldungen bleiben erhalten, aber der nächste Download dauert länger, während die Engine erneut entpackt wird.</string>
+    <string name="cleanup_confirm_all_confirm">Alles löschen</string>
+    <string name="cleanup_confirm_all_cancel">Abbrechen</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">Downloads</string>
+    <string name="history_layout_grid">Große Bilder zeigen</string>
+    <string name="history_layout_list">Als Liste zeigen</string>
+    <string name="history_search_action">Downloads durchsuchen</string>
+    <string name="history_sort_action">Sortieren</string>
+    <string name="history_menu_action">Mehr</string>
+    <string name="history_menu_clear">Verlauf löschen</string>
+    <string name="history_search_placeholder">Downloads durchsuchen</string>
+    <string name="history_search_clear">Suche löschen</string>
+    <string name="history_empty_initial">Noch nichts heruntergeladen</string>
+    <string name="history_empty_filtered">Nichts passt dazu</string>
+    <string name="history_clear_dialog_title">Verlauf löschen</string>
+    <string name="history_clear_dialog_body">Die Liste wird geleert. Deine heruntergeladenen Dateien bleiben unangetastet.</string>
+    <string name="history_clear_dialog_confirm">Löschen</string>
+    <string name="history_clear_dialog_cancel">Abbrechen</string>
+    <string name="history_delete_dialog_title">Datei löschen</string>
+    <string name="history_delete_dialog_body">%1$s wird von deinem Gerät gelöscht.</string>
+    <string name="history_toast_file_deleted">Datei gelöscht</string>
+    <string name="history_toast_file_delete_failed">Die Datei ließ sich nicht löschen</string>
+    <string name="history_delete_dialog_confirm">Löschen</string>
+    <string name="history_delete_dialog_cancel">Abbrechen</string>
+    <string name="history_card_options">Optionen</string>
+    <string name="history_card_properties">Eigenschaften</string>
+    <string name="history_card_remove">Aus der Liste entfernen</string>
+    <string name="history_card_delete">Datei löschen</string>
+    <string name="history_tag_deleted">Gelöscht</string>
+    <string name="history_row_options">Optionen</string>
+    <string name="history_row_properties">Eigenschaften</string>
+    <string name="history_row_remove">Aus der Liste entfernen</string>
+    <string name="history_row_delete">Datei löschen</string>
+    <string name="history_toast_file_gone">Diese Datei ist nicht mehr auf deinem Gerät</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">Eigenschaften</string>
+    <string name="properties_status">Status</string>
+    <string name="properties_status_present">Auf diesem Gerät</string>
+    <string name="properties_status_deleted">Von diesem Gerät gelöscht</string>
+    <string name="properties_kind">Art</string>
+    <string name="properties_kind_video">Video</string>
+    <string name="properties_kind_audio">Audio</string>
+    <string name="properties_quality">Qualität</string>
+    <string name="properties_resolution">Auflösung</string>
+    <string name="properties_length">Länge</string>
+    <string name="properties_codec">Codec</string>
+    <string name="properties_bitrate">Bitrate</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">Größe</string>
+    <string name="properties_container">Container</string>
+    <string name="properties_type">Format</string>
+    <string name="properties_embedded">Eingebettet</string>
+    <string name="properties_file">Datei</string>
+    <string name="properties_saved_to">Gespeichert in</string>
+    <string name="properties_downloaded">Heruntergeladen</string>
+    <string name="properties_source">Quelle</string>
+    <string name="properties_link_copied_opened">Link kopiert und geöffnet</string>
+    <string name="properties_link_copied">Link kopiert</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">Zurück</string>
+    <string name="cookies_title">Cookies</string>
+    <string name="cookies_menu">Mehr</string>
+    <string name="cookies_menu_import">Aus der Zwischenablage einlesen</string>
+    <string name="cookies_menu_export">In die Zwischenablage exportieren</string>
+    <string name="cookies_menu_delete_all">Alle löschen</string>
+    <string name="cookies_imported_title">Eingelesene Cookies</string>
+    <string name="cookies_toast_imported">Cookies eingelesen</string>
+    <string name="cookies_toast_no_data">In der Zwischenablage stehen keine Cookie-Daten</string>
+    <string name="cookies_toast_nothing_to_export">Nichts zum Exportieren da</string>
+    <string name="cookies_toast_exported">In die Zwischenablage kopiert</string>
+    <string name="cookies_toast_entry_copied">In die Zwischenablage kopiert</string>
+    <string name="cookies_use_title">Cookies verwenden</string>
+    <string name="cookies_use_description">Gespeicherte Anmeldungen an den Downloader geben</string>
+    <string name="cookies_new">Neues Cookie</string>
+    <string name="cookies_empty_title">Keine Cookies gespeichert</string>
+    <string name="cookies_empty_body">Füge eines hinzu, um Inhalte mit Altersfreigabe, private oder nur für Mitglieder herunterzuladen.</string>
+    <string name="cookies_delete_title">Cookies löschen</string>
+    <string name="cookies_delete_body">Die gespeicherte Anmeldung für %1$s entfernen?</string>
+    <string name="cookies_delete_confirm">Löschen</string>
+    <string name="cookies_delete_cancel">Abbrechen</string>
+    <string name="cookies_delete_all_title">Alle Cookies löschen</string>
+    <string name="cookies_delete_all_body">Jede gespeicherte Anmeldung wird entfernt. Das lässt sich nicht rückgängig machen.</string>
+    <string name="cookies_delete_all_confirm">Alle löschen</string>
+    <string name="cookies_delete_all_cancel">Abbrechen</string>
+    <string name="cookies_row_fallback_name">Cookies</string>
+    <string name="cookies_sheet_title">Cookies</string>
+    <string name="cookies_sheet_copy">Cookies kopieren</string>
+    <string name="cookies_sheet_delete">Cookies löschen</string>
+    <string name="cookies_field_title">Titel</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">Speichern</string>
+    <string name="cookies_sheet_get">Cookies holen</string>
+    <string name="cookies_sheet_update">Aktualisieren</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">Beste Qualität</string>
+    <string name="batch_type_sheet_title">Bevorzugte Download-Art</string>
+    <string name="batch_type_sheet_subtitle">Als was diese Links heruntergeladen werden</string>
+    <string name="batch_type_audio">Audio</string>
+    <string name="batch_type_video">Video</string>
+    <string name="batch_format_title">Format</string>
+    <string name="batch_format_subtitle">Format wählen</string>
+    <string name="batch_container_title">Container</string>
+    <string name="batch_container_subtitle">Die Datei, als die diese Links gespeichert werden</string>
+    <string name="batch_save_dir_title">Speicherort</string>
+    <string name="batch_open_folder">Diesen Ordner öffnen</string>
+    <string name="batch_change_folder">Ordner wechseln</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">Vorschaubild</string>
+    <string name="batch_bar_chapters">Kapitel</string>
+    <string name="batch_bar_subtitles">Untertitel</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">Dateinamen-Vorlage</string>
+    <string name="batch_bar_download_type">Bevorzugte Download-Art</string>
+    <string name="batch_bar_quality">Qualität: %1$s</string>
+    <string name="batch_bar_save_location">Speicherort</string>
+    <string name="batch_bar_container">Container</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">Herunterladen</string>
+    <string name="batch_header_subtitle">Download anpassen</string>
+    <string name="batch_download_action">Herunterladen</string>
+    <string name="batch_stop_selecting">Auswahl beenden</string>
+    <string name="batch_start_selecting">Links auswählen</string>
+    <string name="batch_list_options">Listenoptionen</string>
+    <string name="batch_menu_select_links">Links auswählen</string>
+    <string name="batch_menu_select_all">Alle auswählen</string>
+    <string name="batch_menu_invert">Auswahl umkehren</string>
+    <string name="batch_menu_remove_selected">Ausgewählte entfernen</string>
+    <string name="batch_menu_done">Fertig</string>
+    <plurals name="batch_selected">
+        <item quantity="one">%d ausgewählt</item>
+        <item quantity="other">%d ausgewählt</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="one">%d Link</item>
+        <item quantity="other">%d Links</item>
+    </plurals>
+    <string name="batch_card_download_type">Download-Art für diesen Link</string>
+    <string name="batch_card_remove">Entfernen</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">Wo diese Datei liegt, ist unbekannt</string>
+    <string name="media_open_chooser">Öffnen mit</string>
+    <string name="media_open_no_app">Nichts auf diesem Gerät kann sie öffnen</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">Download abgebrochen</string>
+    <string name="notification_channel_progress_description">Download-Fortschritt, zeigt ein Symbol in der Statusleiste</string>
+    <string name="notification_channel_complete_description">Hinweise auf abgeschlossene Downloads</string>
+    <string name="notification_action_pause">Pausieren</string>
+    <string name="notification_action_resume">Fortsetzen</string>
+    <string name="notification_action_cancel">Abbrechen</string>
+    <string name="notification_action_sign_in">Anmelden</string>
+    <string name="notification_wifi_title">Wartet auf WLAN</string>
+    <string name="notification_wifi_text">Downloads sind auf WLAN beschränkt. Sie starten, sobald du wieder im WLAN bist.</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">Schließen</string>
+    <string name="cookie_webview_desktop_site">Desktop-Version</string>
+    <string name="cookie_webview_no_cookies">Es wurden keine Cookies gesammelt</string>
+    <string name="cookie_webview_done">"  OK"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">Formate sortieren</string>
+    <string name="format_selection_change">Format wechseln</string>
+    <string name="format_selection_title">Format</string>
+    <string name="format_selection_subtitle">Format wählen</string>
+    <string name="format_selection_confirm">OK</string>
+    <string name="format_selection_loading">Die übrigen Formate werden gelesen</string>
+    <string name="format_sort_quality">Qualität</string>
+    <string name="format_sort_file_size">Dateigröße</string>
+    <string name="format_sort_container">Container</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">Audiosprache</string>
+    <string name="audio_language_subtitle">Tonspur wählen</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">Zurück</string>
+    <string name="appearance_title">Erscheinungsbild</string>
+
+    <!-- Language picker -->
+    <string name="language_title">Sprache</string>
+    <string name="language_system">Systemsprache</string>
+    <string name="language_system_description">Der Sprache des Geräts folgen</string>
+    <string name="language_close">Schließen</string>
+    <string name="language_changed_title">Sprache geändert</string>
+    <string name="language_changed_body">Hazel ist jetzt in dieser Sprache. Was noch nicht übersetzt ist, bleibt auf Englisch.</string>
+    <string name="language_changed_ok">OK</string>
+    <string name="appearance_dark_theme">Dunkles Design</string>
+    <string name="appearance_accent_color">Akzentfarbe</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">Akzentfarbe</string>
+    <string name="accent_picker_close">Schließen</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">Zurück</string>
+    <string name="fetch_settings_title">Links lesen</string>
+    <string name="fetch_settings_timeout_description">Wie lange auf eine langsame Quelle gewartet wird, bevor aufgegeben und neu versucht wird.</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="one">%1$ds Wartezeit, %2$d Versuch</item>
+        <item quantity="other">%1$ds Wartezeit, %2$d Versuche</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">Links lesen</string>
+    <string name="fetch_settings_reading_links_description">Welcher Leser herausfindet, was hinter einem Link steckt. Heruntergeladen wird immer mit yt-dlp, egal was hier gewählt ist.</string>
+    <string name="fetch_settings_force_ipv4_description">Schalte das nur ein, wenn Links in deinem Netz hängen bleiben. Es umgeht eine kaputte IPv6-Route und ist überall sonst langsamer.</string>
+    <string name="fetch_settings_force_ipv4">IPv4 erzwingen</string>
+    <string name="fetch_mode_fast_label">Schnell</string>
+    <string name="fetch_mode_fast_description">Gibt früh auf. Am schnellsten in einem guten Netz, braucht aber öfter einen zweiten Versuch.</string>
+    <string name="fetch_mode_balanced_label">Ausgewogen</string>
+    <string name="fetch_mode_balanced_description">Ein Mittelweg zwischen Tempo und dem Aushalten einer schlechten Verbindung.</string>
+    <string name="fetch_mode_thorough_label">Gründlich</string>
+    <string name="fetch_mode_thorough_description">Wartet länger und versucht es öfter. Am langsamsten, übersteht aber ein schwaches Netz.</string>
+    <string name="listing_source_ytdlp_description">Dieselbe Engine, die auch herunterlädt. Sie funktioniert auf jeder Seite, die sie unterstützt, und aktualisiert sich selbst, also läuft sie weiter, während sich Seiten ändern.</string>
+    <string name="listing_source_newpipe_label">Den eingebauten Leser bevorzugen</string>
+    <string name="listing_source_newpipe_description">Listet Playlists und Kanäle in einer einzigen Anfrage, statt die Engine zu starten, was auf den ihm bekannten Seiten schneller ist. Für alles andere und immer dann, wenn er einen Link nicht lesen kann, greift er auf yt-dlp zurück.</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">Zurück</string>
+    <string name="tools_title">Werkzeuge</string>
+    <string name="tools_empty">Hier ist noch nichts.</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">Zurück</string>
+    <string name="direct_share_save_as">Speichern als</string>
+    <string name="direct_share_video">Video</string>
+    <string name="direct_share_audio_only">Nur Audio</string>
+    <string name="direct_share_title">Hazel Sofort</string>
+    <string name="direct_share_intro">Einen Link mit Hazel Sofort zu teilen startet den Download sofort, ohne Fenster und ohne Rückfragen. Das sind die Antworten, die es dabei verwendet.</string>
+    <string name="direct_share_video_description">Bild und Ton, zu einer Datei zusammengefügt.</string>
+    <string name="direct_share_audio_description">Nur der Ton, im Besten, was die Quelle hergibt.</string>
+    <string name="direct_share_quality_title">Qualitätsgrenze</string>
+    <string name="direct_share_quality_description">Eine Obergrenze, keine feste Größe. Nicht alle Quellen bieten dieselben Höhen an, also wird die größte genommen, die darunter passt, und die kleinste verfügbare, wenn keine passt.</string>
+    <string name="direct_share_output_title">Ausgabe</string>
+    <string name="direct_share_output_description">Die Datei, die auf dem Gerät landet. Standard behält, was die Quelle ohnehin liefert, und das ist die schnellste Wahl, weil nichts neu kodiert wird.</string>
+    <string name="direct_share_filename_template">Dateinamen-Vorlage</string>
+    <string name="direct_share_audio_language">Audiosprache</string>
+    <string name="direct_share_audio_language_default">Die der Quelle</string>
+    <string name="direct_share_extras_title">Extras</string>
+    <string name="direct_share_extras_description">Werden angewandt, wenn die Quelle sie hat. Was sie nicht hat, wird bei dem Download übersprungen, statt ihn scheitern zu lassen.</string>
+    <string name="direct_share_cover_art">Coverbild</string>
+    <string name="direct_share_cover_art_description">Schreibt das Vorschaubild in die Datei, sofern der Container eines aufnehmen kann.</string>
+    <string name="direct_share_chapters">Kapitel</string>
+    <string name="direct_share_subtitles">Untertitel</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">Aus</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="one">%1$d Kategorie herausgeschnitten</item>
+        <item quantity="other">%1$d Kategorien herausgeschnitten</item>
+    </plurals>
+    <string name="direct_share_signins_title">Anmeldungen</string>
+    <string name="direct_share_signins_description">Ein Sofort-Teilen nutzt die gespeicherten Cookies der Seite, zu der der Link gehört, genau wie ein Download aus dem Fenster. Beim Teilen wird nichts gefragt, ein Link hinter einer Anmeldung funktioniert also nur, wenn diese schon gespeichert und eingeschaltet ist.</string>
+    <string name="direct_share_cookies">Cookies</string>
+    <string name="direct_share_cookies_on">An, wird bei jedem Sofort-Teilen genutzt</string>
+    <string name="direct_share_cookies_off">Aus</string>
+    <string name="direct_share_change">%1$s ändern</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">Zurück</string>
+    <string name="storage_locations_downloads">Downloads</string>
+    <string name="storage_locations_title">Downloads</string>
+    <string name="storage_locations_subtitle">Wo Downloads gespeichert werden, und unter welchen Grenzen sie laufen</string>
+    <string name="storage_locations_limits">Grenzen</string>
+    <string name="storage_locations_wifi_only_description">Downloads warten, statt über mobile Daten zu laufen</string>
+    <string name="storage_locations_speed_limit_description">Wie schnell ein Download laufen darf</string>
+    <string name="storage_locations_internal_note">Alle Dateien liegen im internen Speicher deines Geräts. Du kommst jederzeit mit jedem Dateimanager an sie heran.</string>
+    <string name="storage_locations_wifi_only">Nur WLAN</string>
+    <string name="storage_locations_speed_limit">Geschwindigkeitsgrenze</string>
+
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -468,10 +468,13 @@
     <string name="appearance_title">Erscheinungsbild</string>
 
     <!-- Language picker -->
-    <string name="language_title">Sprache</string>
+    <string name="language_title">App-Sprache</string>
     <string name="language_system">Systemsprache</string>
-    <string name="language_system_description">Der Sprache des Geräts folgen</string>
-    <string name="language_close">Schließen</string>
+    <string name="language_system_description">Dem Gerät folgen</string>
+    <string name="language_current">Aktuell: %1$s</string>
+    <string name="language_selected">Gewählt: %1$s</string>
+    <string name="language_cancel">Abbrechen</string>
+    <string name="language_confirm">Bestätigen</string>
     <string name="language_changed_title">Sprache geändert</string>
     <string name="language_changed_body">Hazel ist jetzt in dieser Sprache. Was noch nicht übersetzt ist, bleibt auf Englisch.</string>
     <string name="language_changed_ok">OK</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -475,10 +475,13 @@
     <string name="appearance_title">Apariencia</string>
 
     <!-- Language picker -->
-    <string name="language_title">Idioma</string>
+    <string name="language_title">Idioma de la aplicación</string>
     <string name="language_system">El del sistema</string>
-    <string name="language_system_description">Seguir el idioma del dispositivo</string>
-    <string name="language_close">Cerrar</string>
+    <string name="language_system_description">Seguir al dispositivo</string>
+    <string name="language_current">Actual: %1$s</string>
+    <string name="language_selected">Elegido: %1$s</string>
+    <string name="language_cancel">Cancelar</string>
+    <string name="language_confirm">Confirmar</string>
     <string name="language_changed_title">Idioma cambiado</string>
     <string name="language_changed_body">Hazel ya está en este idioma. Todo lo que la aplicación no tenga traducido se queda en inglés.</string>
     <string name="language_changed_ok">Aceptar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,568 @@
+<resources>
+    <string name="direct_share_label">Instantáneo</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">Inicio</string>
+    <string name="nav_history">Descargas</string>
+    <string name="nav_more">Más</string>
+    <string name="nav_incognito_on">Incógnito activado, las descargas no se registran</string>
+    <string name="nav_incognito_off">Incógnito desactivado</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">Busca o pega un enlace</string>
+    <string name="download_clear">Vaciar</string>
+    <string name="download_show_large_artwork">Mostrar imágenes grandes</string>
+    <string name="download_show_list">Mostrar como lista</string>
+    <string name="download_instant_source">Instantáneo · leyendo desde %1$s</string>
+    <string name="download_incognito_title">Estás en incógnito</string>
+    <string name="download_incognito_body">Las descargas no se añaden a tu historial y los enlaces no se recuerdan. Los archivos se guardan igual que siempre.</string>
+    <string name="download_download_all">Descargar todo</string>
+    <string name="download_saved_aside">Tus descargas están guardadas. Las encontrarás en la pestaña Descargas.</string>
+    <string name="download_options">Opciones de descarga</string>
+    <string name="download_pause">Pausar</string>
+    <string name="download_resume">Reanudar</string>
+    <string name="download_cancel">Cancelar</string>
+    <string name="download_paused">En pausa</string>
+    <string name="download_processing">Procesando</string>
+    <string name="download_waiting_wifi">Esperando al Wi-Fi</string>
+    <string name="download_saved">Guardado</string>
+    <string name="download_queued">En cola</string>
+    <string name="download_downloaded">Descargado</string>
+    <string name="download_failed">Falló</string>
+    <string name="download_remove_link">Quitar enlace</string>
+    <string name="download_cancel_action">Cancelar la descarga</string>
+    <string name="download_resume_action">Reanudar la descarga</string>
+    <plurals name="download_links">
+        <item quantity="one">%d enlace</item>
+        <item quantity="many">%d de enlaces</item>
+        <item quantity="other">%d enlaces</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">Busca o pega un enlace</string>
+    <string name="search_back">Atrás</string>
+    <string name="search_more">Más</string>
+    <string name="search_add_link">Añadir otro enlace</string>
+    <string name="search_clear">Borrar</string>
+    <string name="search_clear_results">Vaciar resultados</string>
+    <string name="search_clear_history">Borrar el historial de búsqueda</string>
+    <string name="search_empty_history">Los enlaces que uses aparecerán aquí</string>
+    <string name="search_no_matches">Ningún enlace coincide</string>
+    <string name="search_remove">Quitar</string>
+    <string name="search_all">Buscar todo</string>
+    <string name="search_forget">Olvidar</string>
+    <string name="search_edit_before">Editar antes de buscar</string>
+    <string name="search_paste_and_fetch">Pegar y buscar</string>
+    <string name="search_nothing_to_paste">No hay nada que pegar</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">Ya descargado</string>
+    <string name="already_downloaded_body">Este enlace ya está guardado en este dispositivo.</string>
+    <string name="already_downloaded_video">Vídeo</string>
+    <string name="already_downloaded_audio">Audio</string>
+    <string name="already_downloaded_keep">Conservarlo</string>
+    <string name="already_downloaded_play">Reproducir</string>
+    <string name="already_downloaded_download_again">Descargar otra vez</string>
+    <string name="already_downloaded_just_now">Ahora mismo</string>
+    <string name="already_downloaded_yesterday">Ayer</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="one">%d min</item>
+        <item quantity="many">%d min</item>
+        <item quantity="other">%d min</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="one">%d h</item>
+        <item quantity="many">%d h</item>
+        <item quantity="other">%d h</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="one">%d día</item>
+        <item quantity="many">%d de días</item>
+        <item quantity="other">%d días</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="one">%d mes</item>
+        <item quantity="many">%d de meses</item>
+        <item quantity="other">%d meses</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">Hace falta iniciar sesión</string>
+    <string name="no_results_error_title">No se pudo leer este enlace</string>
+    <string name="no_results_sign_in_body">La fuente pide una cuenta antes de entregar esto. Al iniciar sesión se guardan las cookies del sitio y se vuelve a intentar.</string>
+    <string name="no_results_continue_body">No se pudieron leer los detalles, pero la descarga aún puede funcionar. Si sigues adelante, se ofrece la mejor calidad disponible.</string>
+    <string name="no_results_refused_body">La fuente rechazó la petición.</string>
+    <string name="no_results_engine_report">Lo que informó el motor</string>
+    <string name="no_results_copy_log">Copiar el registro</string>
+    <string name="no_results_sign_in">Iniciar sesión</string>
+    <string name="no_results_try_anyway">Intentarlo igualmente</string>
+    <string name="no_results_close">Cerrar</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">Primeros pasos</string>
+    <string name="guide_step_paste_link">Pega un enlace en el campo de búsqueda para descargarlo. Puedes añadir varios enlaces y listas de reproducción</string>
+    <string name="guide_step_pick_format">Toca una tarjeta para elegir el formato exacto. Se listan todas las calidades disponibles con su tamaño y su códec.</string>
+    <string name="guide_step_share_instant">Comparte un enlace con Hazel Instantáneo desde cualquier aplicación para descargarlo al instante con la calidad que hayas fijado.</string>
+    <string name="guide_step_finished_downloads">Los archivos terminados aparecen en Descargas. Toca cualquier fila para abrirlo en el reproductor predeterminado del dispositivo.</string>
+    <string name="guide_step_battery_unrestricted">Pon el uso de batería en sin restricciones; si no, Android puede detener las descargas cuando salgas de la aplicación.</string>
+    <string name="guide_battery_settings">Ajustes de batería</string>
+    <string name="guide_close">Cerrar</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">Descargar</string>
+    <string name="format_sheet_subtitle">Ajustar la descarga</string>
+    <string name="format_sheet_play">Reproducir</string>
+    <string name="format_sheet_ok">Aceptar</string>
+    <string name="format_sheet_download">Descargar</string>
+    <string name="format_sheet_tab_audio">Audio</string>
+    <string name="format_sheet_tab_video">Vídeo</string>
+    <string name="format_sheet_label_title">Título</string>
+    <string name="format_sheet_label_author">Autor</string>
+    <string name="format_sheet_label_container">Contenedor</string>
+    <string name="format_sheet_video_quality">Calidad de vídeo</string>
+    <string name="format_sheet_audio_quality">Calidad de audio</string>
+    <string name="format_sheet_no_video_stream">Esta fuente no tiene una pista de vídeo aparte.</string>
+    <string name="format_sheet_no_audio_stream">Esta fuente no tiene una pista de audio aparte.</string>
+    <string name="format_sheet_adjust_video">Ajustar el vídeo</string>
+    <string name="format_sheet_adjust_audio">Ajustar el audio</string>
+    <string name="format_sheet_thumbnail">Miniatura</string>
+    <string name="format_sheet_chapters">Capítulos</string>
+    <string name="format_sheet_subtitles">Subtítulos</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">Idioma del audio</string>
+    <string name="format_sheet_change_audio_language">Cambiar el idioma del audio</string>
+    <string name="format_sheet_filename_template">Plantilla del nombre de archivo</string>
+    <string name="format_sheet_change_field">Cambiar</string>
+    <string name="format_sheet_save_dir">Carpeta</string>
+    <string name="format_sheet_save_location">Dónde guardar</string>
+    <string name="format_sheet_save_location_title">Dónde guardar</string>
+    <string name="format_sheet_save_location_body">Abre esta carpeta en tu gestor de archivos, o elige otra donde guardar las descargas.</string>
+    <string name="format_sheet_open_folder">Abrir la carpeta</string>
+    <string name="format_sheet_reset">Restablecer</string>
+    <string name="format_sheet_change">Cambiar</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">Convertir a</string>
+    <string name="converter_label_saved_to">Guardado en</string>
+    <string name="converter_hazel_storage">El almacenamiento propio de Hazel</string>
+    <string name="converter_storage_warning">Sin acceso al almacenamiento el archivo se queda dentro de Hazel, donde otras aplicaciones no pueden verlo.</string>
+    <string name="converter_back">Atrás</string>
+    <string name="converter_title">Conversor sin conexión</string>
+    <string name="converter_subtitle">De vídeo a audio, nada sale del teléfono</string>
+    <string name="converter_choose_video">Elige un archivo de vídeo</string>
+    <string name="converter_ready">Listo</string>
+    <string name="converter_choose_video_hint">Cualquier cosa del teléfono o de una tarjeta SD</string>
+    <string name="converter_change">Cambiar</string>
+    <string name="converter_converting">Convirtiendo</string>
+    <string name="converter_convert">Convertir</string>
+    <string name="converter_saved">Guardado</string>
+    <string name="converter_open_folder">Abrir la carpeta</string>
+    <string name="converter_convert_another">Convertir otro</string>
+    <string name="converter_error_title">Eso no se convirtió</string>
+    <string name="converter_dismiss">Descartar</string>
+    <string name="converter_save_as_title">Guardar como</string>
+    <string name="converter_save_as_body">Da nombre al archivo, y se escribe en su etiqueta de título.</string>
+    <string name="converter_label_name">Nombre</string>
+    <string name="converter_start">Empezar</string>
+    <string name="converter_format_sheet_title">Convertir a</string>
+    <string name="converter_heading_common">Los tres que merecen la pena</string>
+    <string name="converter_heading_other">Todo lo demás</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">Más</string>
+    <string name="more_battery_title">Descargas en segundo plano</string>
+    <string name="more_battery_body">Las descargas siguen por su cuenta en segundo plano. Aun así, algunos teléfonos las cortan para ahorrar batería. Permite el uso sin restricciones para descartarlo.</string>
+    <string name="more_downloads">Descargas</string>
+    <string name="more_appearance">Apariencia</string>
+    <string name="more_language">Idioma</string>
+    <string name="more_cookies">Cookies</string>
+    <string name="more_link_reading">Lectura de enlaces</string>
+    <string name="more_hazel_instant">Hazel Instantáneo</string>
+    <string name="more_temporary_files">Archivos temporales</string>
+    <string name="more_converter">Convertir vídeo a audio sin conexión</string>
+    <string name="more_engine_update">Actualización del motor yt-dlp</string>
+    <string name="more_support">Apoyar a Hazel</string>
+    <string name="more_license">Licencia</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">Atrás</string>
+    <string name="sponsor_title">Apoyar a Hazel</string>
+    <string name="sponsor_hero_title">Gratis, y así va a seguir</string>
+    <string name="sponsor_hero_body">Hazel se hace por las tardes y los fines de semana, y se regala porque un descargador que cobra por la descarga es un descargador peor. Los sitios cambian constantemente, y seguirles el ritmo es el trabajo.</string>
+    <string name="sponsor_hero_closing">Si la aplicación te ahorró una tarde, cualquiera de estas opciones devuelve ese tiempo. Si no lo hizo, las que no cuestan nada ayudan igual.</string>
+    <string name="sponsor_section_ways">Formas de apoyar</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">Mensual o una sola vez, cancela cuando quieras. Lo gestiona GitHub por completo.</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">Una sola vez, sin necesidad de cuenta.</string>
+    <string name="sponsor_kofi_soon">Se abre pronto</string>
+    <string name="sponsor_section_free">No cuesta nada, ayuda igual</string>
+    <string name="sponsor_star_title">Dale una estrella al proyecto</string>
+    <string name="sponsor_star_subtitle">El único número que mira la gente antes de probar una aplicación.</string>
+    <string name="sponsor_share_title">Cuéntaselo a alguien</string>
+    <string name="sponsor_share_subtitle">El boca a boca es todo el marketing de esta aplicación.</string>
+    <string name="sponsor_issues_title">Avisa de lo que se rompe</string>
+    <string name="sponsor_issues_subtitle">Un sitio que dejó de funcionar es un arreglo que nadie más puede escribir.</string>
+    <string name="sponsor_source_title">Lee el código</string>
+    <string name="sponsor_source_subtitle">Cada línea es pública, y las pull requests son bienvenidas.</string>
+    <string name="sponsor_footer">Sin anuncios, sin medir nada de lo que descargas y sin ninguna función guardada para unos pocos. Apoyar cambia cuánto tiempo se le dedica a Hazel, no lo que hará por ti.</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">Actualización de yt-dlp</string>
+    <string name="update_back">Atrás</string>
+    <string name="update_check_action">Buscar actualizaciones</string>
+    <string name="update_status_up_to_date">Estás al día</string>
+    <string name="update_status_checking">Buscando actualizaciones...</string>
+    <string name="update_status_available">Actualización disponible</string>
+    <string name="update_status_installing">Instalando yt-dlp...</string>
+    <string name="update_status_installed">Motor actualizado</string>
+    <string name="update_status_failed">La actualización falló</string>
+    <string name="update_subtitle_idle">Hazel está usando la última versión de yt-dlp</string>
+    <string name="update_subtitle_checking">Contactando con GitHub...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s está disponible</string>
+    <string name="update_subtitle_updating">Descargando yt-dlp %1$s</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s ya está en uso</string>
+    <string name="update_installed_version">Versión instalada</string>
+    <string name="update_version_unknown">Desconocida</string>
+    <string name="update_new_version">Versión nueva</string>
+    <string name="update_installing_binary">Instalando el binario</string>
+    <string name="update_installing_body">Descargando desde GitHub y sustituyendo el motor. Mantén la aplicación abierta.</string>
+    <string name="update_action_update_now">Actualizar ahora</string>
+    <string name="update_action_installing">Instalando...</string>
+    <string name="update_action_done">Hecho</string>
+    <string name="update_action_retry">Reintentar</string>
+    <string name="update_action_check">Buscar actualizaciones</string>
+    <string name="update_action_checking">Buscando...</string>
+    <string name="update_info_heading">Información</string>
+    <string name="update_info_component">Componente</string>
+    <string name="update_info_repository">Repositorio</string>
+    <string name="update_info_binary_size">Tamaño del binario</string>
+    <string name="update_info_distribution">Distribución</string>
+    <string name="update_info_github_releases">GitHub Releases</string>
+    <string name="update_release_channel">Canal de versiones</string>
+    <string name="update_view_changelog">Ver el registro de cambios</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">Elige el filtrado de SponsorBlock</string>
+    <string name="options_sponsorblock_ok">Aceptar</string>
+    <string name="options_sponsorblock_cancel">Cancelar</string>
+    <string name="options_chapters_title">Capítulos</string>
+    <string name="options_chapters_in_videos">Capítulos en los vídeos</string>
+    <string name="options_chapters_split">Dividir por capítulos</string>
+    <string name="options_chapters_split_body">Dividir escribe un archivo por capítulo en lugar de uno solo.</string>
+    <string name="options_chapters_dismiss">Descartar</string>
+    <string name="options_subtitles_title">Subtítulos</string>
+    <string name="options_subtitles_embed">Incrustar los subtítulos</string>
+    <string name="options_subtitles_save">Guardar los subtítulos</string>
+    <string name="options_subtitles_save_auto">Guardar los subtítulos automáticos</string>
+    <string name="options_subtitles_languages_label">Idiomas de los subtítulos</string>
+    <string name="options_subtitles_dismiss">Descartar</string>
+    <string name="options_subtitles_languages_title">Idiomas de los subtítulos</string>
+    <string name="options_subtitles_languages_hint">Un selector de idioma de yt-dlp, por ejemplo en.*,.*-orig para el inglés más la pista original. Usa all para todos los idiomas que ofrezca la fuente.</string>
+    <string name="options_filename_title">Plantilla del nombre de archivo</string>
+    <string name="options_filename_hint">Plantilla de salida de yt-dlp. Usa %(title)s, %(uploader)s, %(id)s y %(ext)s.</string>
+    <string name="options_text_input_save">Guardar</string>
+    <string name="options_text_input_cancel">Cancelar</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">Atrás</string>
+    <string name="cleanup_title">Archivos temporales</string>
+    <string name="cleanup_header_description">Archivos de trabajo que guarda la aplicación. Tus descargas no están incluidas y nunca se borran desde aquí.</string>
+    <string name="cleanup_action_clear_everything">Borrarlo todo</string>
+    <string name="cleanup_category_link_data_label">Caché de datos de enlaces</string>
+    <string name="cleanup_category_link_data_description">Datos del reproductor que yt-dlp guarda para que un enlace leído una segunda vez vaya más rápido. Se puede borrar sin riesgo.</string>
+    <string name="cleanup_category_partial_downloads_label">Descargas sin terminar</string>
+    <string name="cleanup_category_partial_downloads_description">Fragmentos que dejó una descarga cancelada o fallida antes de guardar su archivo.</string>
+    <string name="cleanup_category_conversions_label">Conversiones sin terminar</string>
+    <string name="cleanup_category_conversions_description">Archivos de trabajo del conversor de audio que nunca llegaron a tu carpeta de música.</string>
+    <string name="cleanup_category_engine_label">Archivos del motor yt-dlp</string>
+    <string name="cleanup_category_engine_description">El descargador y su entorno de ejecución. Borrarlos libera más espacio, pero la siguiente descarga tiene que desempaquetarlos otra vez.</string>
+    <string name="cleanup_category_other_cache_label">Otros archivos en caché</string>
+    <string name="cleanup_category_other_cache_description">Miniaturas y todo lo demás guardado mientras se exploran enlaces.</string>
+    <string name="cleanup_confirm_category_title">¿Borrar estos archivos?</string>
+    <string name="cleanup_confirm_category_safe">Se liberarán %1$s. Nada de lo que has guardado se ve afectado.</string>
+    <string name="cleanup_confirm_category_unsafe">Se liberarán %1$s, y la siguiente descarga tardará más mientras se desempaquetan otra vez.</string>
+    <string name="cleanup_confirm_clear">Borrar</string>
+    <string name="cleanup_confirm_cancel">Cancelar</string>
+    <string name="cleanup_confirm_all_title">¿Borrarlo todo?</string>
+    <string name="cleanup_confirm_all_body">Se liberarán %1$s. Tus descargas y tus sesiones guardadas se conservan, pero la siguiente descarga tardará más mientras se desempaqueta el motor otra vez.</string>
+    <string name="cleanup_confirm_all_confirm">Borrarlo todo</string>
+    <string name="cleanup_confirm_all_cancel">Cancelar</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">Descargas</string>
+    <string name="history_layout_grid">Mostrar imágenes grandes</string>
+    <string name="history_layout_list">Mostrar como lista</string>
+    <string name="history_search_action">Buscar en las descargas</string>
+    <string name="history_sort_action">Ordenar</string>
+    <string name="history_menu_action">Más</string>
+    <string name="history_menu_clear">Borrar el historial</string>
+    <string name="history_search_placeholder">Buscar en las descargas</string>
+    <string name="history_search_clear">Borrar la búsqueda</string>
+    <string name="history_empty_initial">Aún no has descargado nada</string>
+    <string name="history_empty_filtered">Nada coincide con eso</string>
+    <string name="history_clear_dialog_title">Borrar el historial</string>
+    <string name="history_clear_dialog_body">La lista se vacía. Tus archivos descargados no se tocan.</string>
+    <string name="history_clear_dialog_confirm">Borrar</string>
+    <string name="history_clear_dialog_cancel">Cancelar</string>
+    <string name="history_delete_dialog_title">Eliminar el archivo</string>
+    <string name="history_delete_dialog_body">%1$s se eliminará de tu dispositivo.</string>
+    <string name="history_toast_file_deleted">Archivo eliminado</string>
+    <string name="history_toast_file_delete_failed">No se pudo eliminar el archivo</string>
+    <string name="history_delete_dialog_confirm">Eliminar</string>
+    <string name="history_delete_dialog_cancel">Cancelar</string>
+    <string name="history_card_options">Opciones</string>
+    <string name="history_card_properties">Propiedades</string>
+    <string name="history_card_remove">Quitar de la lista</string>
+    <string name="history_card_delete">Eliminar el archivo</string>
+    <string name="history_tag_deleted">Eliminado</string>
+    <string name="history_row_options">Opciones</string>
+    <string name="history_row_properties">Propiedades</string>
+    <string name="history_row_remove">Quitar de la lista</string>
+    <string name="history_row_delete">Eliminar el archivo</string>
+    <string name="history_toast_file_gone">Este archivo ya no está en tu dispositivo</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">Propiedades</string>
+    <string name="properties_status">Estado</string>
+    <string name="properties_status_present">En este dispositivo</string>
+    <string name="properties_status_deleted">Eliminado de este dispositivo</string>
+    <string name="properties_kind">Tipo</string>
+    <string name="properties_kind_video">Vídeo</string>
+    <string name="properties_kind_audio">Audio</string>
+    <string name="properties_quality">Calidad</string>
+    <string name="properties_resolution">Resolución</string>
+    <string name="properties_length">Duración</string>
+    <string name="properties_codec">Códec</string>
+    <string name="properties_bitrate">Tasa de bits</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">Tamaño</string>
+    <string name="properties_container">Contenedor</string>
+    <string name="properties_type">Formato</string>
+    <string name="properties_embedded">Incrustado</string>
+    <string name="properties_file">Archivo</string>
+    <string name="properties_saved_to">Guardado en</string>
+    <string name="properties_downloaded">Descargado</string>
+    <string name="properties_source">Origen</string>
+    <string name="properties_link_copied_opened">Enlace copiado y abierto</string>
+    <string name="properties_link_copied">Enlace copiado</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">Atrás</string>
+    <string name="cookies_title">Cookies</string>
+    <string name="cookies_menu">Más</string>
+    <string name="cookies_menu_import">Importar del portapapeles</string>
+    <string name="cookies_menu_export">Exportar al portapapeles</string>
+    <string name="cookies_menu_delete_all">Eliminar todas</string>
+    <string name="cookies_imported_title">Cookies importadas</string>
+    <string name="cookies_toast_imported">Cookies importadas</string>
+    <string name="cookies_toast_no_data">El portapapeles no contiene datos de cookies</string>
+    <string name="cookies_toast_nothing_to_export">No hay nada que exportar</string>
+    <string name="cookies_toast_exported">Copiado al portapapeles</string>
+    <string name="cookies_toast_entry_copied">Copiado al portapapeles</string>
+    <string name="cookies_use_title">Usar cookies</string>
+    <string name="cookies_use_description">Pasar las sesiones guardadas al descargador</string>
+    <string name="cookies_new">Cookie nueva</string>
+    <string name="cookies_empty_title">No hay cookies guardadas</string>
+    <string name="cookies_empty_body">Añade una para descargar contenido con restricción de edad, privado o solo para miembros.</string>
+    <string name="cookies_delete_title">Eliminar las cookies</string>
+    <string name="cookies_delete_body">¿Quitar la sesión guardada de %1$s?</string>
+    <string name="cookies_delete_confirm">Eliminar</string>
+    <string name="cookies_delete_cancel">Cancelar</string>
+    <string name="cookies_delete_all_title">Eliminar todas las cookies</string>
+    <string name="cookies_delete_all_body">Se quitarán todas las sesiones guardadas. Esto no se puede deshacer.</string>
+    <string name="cookies_delete_all_confirm">Eliminar todas</string>
+    <string name="cookies_delete_all_cancel">Cancelar</string>
+    <string name="cookies_row_fallback_name">Cookies</string>
+    <string name="cookies_sheet_title">Cookies</string>
+    <string name="cookies_sheet_copy">Copiar las cookies</string>
+    <string name="cookies_sheet_delete">Eliminar las cookies</string>
+    <string name="cookies_field_title">Título</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">Guardar</string>
+    <string name="cookies_sheet_get">Obtener cookies</string>
+    <string name="cookies_sheet_update">Actualizar</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">La mejor calidad</string>
+    <string name="batch_type_sheet_title">Tipo de descarga preferido</string>
+    <string name="batch_type_sheet_subtitle">Cómo se descargan estos enlaces</string>
+    <string name="batch_type_audio">Audio</string>
+    <string name="batch_type_video">Vídeo</string>
+    <string name="batch_format_title">Formato</string>
+    <string name="batch_format_subtitle">Elige el formato</string>
+    <string name="batch_container_title">Contenedor</string>
+    <string name="batch_container_subtitle">El archivo en el que se guardan estos enlaces</string>
+    <string name="batch_save_dir_title">Dónde guardar</string>
+    <string name="batch_open_folder">Abrir esta carpeta</string>
+    <string name="batch_change_folder">Cambiar de carpeta</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">Miniatura</string>
+    <string name="batch_bar_chapters">Capítulos</string>
+    <string name="batch_bar_subtitles">Subtítulos</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">Plantilla del nombre de archivo</string>
+    <string name="batch_bar_download_type">Tipo de descarga preferido</string>
+    <string name="batch_bar_quality">Calidad: %1$s</string>
+    <string name="batch_bar_save_location">Dónde guardar</string>
+    <string name="batch_bar_container">Contenedor</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">Descargar</string>
+    <string name="batch_header_subtitle">Ajustar la descarga</string>
+    <string name="batch_download_action">Descargar</string>
+    <string name="batch_stop_selecting">Dejar de seleccionar</string>
+    <string name="batch_start_selecting">Seleccionar enlaces</string>
+    <string name="batch_list_options">Opciones de la lista</string>
+    <string name="batch_menu_select_links">Seleccionar enlaces</string>
+    <string name="batch_menu_select_all">Seleccionar todo</string>
+    <string name="batch_menu_invert">Invertir la selección</string>
+    <string name="batch_menu_remove_selected">Quitar lo seleccionado</string>
+    <string name="batch_menu_done">Hecho</string>
+    <plurals name="batch_selected">
+        <item quantity="one">%d seleccionado</item>
+        <item quantity="many">%d de seleccionados</item>
+        <item quantity="other">%d seleccionados</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="one">%d enlace</item>
+        <item quantity="many">%d de enlaces</item>
+        <item quantity="other">%d enlaces</item>
+    </plurals>
+    <string name="batch_card_download_type">Tipo de descarga para este enlace</string>
+    <string name="batch_card_remove">Quitar</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">No se sabe dónde está este archivo</string>
+    <string name="media_open_chooser">Abrir con</string>
+    <string name="media_open_no_app">Nada en este dispositivo puede abrirlo</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">Descarga cancelada</string>
+    <string name="notification_channel_progress_description">Progreso de la descarga, muestra un icono en la barra de estado</string>
+    <string name="notification_channel_complete_description">Avisos de descarga terminada</string>
+    <string name="notification_action_pause">Pausar</string>
+    <string name="notification_action_resume">Reanudar</string>
+    <string name="notification_action_cancel">Cancelar</string>
+    <string name="notification_action_sign_in">Iniciar sesión</string>
+    <string name="notification_wifi_title">Esperando al Wi-Fi</string>
+    <string name="notification_wifi_text">Las descargas están limitadas al Wi-Fi. Empiezan cuando vuelvas a estar en Wi-Fi.</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">Cerrar</string>
+    <string name="cookie_webview_desktop_site">Versión de escritorio</string>
+    <string name="cookie_webview_no_cookies">No se recogió ninguna cookie</string>
+    <string name="cookie_webview_done">"  Aceptar"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">Ordenar los formatos</string>
+    <string name="format_selection_change">Cambiar de formato</string>
+    <string name="format_selection_title">Formato</string>
+    <string name="format_selection_subtitle">Elige el formato</string>
+    <string name="format_selection_confirm">Aceptar</string>
+    <string name="format_selection_loading">Leyendo el resto de los formatos</string>
+    <string name="format_sort_quality">Calidad</string>
+    <string name="format_sort_file_size">Tamaño del archivo</string>
+    <string name="format_sort_container">Contenedor</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">Idioma del audio</string>
+    <string name="audio_language_subtitle">Elige la pista de sonido</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">Atrás</string>
+    <string name="appearance_title">Apariencia</string>
+
+    <!-- Language picker -->
+    <string name="language_title">Idioma</string>
+    <string name="language_system">El del sistema</string>
+    <string name="language_system_description">Seguir el idioma del dispositivo</string>
+    <string name="language_close">Cerrar</string>
+    <string name="language_changed_title">Idioma cambiado</string>
+    <string name="language_changed_body">Hazel ya está en este idioma. Todo lo que la aplicación no tenga traducido se queda en inglés.</string>
+    <string name="language_changed_ok">Aceptar</string>
+    <string name="appearance_dark_theme">Tema oscuro</string>
+    <string name="appearance_accent_color">Color de acento</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">Color de acento</string>
+    <string name="accent_picker_close">Cerrar</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">Atrás</string>
+    <string name="fetch_settings_title">Lectura de enlaces</string>
+    <string name="fetch_settings_timeout_description">Cuánto esperar a una fuente lenta antes de rendirse y reintentar.</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="one">%1$ds de espera, %2$d intento</item>
+        <item quantity="many">%1$ds de espera, %2$d de intentos</item>
+        <item quantity="other">%1$ds de espera, %2$d intentos</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">Lectura de enlaces</string>
+    <string name="fetch_settings_reading_links_description">Qué lector averigua lo que contiene un enlace. Las descargas siempre usan yt-dlp, sea cual sea la opción elegida aquí.</string>
+    <string name="fetch_settings_force_ipv4_description">Actívalo solo si los enlaces se quedan colgados en tu red. Sirve para sortear una ruta IPv6 rota, y es más lento en todo lo demás.</string>
+    <string name="fetch_settings_force_ipv4">Forzar IPv4</string>
+    <string name="fetch_mode_fast_label">Rápido</string>
+    <string name="fetch_mode_fast_description">Se rinde pronto. Lo más rápido en una buena red, pero es más probable que haga falta un segundo intento.</string>
+    <string name="fetch_mode_balanced_label">Equilibrado</string>
+    <string name="fetch_mode_balanced_description">Un término medio entre la velocidad y aguantar una conexión pobre.</string>
+    <string name="fetch_mode_thorough_label">Minucioso</string>
+    <string name="fetch_mode_thorough_description">Espera más y reintenta más. Lo más lento, pero sobrevive a una red débil.</string>
+    <string name="listing_source_ytdlp_description">El mismo motor que hace la descarga. Funciona en todos los sitios que admite, y se actualiza solo, así que sigue funcionando a medida que los sitios cambian.</string>
+    <string name="listing_source_newpipe_label">Preferir el lector integrado</string>
+    <string name="listing_source_newpipe_description">Lista las listas de reproducción y los canales en una sola petición en vez de arrancar el motor, lo que es más rápido en los sitios que conoce. Recurre a yt-dlp para todo lo demás, y siempre que no pueda leer un enlace.</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">Atrás</string>
+    <string name="tools_title">Herramientas</string>
+    <string name="tools_empty">Aquí todavía no hay nada.</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">Atrás</string>
+    <string name="direct_share_save_as">Guardar como</string>
+    <string name="direct_share_video">Vídeo</string>
+    <string name="direct_share_audio_only">Solo audio</string>
+    <string name="direct_share_title">Hazel Instantáneo</string>
+    <string name="direct_share_intro">Compartir un enlace con Hazel Instantáneo empieza la descarga de inmediato, sin hoja y sin preguntas. Estas son las respuestas que usa.</string>
+    <string name="direct_share_video_description">Imagen y sonido, unidos en un solo archivo.</string>
+    <string name="direct_share_audio_description">Solo el sonido, con lo mejor que ofrezca la fuente.</string>
+    <string name="direct_share_quality_title">Límite de calidad</string>
+    <string name="direct_share_quality_description">Un techo, no un tamaño exacto. No todas las fuentes ofrecen las mismas alturas, así que se coge la mayor que quepa por debajo de esto, y la menor disponible cuando ninguna cabe.</string>
+    <string name="direct_share_output_title">Salida</string>
+    <string name="direct_share_output_description">El archivo que acaba en el dispositivo. Predeterminado conserva lo que ya da la fuente, que es la opción más rápida porque no se recodifica nada.</string>
+    <string name="direct_share_filename_template">Plantilla del nombre de archivo</string>
+    <string name="direct_share_audio_language">Idioma del audio</string>
+    <string name="direct_share_audio_language_default">El de la fuente</string>
+    <string name="direct_share_extras_title">Extras</string>
+    <string name="direct_share_extras_description">Se aplican cuando la fuente los tiene. Lo que no tenga se omite en esa descarga en vez de hacerla fallar.</string>
+    <string name="direct_share_cover_art">Carátula</string>
+    <string name="direct_share_cover_art_description">Escribe la miniatura dentro del archivo, cuando el contenedor puede llevar una.</string>
+    <string name="direct_share_chapters">Capítulos</string>
+    <string name="direct_share_subtitles">Subtítulos</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">Desactivado</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="one">%1$d categoría cortada</item>
+        <item quantity="many">%1$d de categorías cortadas</item>
+        <item quantity="other">%1$d categorías cortadas</item>
+    </plurals>
+    <string name="direct_share_signins_title">Sesiones</string>
+    <string name="direct_share_signins_description">Una compartición instantánea usa las cookies guardadas del sitio al que pertenezca el enlace, igual que una descarga empezada desde la hoja. No se pregunta nada al compartir, así que un enlace tras un inicio de sesión solo funciona si la sesión ya está guardada y activada.</string>
+    <string name="direct_share_cookies">Cookies</string>
+    <string name="direct_share_cookies_on">Activado, se usan en cada compartición instantánea</string>
+    <string name="direct_share_cookies_off">Desactivado</string>
+    <string name="direct_share_change">Cambiar %1$s</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">Atrás</string>
+    <string name="storage_locations_downloads">Descargas</string>
+    <string name="storage_locations_title">Descargas</string>
+    <string name="storage_locations_subtitle">Dónde se guardan las descargas, y los límites con los que funcionan</string>
+    <string name="storage_locations_limits">Límites</string>
+    <string name="storage_locations_wifi_only_description">Las descargas esperan en vez de tirar de los datos móviles</string>
+    <string name="storage_locations_speed_limit_description">A qué velocidad se le permite ir a una descarga</string>
+    <string name="storage_locations_internal_note">Todos los archivos se guardan en el almacenamiento interno de tu dispositivo. Puedes acceder a ellos cuando quieras con cualquier gestor de archivos.</string>
+    <string name="storage_locations_wifi_only">Solo con Wi-Fi</string>
+    <string name="storage_locations_speed_limit">Límite de velocidad</string>
+
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,568 @@
+<resources>
+    <string name="direct_share_label">Instantané</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">Accueil</string>
+    <string name="nav_history">Téléchargements</string>
+    <string name="nav_more">Plus</string>
+    <string name="nav_incognito_on">Navigation privée activée, les téléchargements ne sont pas enregistrés</string>
+    <string name="nav_incognito_off">Navigation privée désactivée</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">Cherchez ou collez un lien</string>
+    <string name="download_clear">Vider</string>
+    <string name="download_show_large_artwork">Afficher les grandes images</string>
+    <string name="download_show_list">Afficher en liste</string>
+    <string name="download_instant_source">Instantané · lecture depuis %1$s</string>
+    <string name="download_incognito_title">Vous êtes en navigation privée</string>
+    <string name="download_incognito_body">Les téléchargements ne sont pas ajoutés à votre historique et les liens ne sont pas retenus. Les fichiers sont enregistrés comme d\'habitude.</string>
+    <string name="download_download_all">Tout télécharger</string>
+    <string name="download_saved_aside">Vos téléchargements sont enregistrés. Vous les trouverez dans l\'onglet Téléchargements.</string>
+    <string name="download_options">Options de téléchargement</string>
+    <string name="download_pause">Mettre en pause</string>
+    <string name="download_resume">Reprendre</string>
+    <string name="download_cancel">Annuler</string>
+    <string name="download_paused">En pause</string>
+    <string name="download_processing">Traitement en cours</string>
+    <string name="download_waiting_wifi">En attente du Wi-Fi</string>
+    <string name="download_saved">Enregistré</string>
+    <string name="download_queued">En file d\'attente</string>
+    <string name="download_downloaded">Téléchargé</string>
+    <string name="download_failed">Échec</string>
+    <string name="download_remove_link">Retirer le lien</string>
+    <string name="download_cancel_action">Annuler le téléchargement</string>
+    <string name="download_resume_action">Reprendre le téléchargement</string>
+    <plurals name="download_links">
+        <item quantity="one">%d lien</item>
+        <item quantity="many">%d de liens</item>
+        <item quantity="other">%d liens</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">Cherchez ou collez un lien</string>
+    <string name="search_back">Retour</string>
+    <string name="search_more">Plus</string>
+    <string name="search_add_link">Ajouter un autre lien</string>
+    <string name="search_clear">Effacer</string>
+    <string name="search_clear_results">Vider les résultats</string>
+    <string name="search_clear_history">Effacer l\'historique de recherche</string>
+    <string name="search_empty_history">Les liens que vous utilisez apparaîtront ici</string>
+    <string name="search_no_matches">Aucun lien ne correspond</string>
+    <string name="search_remove">Retirer</string>
+    <string name="search_all">Tout chercher</string>
+    <string name="search_forget">Oublier</string>
+    <string name="search_edit_before">Modifier avant de chercher</string>
+    <string name="search_paste_and_fetch">Coller et chercher</string>
+    <string name="search_nothing_to_paste">Rien à coller</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">Déjà téléchargé</string>
+    <string name="already_downloaded_body">Ce lien est déjà enregistré sur cet appareil.</string>
+    <string name="already_downloaded_video">Vidéo</string>
+    <string name="already_downloaded_audio">Audio</string>
+    <string name="already_downloaded_keep">Le garder</string>
+    <string name="already_downloaded_play">Lire</string>
+    <string name="already_downloaded_download_again">Télécharger à nouveau</string>
+    <string name="already_downloaded_just_now">À l\'instant</string>
+    <string name="already_downloaded_yesterday">Hier</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="one">%d min</item>
+        <item quantity="many">%d min</item>
+        <item quantity="other">%d min</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="one">%d h</item>
+        <item quantity="many">%d h</item>
+        <item quantity="other">%d h</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="one">%d jour</item>
+        <item quantity="many">%d de jours</item>
+        <item quantity="other">%d jours</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="one">%d mois</item>
+        <item quantity="many">%d de mois</item>
+        <item quantity="other">%d mois</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">Connexion requise</string>
+    <string name="no_results_error_title">Impossible de lire ce lien</string>
+    <string name="no_results_sign_in_body">La source demande un compte avant de livrer ceci. Se connecter enregistre les cookies du site et réessaie.</string>
+    <string name="no_results_continue_body">Les détails n\'ont pas pu être lus, mais le téléchargement peut tout de même fonctionner. En continuant, la meilleure qualité disponible est proposée.</string>
+    <string name="no_results_refused_body">La source a refusé la demande.</string>
+    <string name="no_results_engine_report">Ce que le moteur a signalé</string>
+    <string name="no_results_copy_log">Copier le journal</string>
+    <string name="no_results_sign_in">Se connecter</string>
+    <string name="no_results_try_anyway">Essayer quand même</string>
+    <string name="no_results_close">Fermer</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">Pour commencer</string>
+    <string name="guide_step_paste_link">Collez un lien dans le champ de recherche pour le télécharger. Vous pouvez ajouter plusieurs liens et des playlists</string>
+    <string name="guide_step_pick_format">Touchez une carte pour choisir le format exact. Toutes les qualités disponibles sont listées avec leur taille et leur codec.</string>
+    <string name="guide_step_share_instant">Partagez un lien vers Hazel Instantané depuis n\'importe quelle application pour le télécharger aussitôt dans la qualité que vous avez définie.</string>
+    <string name="guide_step_finished_downloads">Les fichiers terminés apparaissent dans Téléchargements. Touchez une ligne pour l\'ouvrir dans le lecteur par défaut de l\'appareil.</string>
+    <string name="guide_step_battery_unrestricted">Réglez l\'usage de la batterie sur illimité, sinon Android peut arrêter les téléchargements quand vous quittez l\'application.</string>
+    <string name="guide_battery_settings">Réglages de la batterie</string>
+    <string name="guide_close">Fermer</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">Télécharger</string>
+    <string name="format_sheet_subtitle">Ajuster le téléchargement</string>
+    <string name="format_sheet_play">Lire</string>
+    <string name="format_sheet_ok">OK</string>
+    <string name="format_sheet_download">Télécharger</string>
+    <string name="format_sheet_tab_audio">Audio</string>
+    <string name="format_sheet_tab_video">Vidéo</string>
+    <string name="format_sheet_label_title">Titre</string>
+    <string name="format_sheet_label_author">Auteur</string>
+    <string name="format_sheet_label_container">Conteneur</string>
+    <string name="format_sheet_video_quality">Qualité vidéo</string>
+    <string name="format_sheet_audio_quality">Qualité audio</string>
+    <string name="format_sheet_no_video_stream">Cette source n\'a pas de flux vidéo séparé.</string>
+    <string name="format_sheet_no_audio_stream">Cette source n\'a pas de flux audio séparé.</string>
+    <string name="format_sheet_adjust_video">Ajuster la vidéo</string>
+    <string name="format_sheet_adjust_audio">Ajuster l\'audio</string>
+    <string name="format_sheet_thumbnail">Miniature</string>
+    <string name="format_sheet_chapters">Chapitres</string>
+    <string name="format_sheet_subtitles">Sous-titres</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">Langue de l\'audio</string>
+    <string name="format_sheet_change_audio_language">Changer la langue de l\'audio</string>
+    <string name="format_sheet_filename_template">Modèle de nom de fichier</string>
+    <string name="format_sheet_change_field">Modifier</string>
+    <string name="format_sheet_save_dir">Dossier</string>
+    <string name="format_sheet_save_location">Emplacement</string>
+    <string name="format_sheet_save_location_title">Emplacement</string>
+    <string name="format_sheet_save_location_body">Ouvrez ce dossier dans votre gestionnaire de fichiers, ou choisissez-en un autre où enregistrer les téléchargements.</string>
+    <string name="format_sheet_open_folder">Ouvrir le dossier</string>
+    <string name="format_sheet_reset">Réinitialiser</string>
+    <string name="format_sheet_change">Modifier</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">Convertir en</string>
+    <string name="converter_label_saved_to">Enregistré dans</string>
+    <string name="converter_hazel_storage">Le stockage propre à Hazel</string>
+    <string name="converter_storage_warning">Sans accès au stockage, le fichier reste à l\'intérieur de Hazel, où les autres applications ne peuvent pas le voir.</string>
+    <string name="converter_back">Retour</string>
+    <string name="converter_title">Convertisseur hors ligne</string>
+    <string name="converter_subtitle">De la vidéo vers l\'audio, rien ne quitte le téléphone</string>
+    <string name="converter_choose_video">Choisissez un fichier vidéo</string>
+    <string name="converter_ready">Prêt</string>
+    <string name="converter_choose_video_hint">N\'importe quoi sur le téléphone ou une carte SD</string>
+    <string name="converter_change">Changer</string>
+    <string name="converter_converting">Conversion en cours</string>
+    <string name="converter_convert">Convertir</string>
+    <string name="converter_saved">Enregistré</string>
+    <string name="converter_open_folder">Ouvrir le dossier</string>
+    <string name="converter_convert_another">Convertir un autre</string>
+    <string name="converter_error_title">Cela n\'a pas été converti</string>
+    <string name="converter_dismiss">Ignorer</string>
+    <string name="converter_save_as_title">Enregistrer sous</string>
+    <string name="converter_save_as_body">Donne son nom au fichier, et est aussi écrit dans son étiquette de titre.</string>
+    <string name="converter_label_name">Nom</string>
+    <string name="converter_start">Démarrer</string>
+    <string name="converter_format_sheet_title">Convertir en</string>
+    <string name="converter_heading_common">Les trois qui valent le coup</string>
+    <string name="converter_heading_other">Tout le reste</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">Plus</string>
+    <string name="more_battery_title">Téléchargements en arrière-plan</string>
+    <string name="more_battery_body">Les téléchargements continuent tout seuls en arrière-plan. Certains téléphones les interrompent quand même pour économiser la batterie. Autorisez un usage illimité pour écarter ce risque.</string>
+    <string name="more_downloads">Téléchargements</string>
+    <string name="more_appearance">Apparence</string>
+    <string name="more_language">Langue</string>
+    <string name="more_cookies">Cookies</string>
+    <string name="more_link_reading">Lecture des liens</string>
+    <string name="more_hazel_instant">Hazel Instantané</string>
+    <string name="more_temporary_files">Fichiers temporaires</string>
+    <string name="more_converter">Convertir une vidéo en audio hors ligne</string>
+    <string name="more_engine_update">Mise à jour du moteur yt-dlp</string>
+    <string name="more_support">Soutenir Hazel</string>
+    <string name="more_license">Licence</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">Retour</string>
+    <string name="sponsor_title">Soutenir Hazel</string>
+    <string name="sponsor_hero_title">Gratuit, et ça ne changera pas</string>
+    <string name="sponsor_hero_body">Hazel se construit le soir et le week-end, et il est donné parce qu\'un téléchargeur qui fait payer le téléchargement est un moins bon téléchargeur. Les sites changent sans arrêt, et suivre ces changements, c\'est tout le travail.</string>
+    <string name="sponsor_hero_closing">Si l\'application vous a fait gagner un après-midi, n\'importe laquelle des options ci-dessous rend ce temps. Sinon, celles qui ne coûtent rien aident tout autant.</string>
+    <string name="sponsor_section_ways">Façons de soutenir</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">Tous les mois ou une seule fois, résiliable quand vous voulez. Entièrement géré par GitHub.</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">Une seule fois, sans compte à créer.</string>
+    <string name="sponsor_kofi_soon">Ouverture prochaine</string>
+    <string name="sponsor_section_free">Ne coûte rien, aide autant</string>
+    <string name="sponsor_star_title">Mettez une étoile au projet</string>
+    <string name="sponsor_star_subtitle">Le seul chiffre que les gens regardent avant d\'essayer une application.</string>
+    <string name="sponsor_share_title">Parlez-en à quelqu\'un</string>
+    <string name="sponsor_share_subtitle">Le bouche-à-oreille est toute la promotion de cette application.</string>
+    <string name="sponsor_issues_title">Signalez ce qui casse</string>
+    <string name="sponsor_issues_subtitle">Un site qui a cessé de fonctionner, c\'est un correctif que personne d\'autre ne peut écrire.</string>
+    <string name="sponsor_source_title">Lisez le code</string>
+    <string name="sponsor_source_subtitle">Chaque ligne est publique, et les pull requests sont les bienvenues.</string>
+    <string name="sponsor_footer">Pas de publicité, aucune mesure de ce que vous téléchargez, et aucune fonction réservée à quelques-uns. Soutenir change le temps consacré à Hazel, pas ce qu\'il fera pour vous.</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">Mise à jour de yt-dlp</string>
+    <string name="update_back">Retour</string>
+    <string name="update_check_action">Rechercher des mises à jour</string>
+    <string name="update_status_up_to_date">Vous êtes à jour</string>
+    <string name="update_status_checking">Recherche de mises à jour...</string>
+    <string name="update_status_available">Mise à jour disponible</string>
+    <string name="update_status_installing">Installation de yt-dlp...</string>
+    <string name="update_status_installed">Moteur mis à jour</string>
+    <string name="update_status_failed">La mise à jour a échoué</string>
+    <string name="update_subtitle_idle">Hazel utilise la dernière version de yt-dlp</string>
+    <string name="update_subtitle_checking">Connexion à GitHub...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s est disponible</string>
+    <string name="update_subtitle_updating">Téléchargement de yt-dlp %1$s</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s est maintenant utilisé</string>
+    <string name="update_installed_version">Version installée</string>
+    <string name="update_version_unknown">Inconnue</string>
+    <string name="update_new_version">Nouvelle version</string>
+    <string name="update_installing_binary">Installation du binaire</string>
+    <string name="update_installing_body">Téléchargement depuis GitHub et remplacement du moteur. Gardez l\'application ouverte.</string>
+    <string name="update_action_update_now">Mettre à jour</string>
+    <string name="update_action_installing">Installation...</string>
+    <string name="update_action_done">Terminé</string>
+    <string name="update_action_retry">Réessayer</string>
+    <string name="update_action_check">Rechercher des mises à jour</string>
+    <string name="update_action_checking">Recherche...</string>
+    <string name="update_info_heading">Informations</string>
+    <string name="update_info_component">Composant</string>
+    <string name="update_info_repository">Dépôt</string>
+    <string name="update_info_binary_size">Taille du binaire</string>
+    <string name="update_info_distribution">Distribution</string>
+    <string name="update_info_github_releases">GitHub Releases</string>
+    <string name="update_release_channel">Canal de publication</string>
+    <string name="update_view_changelog">Voir le journal des modifications</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">Choisir le filtrage SponsorBlock</string>
+    <string name="options_sponsorblock_ok">OK</string>
+    <string name="options_sponsorblock_cancel">Annuler</string>
+    <string name="options_chapters_title">Chapitres</string>
+    <string name="options_chapters_in_videos">Chapitres dans les vidéos</string>
+    <string name="options_chapters_split">Découper par chapitres</string>
+    <string name="options_chapters_split_body">Le découpage écrit un fichier par chapitre au lieu d\'un seul.</string>
+    <string name="options_chapters_dismiss">Ignorer</string>
+    <string name="options_subtitles_title">Sous-titres</string>
+    <string name="options_subtitles_embed">Intégrer les sous-titres</string>
+    <string name="options_subtitles_save">Enregistrer les sous-titres</string>
+    <string name="options_subtitles_save_auto">Enregistrer les sous-titres automatiques</string>
+    <string name="options_subtitles_languages_label">Langues des sous-titres</string>
+    <string name="options_subtitles_dismiss">Ignorer</string>
+    <string name="options_subtitles_languages_title">Langues des sous-titres</string>
+    <string name="options_subtitles_languages_hint">Un sélecteur de langue yt-dlp, par exemple en.*,.*-orig pour l\'anglais plus la piste d\'origine. Utilisez all pour toutes les langues proposées par la source.</string>
+    <string name="options_filename_title">Modèle de nom de fichier</string>
+    <string name="options_filename_hint">Modèle de sortie yt-dlp. Utilisez %(title)s, %(uploader)s, %(id)s et %(ext)s.</string>
+    <string name="options_text_input_save">Enregistrer</string>
+    <string name="options_text_input_cancel">Annuler</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">Retour</string>
+    <string name="cleanup_title">Fichiers temporaires</string>
+    <string name="cleanup_header_description">Fichiers de travail conservés par l\'application. Vos téléchargements n\'en font pas partie et ne sont jamais supprimés d\'ici.</string>
+    <string name="cleanup_action_clear_everything">Tout effacer</string>
+    <string name="cleanup_category_link_data_label">Cache des données de liens</string>
+    <string name="cleanup_category_link_data_description">Les données de lecteur que yt-dlp conserve pour qu\'un lien relu une deuxième fois soit plus rapide. Sans risque à effacer.</string>
+    <string name="cleanup_category_partial_downloads_label">Téléchargements inachevés</string>
+    <string name="cleanup_category_partial_downloads_description">Fragments laissés par un téléchargement annulé ou en échec avant l\'enregistrement du fichier.</string>
+    <string name="cleanup_category_conversions_label">Conversions inachevées</string>
+    <string name="cleanup_category_conversions_description">Fichiers de travail du convertisseur audio qui ne sont jamais arrivés dans votre dossier de musique.</string>
+    <string name="cleanup_category_engine_label">Fichiers du moteur yt-dlp</string>
+    <string name="cleanup_category_engine_description">Le téléchargeur et son environnement d\'exécution. Les effacer libère le plus de place, mais le prochain téléchargement doit les décompresser à nouveau.</string>
+    <string name="cleanup_category_other_cache_label">Autres fichiers en cache</string>
+    <string name="cleanup_category_other_cache_description">Les miniatures et tout ce qui a été mis en cache pendant la consultation des liens.</string>
+    <string name="cleanup_confirm_category_title">Effacer ces fichiers ?</string>
+    <string name="cleanup_confirm_category_safe">%1$s seront libérés. Rien de ce que vous avez enregistré n\'est touché.</string>
+    <string name="cleanup_confirm_category_unsafe">%1$s seront libérés, et le prochain téléchargement prendra plus de temps pendant leur décompression.</string>
+    <string name="cleanup_confirm_clear">Effacer</string>
+    <string name="cleanup_confirm_cancel">Annuler</string>
+    <string name="cleanup_confirm_all_title">Tout effacer ?</string>
+    <string name="cleanup_confirm_all_body">%1$s seront libérés. Vos téléchargements et vos connexions enregistrées sont conservés, mais le prochain téléchargement prendra plus de temps pendant la décompression du moteur.</string>
+    <string name="cleanup_confirm_all_confirm">Tout effacer</string>
+    <string name="cleanup_confirm_all_cancel">Annuler</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">Téléchargements</string>
+    <string name="history_layout_grid">Afficher les grandes images</string>
+    <string name="history_layout_list">Afficher en liste</string>
+    <string name="history_search_action">Chercher dans les téléchargements</string>
+    <string name="history_sort_action">Trier</string>
+    <string name="history_menu_action">Plus</string>
+    <string name="history_menu_clear">Effacer l\'historique</string>
+    <string name="history_search_placeholder">Chercher dans les téléchargements</string>
+    <string name="history_search_clear">Effacer la recherche</string>
+    <string name="history_empty_initial">Rien n\'a encore été téléchargé</string>
+    <string name="history_empty_filtered">Rien ne correspond</string>
+    <string name="history_clear_dialog_title">Effacer l\'historique</string>
+    <string name="history_clear_dialog_body">La liste est vidée. Vos fichiers téléchargés ne sont pas touchés.</string>
+    <string name="history_clear_dialog_confirm">Effacer</string>
+    <string name="history_clear_dialog_cancel">Annuler</string>
+    <string name="history_delete_dialog_title">Supprimer le fichier</string>
+    <string name="history_delete_dialog_body">%1$s sera supprimé de votre appareil.</string>
+    <string name="history_toast_file_deleted">Fichier supprimé</string>
+    <string name="history_toast_file_delete_failed">Impossible de supprimer le fichier</string>
+    <string name="history_delete_dialog_confirm">Supprimer</string>
+    <string name="history_delete_dialog_cancel">Annuler</string>
+    <string name="history_card_options">Options</string>
+    <string name="history_card_properties">Propriétés</string>
+    <string name="history_card_remove">Retirer de la liste</string>
+    <string name="history_card_delete">Supprimer le fichier</string>
+    <string name="history_tag_deleted">Supprimé</string>
+    <string name="history_row_options">Options</string>
+    <string name="history_row_properties">Propriétés</string>
+    <string name="history_row_remove">Retirer de la liste</string>
+    <string name="history_row_delete">Supprimer le fichier</string>
+    <string name="history_toast_file_gone">Ce fichier n\'est plus sur votre appareil</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">Propriétés</string>
+    <string name="properties_status">État</string>
+    <string name="properties_status_present">Sur cet appareil</string>
+    <string name="properties_status_deleted">Supprimé de cet appareil</string>
+    <string name="properties_kind">Type</string>
+    <string name="properties_kind_video">Vidéo</string>
+    <string name="properties_kind_audio">Audio</string>
+    <string name="properties_quality">Qualité</string>
+    <string name="properties_resolution">Résolution</string>
+    <string name="properties_length">Durée</string>
+    <string name="properties_codec">Codec</string>
+    <string name="properties_bitrate">Débit</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">Taille</string>
+    <string name="properties_container">Conteneur</string>
+    <string name="properties_type">Format</string>
+    <string name="properties_embedded">Intégré</string>
+    <string name="properties_file">Fichier</string>
+    <string name="properties_saved_to">Enregistré dans</string>
+    <string name="properties_downloaded">Téléchargé le</string>
+    <string name="properties_source">Source</string>
+    <string name="properties_link_copied_opened">Lien copié et ouvert</string>
+    <string name="properties_link_copied">Lien copié</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">Retour</string>
+    <string name="cookies_title">Cookies</string>
+    <string name="cookies_menu">Plus</string>
+    <string name="cookies_menu_import">Importer depuis le presse-papiers</string>
+    <string name="cookies_menu_export">Exporter vers le presse-papiers</string>
+    <string name="cookies_menu_delete_all">Tout supprimer</string>
+    <string name="cookies_imported_title">Cookies importés</string>
+    <string name="cookies_toast_imported">Cookies importés</string>
+    <string name="cookies_toast_no_data">Le presse-papiers ne contient aucun cookie</string>
+    <string name="cookies_toast_nothing_to_export">Rien à exporter</string>
+    <string name="cookies_toast_exported">Copié dans le presse-papiers</string>
+    <string name="cookies_toast_entry_copied">Copié dans le presse-papiers</string>
+    <string name="cookies_use_title">Utiliser les cookies</string>
+    <string name="cookies_use_description">Transmettre les connexions enregistrées au téléchargeur</string>
+    <string name="cookies_new">Nouveau cookie</string>
+    <string name="cookies_empty_title">Aucun cookie enregistré</string>
+    <string name="cookies_empty_body">Ajoutez-en un pour télécharger des contenus soumis à une limite d\'âge, privés ou réservés aux membres.</string>
+    <string name="cookies_delete_title">Supprimer les cookies</string>
+    <string name="cookies_delete_body">Retirer la connexion enregistrée pour %1$s ?</string>
+    <string name="cookies_delete_confirm">Supprimer</string>
+    <string name="cookies_delete_cancel">Annuler</string>
+    <string name="cookies_delete_all_title">Supprimer tous les cookies</string>
+    <string name="cookies_delete_all_body">Toutes les connexions enregistrées seront retirées. C\'est irréversible.</string>
+    <string name="cookies_delete_all_confirm">Tout supprimer</string>
+    <string name="cookies_delete_all_cancel">Annuler</string>
+    <string name="cookies_row_fallback_name">Cookies</string>
+    <string name="cookies_sheet_title">Cookies</string>
+    <string name="cookies_sheet_copy">Copier les cookies</string>
+    <string name="cookies_sheet_delete">Supprimer les cookies</string>
+    <string name="cookies_field_title">Titre</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">Enregistrer</string>
+    <string name="cookies_sheet_get">Obtenir les cookies</string>
+    <string name="cookies_sheet_update">Mettre à jour</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">Meilleure qualité</string>
+    <string name="batch_type_sheet_title">Type de téléchargement préféré</string>
+    <string name="batch_type_sheet_subtitle">Sous quelle forme ces liens sont téléchargés</string>
+    <string name="batch_type_audio">Audio</string>
+    <string name="batch_type_video">Vidéo</string>
+    <string name="batch_format_title">Format</string>
+    <string name="batch_format_subtitle">Choisir le format</string>
+    <string name="batch_container_title">Conteneur</string>
+    <string name="batch_container_subtitle">Le fichier dans lequel ces liens sont enregistrés</string>
+    <string name="batch_save_dir_title">Emplacement</string>
+    <string name="batch_open_folder">Ouvrir ce dossier</string>
+    <string name="batch_change_folder">Changer de dossier</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">Miniature</string>
+    <string name="batch_bar_chapters">Chapitres</string>
+    <string name="batch_bar_subtitles">Sous-titres</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">Modèle de nom de fichier</string>
+    <string name="batch_bar_download_type">Type de téléchargement préféré</string>
+    <string name="batch_bar_quality">Qualité : %1$s</string>
+    <string name="batch_bar_save_location">Emplacement</string>
+    <string name="batch_bar_container">Conteneur</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">Télécharger</string>
+    <string name="batch_header_subtitle">Ajuster le téléchargement</string>
+    <string name="batch_download_action">Télécharger</string>
+    <string name="batch_stop_selecting">Arrêter la sélection</string>
+    <string name="batch_start_selecting">Sélectionner des liens</string>
+    <string name="batch_list_options">Options de la liste</string>
+    <string name="batch_menu_select_links">Sélectionner des liens</string>
+    <string name="batch_menu_select_all">Tout sélectionner</string>
+    <string name="batch_menu_invert">Inverser la sélection</string>
+    <string name="batch_menu_remove_selected">Retirer la sélection</string>
+    <string name="batch_menu_done">Terminé</string>
+    <plurals name="batch_selected">
+        <item quantity="one">%d sélectionné</item>
+        <item quantity="many">%d de sélectionnés</item>
+        <item quantity="other">%d sélectionnés</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="one">%d lien</item>
+        <item quantity="many">%d de liens</item>
+        <item quantity="other">%d liens</item>
+    </plurals>
+    <string name="batch_card_download_type">Type de téléchargement pour ce lien</string>
+    <string name="batch_card_remove">Retirer</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">L\'emplacement de ce fichier est inconnu</string>
+    <string name="media_open_chooser">Ouvrir avec</string>
+    <string name="media_open_no_app">Rien sur cet appareil ne peut l\'ouvrir</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">Téléchargement annulé</string>
+    <string name="notification_channel_progress_description">Progression du téléchargement, affiche une icône dans la barre d\'état</string>
+    <string name="notification_channel_complete_description">Alertes de téléchargement terminé</string>
+    <string name="notification_action_pause">Pause</string>
+    <string name="notification_action_resume">Reprendre</string>
+    <string name="notification_action_cancel">Annuler</string>
+    <string name="notification_action_sign_in">Se connecter</string>
+    <string name="notification_wifi_title">En attente du Wi-Fi</string>
+    <string name="notification_wifi_text">Les téléchargements sont limités au Wi-Fi. Ils démarrent dès que vous y êtes de nouveau.</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">Fermer</string>
+    <string name="cookie_webview_desktop_site">Version ordinateur</string>
+    <string name="cookie_webview_no_cookies">Aucun cookie n\'a été récupéré</string>
+    <string name="cookie_webview_done">"  OK"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">Trier les formats</string>
+    <string name="format_selection_change">Changer de format</string>
+    <string name="format_selection_title">Format</string>
+    <string name="format_selection_subtitle">Choisir le format</string>
+    <string name="format_selection_confirm">OK</string>
+    <string name="format_selection_loading">Lecture du reste des formats</string>
+    <string name="format_sort_quality">Qualité</string>
+    <string name="format_sort_file_size">Taille du fichier</string>
+    <string name="format_sort_container">Conteneur</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">Langue de l\'audio</string>
+    <string name="audio_language_subtitle">Choisir la bande-son</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">Retour</string>
+    <string name="appearance_title">Apparence</string>
+
+    <!-- Language picker -->
+    <string name="language_title">Langue</string>
+    <string name="language_system">Celle du système</string>
+    <string name="language_system_description">Suivre la langue de l\'appareil</string>
+    <string name="language_close">Fermer</string>
+    <string name="language_changed_title">Langue modifiée</string>
+    <string name="language_changed_body">Hazel est maintenant dans cette langue. Ce qui n\'a pas encore été traduit reste en anglais.</string>
+    <string name="language_changed_ok">OK</string>
+    <string name="appearance_dark_theme">Thème sombre</string>
+    <string name="appearance_accent_color">Couleur d\'accent</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">Couleur d\'accent</string>
+    <string name="accent_picker_close">Fermer</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">Retour</string>
+    <string name="fetch_settings_title">Lecture des liens</string>
+    <string name="fetch_settings_timeout_description">Combien de temps attendre une source lente avant d\'abandonner et de réessayer.</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="one">%1$ds d\'attente, %2$d essai</item>
+        <item quantity="many">%1$ds d\'attente, %2$d d\'essais</item>
+        <item quantity="other">%1$ds d\'attente, %2$d essais</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">Lecture des liens</string>
+    <string name="fetch_settings_reading_links_description">Quel lecteur détermine ce que contient un lien. Les téléchargements passent toujours par yt-dlp, quel que soit le choix fait ici.</string>
+    <string name="fetch_settings_force_ipv4_description">N\'activez ceci que si les liens restent bloqués sur votre réseau. Cela contourne une route IPv6 défaillante, et c\'est plus lent partout ailleurs.</string>
+    <string name="fetch_settings_force_ipv4">Forcer l\'IPv4</string>
+    <string name="fetch_mode_fast_label">Rapide</string>
+    <string name="fetch_mode_fast_description">Abandonne vite. Le plus rapide sur un bon réseau, mais une deuxième tentative est plus souvent nécessaire.</string>
+    <string name="fetch_mode_balanced_label">Équilibré</string>
+    <string name="fetch_mode_balanced_description">Un juste milieu entre la vitesse et la tolérance à une mauvaise connexion.</string>
+    <string name="fetch_mode_thorough_label">Minutieux</string>
+    <string name="fetch_mode_thorough_description">Attend plus longtemps et réessaie davantage. Le plus lent, mais il survit à un réseau faible.</string>
+    <string name="listing_source_ytdlp_description">Le moteur qui fait aussi le téléchargement. Il fonctionne sur tous les sites qu\'il prend en charge, et se met à jour tout seul, donc il continue de marcher à mesure que les sites changent.</string>
+    <string name="listing_source_newpipe_label">Préférer le lecteur intégré</string>
+    <string name="listing_source_newpipe_description">Liste les playlists et les chaînes en une seule requête au lieu de lancer le moteur, ce qui est plus rapide sur les sites qu\'il connaît. Il revient à yt-dlp pour tout le reste, et dès qu\'il ne parvient pas à lire un lien.</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">Retour</string>
+    <string name="tools_title">Outils</string>
+    <string name="tools_empty">Il n\'y a encore rien ici.</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">Retour</string>
+    <string name="direct_share_save_as">Enregistrer comme</string>
+    <string name="direct_share_video">Vidéo</string>
+    <string name="direct_share_audio_only">Audio seul</string>
+    <string name="direct_share_title">Hazel Instantané</string>
+    <string name="direct_share_intro">Partager un lien vers Hazel Instantané lance le téléchargement aussitôt, sans panneau et sans question. Voici les réponses qu\'il utilise.</string>
+    <string name="direct_share_video_description">Image et son, réunis dans un seul fichier.</string>
+    <string name="direct_share_audio_description">Le son seul, dans ce que la source propose de mieux.</string>
+    <string name="direct_share_quality_title">Limite de qualité</string>
+    <string name="direct_share_quality_description">Un plafond, pas une taille exacte. Les sources ne proposent pas toutes les mêmes hauteurs, donc la plus grande qui tient en dessous est retenue, et la plus petite disponible quand aucune ne tient.</string>
+    <string name="direct_share_output_title">Sortie</string>
+    <string name="direct_share_output_description">Le fichier qui arrive sur l\'appareil. Par défaut garde ce que la source fournit déjà, ce qui est l\'option la plus rapide puisque rien n\'est réencodé.</string>
+    <string name="direct_share_filename_template">Modèle de nom de fichier</string>
+    <string name="direct_share_audio_language">Langue de l\'audio</string>
+    <string name="direct_share_audio_language_default">Celle de la source</string>
+    <string name="direct_share_extras_title">Suppléments</string>
+    <string name="direct_share_extras_description">Appliqués quand la source les possède. Ce qu\'elle n\'a pas est ignoré pour ce téléchargement plutôt que de le faire échouer.</string>
+    <string name="direct_share_cover_art">Pochette</string>
+    <string name="direct_share_cover_art_description">Écrit la miniature dans le fichier, lorsque le conteneur peut en accueillir une.</string>
+    <string name="direct_share_chapters">Chapitres</string>
+    <string name="direct_share_subtitles">Sous-titres</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">Désactivé</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="one">%1$d catégorie coupée</item>
+        <item quantity="many">%1$d de catégories coupées</item>
+        <item quantity="other">%1$d catégories coupées</item>
+    </plurals>
+    <string name="direct_share_signins_title">Connexions</string>
+    <string name="direct_share_signins_description">Un partage instantané utilise les cookies enregistrés du site auquel appartient le lien, comme un téléchargement lancé depuis le panneau. Rien n\'est demandé au moment du partage, donc un lien derrière une connexion ne fonctionne que si celle-ci est déjà enregistrée et activée.</string>
+    <string name="direct_share_cookies">Cookies</string>
+    <string name="direct_share_cookies_on">Activé, utilisés à chaque partage instantané</string>
+    <string name="direct_share_cookies_off">Désactivé</string>
+    <string name="direct_share_change">Modifier %1$s</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">Retour</string>
+    <string name="storage_locations_downloads">Téléchargements</string>
+    <string name="storage_locations_title">Téléchargements</string>
+    <string name="storage_locations_subtitle">Où les téléchargements sont enregistrés, et les limites qui s\'y appliquent</string>
+    <string name="storage_locations_limits">Limites</string>
+    <string name="storage_locations_wifi_only_description">Les téléchargements attendent au lieu d\'utiliser les données mobiles</string>
+    <string name="storage_locations_speed_limit_description">À quelle vitesse un téléchargement peut aller</string>
+    <string name="storage_locations_internal_note">Tous les fichiers sont conservés dans le stockage interne de votre appareil. Vous pouvez y accéder à tout moment avec n\'importe quel gestionnaire de fichiers.</string>
+    <string name="storage_locations_wifi_only">Wi-Fi uniquement</string>
+    <string name="storage_locations_speed_limit">Limite de vitesse</string>
+
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -475,10 +475,13 @@
     <string name="appearance_title">Apparence</string>
 
     <!-- Language picker -->
-    <string name="language_title">Langue</string>
+    <string name="language_title">Langue de l\'application</string>
     <string name="language_system">Celle du système</string>
-    <string name="language_system_description">Suivre la langue de l\'appareil</string>
-    <string name="language_close">Fermer</string>
+    <string name="language_system_description">Suivre l\'appareil</string>
+    <string name="language_current">Actuelle : %1$s</string>
+    <string name="language_selected">Choisie : %1$s</string>
+    <string name="language_cancel">Annuler</string>
+    <string name="language_confirm">Confirmer</string>
     <string name="language_changed_title">Langue modifiée</string>
     <string name="language_changed_body">Hazel est maintenant dans cette langue. Ce qui n\'a pas encore été traduit reste en anglais.</string>
     <string name="language_changed_ok">OK</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,0 +1,559 @@
+<resources>
+    <string name="direct_share_label">इंस्टेंट</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">होम</string>
+    <string name="nav_history">डाउनलोड</string>
+    <string name="nav_more">और</string>
+    <string name="nav_incognito_on">गुप्त मोड चालू है, डाउनलोड दर्ज नहीं होंगे</string>
+    <string name="nav_incognito_off">गुप्त मोड बंद है</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">खोजें या लिंक चिपकाएँ</string>
+    <string name="download_clear">हटाएँ</string>
+    <string name="download_show_large_artwork">बड़ी तस्वीरें दिखाएँ</string>
+    <string name="download_show_list">सूची के रूप में दिखाएँ</string>
+    <string name="download_instant_source">इंस्टेंट · %1$s से पढ़ा जा रहा है</string>
+    <string name="download_incognito_title">आप गुप्त मोड में हैं</string>
+    <string name="download_incognito_body">डाउनलोड आपके इतिहास में नहीं जुड़ते और लिंक याद नहीं रखे जाते। फ़ाइलें हमेशा की तरह सहेजी जाती हैं।</string>
+    <string name="download_download_all">सब डाउनलोड करें</string>
+    <string name="download_saved_aside">आपके डाउनलोड सहेज लिए गए हैं। उन्हें डाउनलोड टैब में देखें।</string>
+    <string name="download_options">डाउनलोड विकल्प</string>
+    <string name="download_pause">रोकें</string>
+    <string name="download_resume">फिर शुरू करें</string>
+    <string name="download_cancel">रद्द करें</string>
+    <string name="download_paused">रुका हुआ</string>
+    <string name="download_processing">तैयार किया जा रहा है</string>
+    <string name="download_waiting_wifi">वाई-फ़ाई का इंतज़ार</string>
+    <string name="download_saved">सहेजा गया</string>
+    <string name="download_queued">कतार में</string>
+    <string name="download_downloaded">डाउनलोड हो चुका</string>
+    <string name="download_failed">विफल</string>
+    <string name="download_remove_link">लिंक हटाएँ</string>
+    <string name="download_cancel_action">डाउनलोड रद्द करें</string>
+    <string name="download_resume_action">डाउनलोड फिर शुरू करें</string>
+    <plurals name="download_links">
+        <item quantity="one">%d लिंक</item>
+        <item quantity="other">%d लिंक</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">खोजें या लिंक चिपकाएँ</string>
+    <string name="search_back">वापस</string>
+    <string name="search_more">और</string>
+    <string name="search_add_link">एक और लिंक जोड़ें</string>
+    <string name="search_clear">मिटाएँ</string>
+    <string name="search_clear_results">परिणाम हटाएँ</string>
+    <string name="search_clear_history">खोज इतिहास मिटाएँ</string>
+    <string name="search_empty_history">आपके इस्तेमाल किए लिंक यहाँ दिखेंगे</string>
+    <string name="search_no_matches">कोई लिंक मेल नहीं खाता</string>
+    <string name="search_remove">हटाएँ</string>
+    <string name="search_all">सब खोजें</string>
+    <string name="search_forget">भूल जाएँ</string>
+    <string name="search_edit_before">खोजने से पहले बदलें</string>
+    <string name="search_paste_and_fetch">चिपकाएँ और खोजें</string>
+    <string name="search_nothing_to_paste">चिपकाने के लिए कुछ नहीं है</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">पहले से डाउनलोड है</string>
+    <string name="already_downloaded_body">यह लिंक इस डिवाइस पर पहले से सहेजा हुआ है।</string>
+    <string name="already_downloaded_video">वीडियो</string>
+    <string name="already_downloaded_audio">ऑडियो</string>
+    <string name="already_downloaded_keep">रहने दें</string>
+    <string name="already_downloaded_play">चलाएँ</string>
+    <string name="already_downloaded_download_again">फिर से डाउनलोड करें</string>
+    <string name="already_downloaded_just_now">अभी अभी</string>
+    <string name="already_downloaded_yesterday">कल</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="one">%d मिनट</item>
+        <item quantity="other">%d मिनट</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="one">%d घंटा</item>
+        <item quantity="other">%d घंटे</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="one">%d दिन</item>
+        <item quantity="other">%d दिन</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="one">%d माह</item>
+        <item quantity="other">%d माह</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">साइन इन ज़रूरी है</string>
+    <string name="no_results_error_title">यह लिंक पढ़ा नहीं जा सका</string>
+    <string name="no_results_sign_in_body">यह स्रोत देने से पहले खाता माँगता है। साइन इन करने पर साइट की कुकीज़ सहेजी जाती हैं और दोबारा कोशिश होती है।</string>
+    <string name="no_results_continue_body">जानकारी पढ़ी नहीं जा सकी, पर डाउनलोड फिर भी चल सकता है। आगे बढ़ने पर उपलब्ध सबसे अच्छी क्वालिटी दी जाती है।</string>
+    <string name="no_results_refused_body">स्रोत ने अनुरोध ठुकरा दिया।</string>
+    <string name="no_results_engine_report">इंजन ने क्या बताया</string>
+    <string name="no_results_copy_log">लॉग कॉपी करें</string>
+    <string name="no_results_sign_in">साइन इन करें</string>
+    <string name="no_results_try_anyway">फिर भी कोशिश करें</string>
+    <string name="no_results_close">बंद करें</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">शुरुआत करें</string>
+    <string name="guide_step_paste_link">डाउनलोड करने के लिए खोज बॉक्स में लिंक चिपकाएँ। आप कई लिंक और प्लेलिस्ट भी जोड़ सकते हैं</string>
+    <string name="guide_step_pick_format">सही फ़ॉर्मैट चुनने के लिए किसी कार्ड पर टैप करें। हर उपलब्ध क्वालिटी उसके आकार और कोडेक के साथ दिखाई जाती है।</string>
+    <string name="guide_step_share_instant">किसी भी ऐप से Hazel इंस्टेंट को लिंक साझा करें और तय की गई क्वालिटी में तुरंत डाउनलोड करें।</string>
+    <string name="guide_step_finished_downloads">पूरी हुई फ़ाइलें डाउनलोड में दिखती हैं। डिवाइस के डिफ़ॉल्ट प्लेयर में खोलने के लिए किसी भी पंक्ति पर टैप करें।</string>
+    <string name="guide_step_battery_unrestricted">बैटरी उपयोग को अप्रतिबंधित पर रखें, वरना ऐप से बाहर जाते ही Android डाउनलोड रोक सकता है।</string>
+    <string name="guide_battery_settings">बैटरी सेटिंग</string>
+    <string name="guide_close">बंद करें</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">डाउनलोड</string>
+    <string name="format_sheet_subtitle">डाउनलोड सेट करें</string>
+    <string name="format_sheet_play">चलाएँ</string>
+    <string name="format_sheet_ok">ठीक है</string>
+    <string name="format_sheet_download">डाउनलोड</string>
+    <string name="format_sheet_tab_audio">ऑडियो</string>
+    <string name="format_sheet_tab_video">वीडियो</string>
+    <string name="format_sheet_label_title">शीर्षक</string>
+    <string name="format_sheet_label_author">लेखक</string>
+    <string name="format_sheet_label_container">कंटेनर</string>
+    <string name="format_sheet_video_quality">वीडियो क्वालिटी</string>
+    <string name="format_sheet_audio_quality">ऑडियो क्वालिटी</string>
+    <string name="format_sheet_no_video_stream">इस स्रोत में अलग वीडियो स्ट्रीम नहीं है।</string>
+    <string name="format_sheet_no_audio_stream">इस स्रोत में अलग ऑडियो स्ट्रीम नहीं है।</string>
+    <string name="format_sheet_adjust_video">वीडियो सेट करें</string>
+    <string name="format_sheet_adjust_audio">ऑडियो सेट करें</string>
+    <string name="format_sheet_thumbnail">थंबनेल</string>
+    <string name="format_sheet_chapters">अध्याय</string>
+    <string name="format_sheet_subtitles">उपशीर्षक</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">ऑडियो की भाषा</string>
+    <string name="format_sheet_change_audio_language">ऑडियो की भाषा बदलें</string>
+    <string name="format_sheet_filename_template">फ़ाइल नाम टेम्पलेट</string>
+    <string name="format_sheet_change_field">बदलें</string>
+    <string name="format_sheet_save_dir">फ़ोल्डर</string>
+    <string name="format_sheet_save_location">सहेजने की जगह</string>
+    <string name="format_sheet_save_location_title">सहेजने की जगह</string>
+    <string name="format_sheet_save_location_body">इस फ़ोल्डर को अपने फ़ाइल मैनेजर में खोलें, या डाउनलोड सहेजने के लिए दूसरा चुनें।</string>
+    <string name="format_sheet_open_folder">फ़ोल्डर खोलें</string>
+    <string name="format_sheet_reset">रीसेट करें</string>
+    <string name="format_sheet_change">बदलें</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">इसमें बदलें</string>
+    <string name="converter_label_saved_to">यहाँ सहेजा गया</string>
+    <string name="converter_hazel_storage">Hazel का अपना स्टोरेज</string>
+    <string name="converter_storage_warning">स्टोरेज की अनुमति के बिना फ़ाइल Hazel के अंदर ही रहती है, जहाँ दूसरे ऐप उसे नहीं देख सकते।</string>
+    <string name="converter_back">वापस</string>
+    <string name="converter_title">ऑफ़लाइन कन्वर्टर</string>
+    <string name="converter_subtitle">वीडियो से ऑडियो, कुछ भी फ़ोन से बाहर नहीं जाता</string>
+    <string name="converter_choose_video">कोई वीडियो फ़ाइल चुनें</string>
+    <string name="converter_ready">तैयार</string>
+    <string name="converter_choose_video_hint">फ़ोन या SD कार्ड की कोई भी फ़ाइल</string>
+    <string name="converter_change">बदलें</string>
+    <string name="converter_converting">बदला जा रहा है</string>
+    <string name="converter_convert">बदलें</string>
+    <string name="converter_saved">सहेजा गया</string>
+    <string name="converter_open_folder">फ़ोल्डर खोलें</string>
+    <string name="converter_convert_another">दूसरा बदलें</string>
+    <string name="converter_error_title">यह नहीं बदला जा सका</string>
+    <string name="converter_dismiss">हटाएँ</string>
+    <string name="converter_save_as_title">इस नाम से सहेजें</string>
+    <string name="converter_save_as_body">फ़ाइल का नाम तय करता है, और उसके शीर्षक टैग में भी लिखा जाता है।</string>
+    <string name="converter_label_name">नाम</string>
+    <string name="converter_start">शुरू करें</string>
+    <string name="converter_format_sheet_title">इसमें बदलें</string>
+    <string name="converter_heading_common">काम के तीन</string>
+    <string name="converter_heading_other">बाकी सब</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">और</string>
+    <string name="more_battery_title">पृष्ठभूमि में डाउनलोड</string>
+    <string name="more_battery_body">डाउनलोड पृष्ठभूमि में अपने आप चलते रहते हैं। फिर भी कुछ फ़ोन बैटरी बचाने के लिए उन्हें बीच में रोक देते हैं। इसे टालने के लिए अप्रतिबंधित उपयोग की अनुमति दें।</string>
+    <string name="more_downloads">डाउनलोड</string>
+    <string name="more_appearance">दिखावट</string>
+    <string name="more_language">भाषा</string>
+    <string name="more_cookies">कुकीज़</string>
+    <string name="more_link_reading">लिंक पढ़ना</string>
+    <string name="more_hazel_instant">Hazel इंस्टेंट</string>
+    <string name="more_temporary_files">अस्थायी फ़ाइलें</string>
+    <string name="more_converter">ऑफ़लाइन वीडियो को ऑडियो में बदलें</string>
+    <string name="more_engine_update">yt-dlp इंजन अपडेट</string>
+    <string name="more_support">Hazel का साथ दें</string>
+    <string name="more_license">लाइसेंस</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">वापस</string>
+    <string name="sponsor_title">Hazel का साथ दें</string>
+    <string name="sponsor_hero_title">मुफ़्त है, और मुफ़्त ही रहेगा</string>
+    <string name="sponsor_hero_body">Hazel शाम और छुट्टियों में बनाया जाता है, और मुफ़्त दिया जाता है क्योंकि डाउनलोड के पैसे लेने वाला डाउनलोडर एक कमज़ोर डाउनलोडर है। साइटें लगातार बदलती रहती हैं, और उनके साथ चलते रहना ही असली काम है।</string>
+    <string name="sponsor_hero_closing">अगर इस ऐप ने आपकी एक दोपहर बचाई है, तो नीचे दिया कोई भी तरीका वह समय वापस लौटा देता है। अगर नहीं बचाई, तो बिना पैसे वाले तरीके भी उतनी ही मदद करते हैं।</string>
+    <string name="sponsor_section_ways">साथ देने के तरीके</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">हर महीने या एक बार, जब चाहें बंद करें। पूरा इंतज़ाम GitHub करता है।</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">एक बार का, खाते की ज़रूरत नहीं।</string>
+    <string name="sponsor_kofi_soon">जल्द खुल रहा है</string>
+    <string name="sponsor_section_free">कुछ खर्च नहीं, मदद उतनी ही</string>
+    <string name="sponsor_star_title">प्रोजेक्ट को स्टार दें</string>
+    <string name="sponsor_star_subtitle">ऐप आज़माने से पहले लोग यही एक आँकड़ा देखते हैं।</string>
+    <string name="sponsor_share_title">किसी को इसके बारे में बताएँ</string>
+    <string name="sponsor_share_subtitle">इस ऐप का पूरा प्रचार बस लोगों की बातचीत है।</string>
+    <string name="sponsor_issues_title">जो टूटे, उसकी ख़बर दें</string>
+    <string name="sponsor_issues_subtitle">जो साइट काम करना बंद कर दे, उसका सुधार कोई और नहीं लिख सकता।</string>
+    <string name="sponsor_source_title">कोड पढ़ें</string>
+    <string name="sponsor_source_subtitle">इसकी हर पंक्ति सार्वजनिक है, और पुल रिक्वेस्ट का स्वागत है।</string>
+    <string name="sponsor_footer">कोई विज्ञापन नहीं, आप क्या डाउनलोड करते हैं इसका कोई हिसाब नहीं, और कोई सुविधा किसी के लिए रोकी नहीं गई। साथ देने से यह बदलता है कि Hazel में कितना समय लगता है, यह नहीं कि वह आपके लिए क्या करेगा।</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">yt-dlp अपडेट</string>
+    <string name="update_back">वापस</string>
+    <string name="update_check_action">अपडेट देखें</string>
+    <string name="update_status_up_to_date">आप अद्यतन हैं</string>
+    <string name="update_status_checking">अपडेट देखे जा रहे हैं...</string>
+    <string name="update_status_available">अपडेट उपलब्ध है</string>
+    <string name="update_status_installing">yt-dlp इंस्टॉल हो रहा है...</string>
+    <string name="update_status_installed">इंजन अपडेट हुआ</string>
+    <string name="update_status_failed">अपडेट विफल</string>
+    <string name="update_subtitle_idle">Hazel नवीनतम yt-dlp बिल्ड पर चल रहा है</string>
+    <string name="update_subtitle_checking">GitHub से संपर्क हो रहा है...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s उपलब्ध है</string>
+    <string name="update_subtitle_updating">yt-dlp %1$s डाउनलोड हो रहा है</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s अब इस्तेमाल में है</string>
+    <string name="update_installed_version">इंस्टॉल किया संस्करण</string>
+    <string name="update_version_unknown">अज्ञात</string>
+    <string name="update_new_version">नया संस्करण</string>
+    <string name="update_installing_binary">बाइनरी इंस्टॉल हो रही है</string>
+    <string name="update_installing_body">GitHub से डाउनलोड करके इंजन बदला जा रहा है। ऐप खुला रखें।</string>
+    <string name="update_action_update_now">अभी अपडेट करें</string>
+    <string name="update_action_installing">इंस्टॉल हो रहा है...</string>
+    <string name="update_action_done">हो गया</string>
+    <string name="update_action_retry">फिर कोशिश करें</string>
+    <string name="update_action_check">अपडेट देखें</string>
+    <string name="update_action_checking">देखा जा रहा है...</string>
+    <string name="update_info_heading">जानकारी</string>
+    <string name="update_info_component">घटक</string>
+    <string name="update_info_repository">रिपॉज़िटरी</string>
+    <string name="update_info_binary_size">बाइनरी का आकार</string>
+    <string name="update_info_distribution">वितरण</string>
+    <string name="update_info_github_releases">GitHub Releases</string>
+    <string name="update_release_channel">रिलीज़ चैनल</string>
+    <string name="update_view_changelog">बदलावों की सूची देखें</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">SponsorBlock फ़िल्टर चुनें</string>
+    <string name="options_sponsorblock_ok">ठीक है</string>
+    <string name="options_sponsorblock_cancel">रद्द करें</string>
+    <string name="options_chapters_title">अध्याय</string>
+    <string name="options_chapters_in_videos">वीडियो में अध्याय</string>
+    <string name="options_chapters_split">अध्यायों में बाँटें</string>
+    <string name="options_chapters_split_body">बाँटने पर एक फ़ाइल के बजाय हर अध्याय की अलग फ़ाइल बनती है।</string>
+    <string name="options_chapters_dismiss">हटाएँ</string>
+    <string name="options_subtitles_title">उपशीर्षक</string>
+    <string name="options_subtitles_embed">उपशीर्षक फ़ाइल में जोड़ें</string>
+    <string name="options_subtitles_save">उपशीर्षक सहेजें</string>
+    <string name="options_subtitles_save_auto">अपने आप बने उपशीर्षक सहेजें</string>
+    <string name="options_subtitles_languages_label">उपशीर्षक की भाषाएँ</string>
+    <string name="options_subtitles_dismiss">हटाएँ</string>
+    <string name="options_subtitles_languages_title">उपशीर्षक की भाषाएँ</string>
+    <string name="options_subtitles_languages_hint">yt-dlp का भाषा चयनकर्ता, जैसे en.*,.*-orig अंग्रेज़ी और मूल ट्रैक के लिए। स्रोत की हर भाषा के लिए all इस्तेमाल करें।</string>
+    <string name="options_filename_title">फ़ाइल नाम टेम्पलेट</string>
+    <string name="options_filename_hint">yt-dlp का आउटपुट टेम्पलेट। %(title)s, %(uploader)s, %(id)s और %(ext)s इस्तेमाल करें।</string>
+    <string name="options_text_input_save">सहेजें</string>
+    <string name="options_text_input_cancel">रद्द करें</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">वापस</string>
+    <string name="cleanup_title">अस्थायी फ़ाइलें</string>
+    <string name="cleanup_header_description">ऐप के काम की फ़ाइलें। आपके डाउनलोड इसमें शामिल नहीं हैं और यहाँ से कभी नहीं हटते।</string>
+    <string name="cleanup_action_clear_everything">सब कुछ मिटाएँ</string>
+    <string name="cleanup_category_link_data_label">लिंक डेटा कैश</string>
+    <string name="cleanup_category_link_data_description">प्लेयर का वह डेटा जो yt-dlp रखता है ताकि दोबारा पढ़ा गया लिंक जल्दी खुले। मिटाना सुरक्षित है।</string>
+    <string name="cleanup_category_partial_downloads_label">अधूरे डाउनलोड</string>
+    <string name="cleanup_category_partial_downloads_description">फ़ाइल सहेजे जाने से पहले रद्द या विफल हुए डाउनलोड के बचे हुए टुकड़े।</string>
+    <string name="cleanup_category_conversions_label">अधूरे रूपांतरण</string>
+    <string name="cleanup_category_conversions_description">ऑडियो कन्वर्टर की वे फ़ाइलें जो कभी आपके संगीत फ़ोल्डर तक नहीं पहुँचीं।</string>
+    <string name="cleanup_category_engine_label">yt-dlp इंजन की फ़ाइलें</string>
+    <string name="cleanup_category_engine_description">डाउनलोडर और उसका रनटाइम। मिटाने से सबसे ज़्यादा जगह खाली होती है, पर अगले डाउनलोड में उन्हें फिर से खोलना पड़ता है।</string>
+    <string name="cleanup_category_other_cache_label">अन्य कैश की गई फ़ाइलें</string>
+    <string name="cleanup_category_other_cache_description">थंबनेल और लिंक देखते समय कैश हुआ बाकी सब कुछ।</string>
+    <string name="cleanup_confirm_category_title">ये फ़ाइलें मिटाएँ?</string>
+    <string name="cleanup_confirm_category_safe">%1$s खाली हो जाएगा। आपकी सहेजी हुई किसी चीज़ पर असर नहीं पड़ेगा।</string>
+    <string name="cleanup_confirm_category_unsafe">%1$s खाली हो जाएगा, और अगला डाउनलोड इन्हें फिर से खोलने में ज़्यादा समय लेगा।</string>
+    <string name="cleanup_confirm_clear">मिटाएँ</string>
+    <string name="cleanup_confirm_cancel">रद्द करें</string>
+    <string name="cleanup_confirm_all_title">सब कुछ मिटाएँ?</string>
+    <string name="cleanup_confirm_all_body">%1$s खाली हो जाएगा। आपके डाउनलोड और सहेजे गए साइन इन बने रहेंगे, पर अगला डाउनलोड इंजन को फिर से खोलने में ज़्यादा समय लेगा।</string>
+    <string name="cleanup_confirm_all_confirm">सब कुछ मिटाएँ</string>
+    <string name="cleanup_confirm_all_cancel">रद्द करें</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">डाउनलोड</string>
+    <string name="history_layout_grid">बड़ी तस्वीरें दिखाएँ</string>
+    <string name="history_layout_list">सूची के रूप में दिखाएँ</string>
+    <string name="history_search_action">डाउनलोड में खोजें</string>
+    <string name="history_sort_action">क्रम</string>
+    <string name="history_menu_action">और</string>
+    <string name="history_menu_clear">इतिहास मिटाएँ</string>
+    <string name="history_search_placeholder">डाउनलोड में खोजें</string>
+    <string name="history_search_clear">खोज मिटाएँ</string>
+    <string name="history_empty_initial">अभी तक कुछ डाउनलोड नहीं हुआ</string>
+    <string name="history_empty_filtered">इससे कुछ मेल नहीं खाता</string>
+    <string name="history_clear_dialog_title">इतिहास मिटाएँ</string>
+    <string name="history_clear_dialog_body">सूची खाली हो जाती है। आपकी डाउनलोड की गई फ़ाइलों को कुछ नहीं होता।</string>
+    <string name="history_clear_dialog_confirm">मिटाएँ</string>
+    <string name="history_clear_dialog_cancel">रद्द करें</string>
+    <string name="history_delete_dialog_title">फ़ाइल हटाएँ</string>
+    <string name="history_delete_dialog_body">%1$s आपके डिवाइस से हटा दी जाएगी।</string>
+    <string name="history_toast_file_deleted">फ़ाइल हटा दी गई</string>
+    <string name="history_toast_file_delete_failed">फ़ाइल हटाई नहीं जा सकी</string>
+    <string name="history_delete_dialog_confirm">हटाएँ</string>
+    <string name="history_delete_dialog_cancel">रद्द करें</string>
+    <string name="history_card_options">विकल्प</string>
+    <string name="history_card_properties">विवरण</string>
+    <string name="history_card_remove">सूची से हटाएँ</string>
+    <string name="history_card_delete">फ़ाइल हटाएँ</string>
+    <string name="history_tag_deleted">हटाई गई</string>
+    <string name="history_row_options">विकल्प</string>
+    <string name="history_row_properties">विवरण</string>
+    <string name="history_row_remove">सूची से हटाएँ</string>
+    <string name="history_row_delete">फ़ाइल हटाएँ</string>
+    <string name="history_toast_file_gone">यह फ़ाइल अब आपके डिवाइस पर नहीं है</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">विवरण</string>
+    <string name="properties_status">स्थिति</string>
+    <string name="properties_status_present">इस डिवाइस पर है</string>
+    <string name="properties_status_deleted">इस डिवाइस से हटाई गई</string>
+    <string name="properties_kind">प्रकार</string>
+    <string name="properties_kind_video">वीडियो</string>
+    <string name="properties_kind_audio">ऑडियो</string>
+    <string name="properties_quality">क्वालिटी</string>
+    <string name="properties_resolution">रिज़ॉल्यूशन</string>
+    <string name="properties_length">अवधि</string>
+    <string name="properties_codec">कोडेक</string>
+    <string name="properties_bitrate">बिटरेट</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">आकार</string>
+    <string name="properties_container">कंटेनर</string>
+    <string name="properties_type">फ़ॉर्मैट</string>
+    <string name="properties_embedded">जोड़ा गया</string>
+    <string name="properties_file">फ़ाइल</string>
+    <string name="properties_saved_to">यहाँ सहेजा गया</string>
+    <string name="properties_downloaded">डाउनलोड किया</string>
+    <string name="properties_source">स्रोत</string>
+    <string name="properties_link_copied_opened">लिंक कॉपी करके खोला गया</string>
+    <string name="properties_link_copied">लिंक कॉपी हुआ</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">वापस</string>
+    <string name="cookies_title">कुकीज़</string>
+    <string name="cookies_menu">और</string>
+    <string name="cookies_menu_import">क्लिपबोर्ड से लाएँ</string>
+    <string name="cookies_menu_export">क्लिपबोर्ड में भेजें</string>
+    <string name="cookies_menu_delete_all">सब हटाएँ</string>
+    <string name="cookies_imported_title">लाई गई कुकीज़</string>
+    <string name="cookies_toast_imported">कुकीज़ ले ली गईं</string>
+    <string name="cookies_toast_no_data">क्लिपबोर्ड में कुकी डेटा नहीं है</string>
+    <string name="cookies_toast_nothing_to_export">भेजने के लिए कुछ नहीं है</string>
+    <string name="cookies_toast_exported">क्लिपबोर्ड में कॉपी हुआ</string>
+    <string name="cookies_toast_entry_copied">क्लिपबोर्ड में कॉपी हुआ</string>
+    <string name="cookies_use_title">कुकीज़ इस्तेमाल करें</string>
+    <string name="cookies_use_description">सहेजे गए साइन इन डाउनलोडर को दें</string>
+    <string name="cookies_new">नई कुकी</string>
+    <string name="cookies_empty_title">कोई कुकी सहेजी नहीं है</string>
+    <string name="cookies_empty_body">आयु प्रतिबंधित, निजी या सिर्फ़ सदस्यों वाला कंटेंट डाउनलोड करने के लिए एक जोड़ें।</string>
+    <string name="cookies_delete_title">कुकीज़ हटाएँ</string>
+    <string name="cookies_delete_body">%1$s का सहेजा हुआ साइन इन हटाएँ?</string>
+    <string name="cookies_delete_confirm">हटाएँ</string>
+    <string name="cookies_delete_cancel">रद्द करें</string>
+    <string name="cookies_delete_all_title">सारी कुकीज़ हटाएँ</string>
+    <string name="cookies_delete_all_body">हर सहेजा हुआ साइन इन हटा दिया जाएगा। इसे वापस नहीं लाया जा सकता।</string>
+    <string name="cookies_delete_all_confirm">सब हटाएँ</string>
+    <string name="cookies_delete_all_cancel">रद्द करें</string>
+    <string name="cookies_row_fallback_name">कुकीज़</string>
+    <string name="cookies_sheet_title">कुकीज़</string>
+    <string name="cookies_sheet_copy">कुकीज़ कॉपी करें</string>
+    <string name="cookies_sheet_delete">कुकीज़ हटाएँ</string>
+    <string name="cookies_field_title">शीर्षक</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">सहेजें</string>
+    <string name="cookies_sheet_get">कुकीज़ लें</string>
+    <string name="cookies_sheet_update">अपडेट करें</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">सबसे अच्छी क्वालिटी</string>
+    <string name="batch_type_sheet_title">पसंदीदा डाउनलोड प्रकार</string>
+    <string name="batch_type_sheet_subtitle">ये लिंक किस रूप में डाउनलोड होंगे</string>
+    <string name="batch_type_audio">ऑडियो</string>
+    <string name="batch_type_video">वीडियो</string>
+    <string name="batch_format_title">फ़ॉर्मैट</string>
+    <string name="batch_format_subtitle">फ़ॉर्मैट चुनें</string>
+    <string name="batch_container_title">कंटेनर</string>
+    <string name="batch_container_subtitle">ये लिंक जिस फ़ाइल के रूप में सहेजे जाएँगे</string>
+    <string name="batch_save_dir_title">सहेजने की जगह</string>
+    <string name="batch_open_folder">यह फ़ोल्डर खोलें</string>
+    <string name="batch_change_folder">फ़ोल्डर बदलें</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">थंबनेल</string>
+    <string name="batch_bar_chapters">अध्याय</string>
+    <string name="batch_bar_subtitles">उपशीर्षक</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">फ़ाइल नाम टेम्पलेट</string>
+    <string name="batch_bar_download_type">पसंदीदा डाउनलोड प्रकार</string>
+    <string name="batch_bar_quality">क्वालिटी: %1$s</string>
+    <string name="batch_bar_save_location">सहेजने की जगह</string>
+    <string name="batch_bar_container">कंटेनर</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">डाउनलोड</string>
+    <string name="batch_header_subtitle">डाउनलोड सेट करें</string>
+    <string name="batch_download_action">डाउनलोड</string>
+    <string name="batch_stop_selecting">चुनना बंद करें</string>
+    <string name="batch_start_selecting">लिंक चुनें</string>
+    <string name="batch_list_options">सूची के विकल्प</string>
+    <string name="batch_menu_select_links">लिंक चुनें</string>
+    <string name="batch_menu_select_all">सब चुनें</string>
+    <string name="batch_menu_invert">चयन उलटें</string>
+    <string name="batch_menu_remove_selected">चुने हुए हटाएँ</string>
+    <string name="batch_menu_done">हो गया</string>
+    <plurals name="batch_selected">
+        <item quantity="one">%d चुना गया</item>
+        <item quantity="other">%d चुने गए</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="one">%d लिंक</item>
+        <item quantity="other">%d लिंक</item>
+    </plurals>
+    <string name="batch_card_download_type">इस लिंक के लिए डाउनलोड प्रकार</string>
+    <string name="batch_card_remove">हटाएँ</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">इस फ़ाइल की जगह पता नहीं है</string>
+    <string name="media_open_chooser">इससे खोलें</string>
+    <string name="media_open_no_app">इस डिवाइस पर इसे खोलने वाला कुछ नहीं है</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">डाउनलोड रद्द हुआ</string>
+    <string name="notification_channel_progress_description">डाउनलोड की प्रगति, स्टेटस बार में आइकन दिखाता है</string>
+    <string name="notification_channel_complete_description">डाउनलोड पूरा होने की सूचनाएँ</string>
+    <string name="notification_action_pause">रोकें</string>
+    <string name="notification_action_resume">फिर शुरू करें</string>
+    <string name="notification_action_cancel">रद्द करें</string>
+    <string name="notification_action_sign_in">साइन इन करें</string>
+    <string name="notification_wifi_title">वाई-फ़ाई का इंतज़ार</string>
+    <string name="notification_wifi_text">डाउनलोड सिर्फ़ वाई-फ़ाई पर सेट हैं। वाई-फ़ाई पर लौटते ही वे शुरू हो जाएँगे।</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">बंद करें</string>
+    <string name="cookie_webview_desktop_site">डेस्कटॉप साइट</string>
+    <string name="cookie_webview_no_cookies">कोई कुकी नहीं मिली</string>
+    <string name="cookie_webview_done">"  ठीक है"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">फ़ॉर्मैट क्रम में लगाएँ</string>
+    <string name="format_selection_change">फ़ॉर्मैट बदलें</string>
+    <string name="format_selection_title">फ़ॉर्मैट</string>
+    <string name="format_selection_subtitle">फ़ॉर्मैट चुनें</string>
+    <string name="format_selection_confirm">ठीक है</string>
+    <string name="format_selection_loading">बाकी फ़ॉर्मैट पढ़े जा रहे हैं</string>
+    <string name="format_sort_quality">क्वालिटी</string>
+    <string name="format_sort_file_size">फ़ाइल का आकार</string>
+    <string name="format_sort_container">कंटेनर</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">ऑडियो की भाषा</string>
+    <string name="audio_language_subtitle">साउंडट्रैक चुनें</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">वापस</string>
+    <string name="appearance_title">दिखावट</string>
+
+    <!-- Language picker -->
+    <string name="language_title">भाषा</string>
+    <string name="language_system">सिस्टम की भाषा</string>
+    <string name="language_system_description">डिवाइस की भाषा के अनुसार चलें</string>
+    <string name="language_close">बंद करें</string>
+    <string name="language_changed_title">भाषा बदल गई</string>
+    <string name="language_changed_body">Hazel अब इस भाषा में है। ऐप का जो हिस्सा अनूदित नहीं है, वह अंग्रेज़ी में ही रहेगा।</string>
+    <string name="language_changed_ok">ठीक है</string>
+    <string name="appearance_dark_theme">गहरी थीम</string>
+    <string name="appearance_accent_color">एक्सेंट रंग</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">एक्सेंट रंग</string>
+    <string name="accent_picker_close">बंद करें</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">वापस</string>
+    <string name="fetch_settings_title">लिंक पढ़ना</string>
+    <string name="fetch_settings_timeout_description">धीमे स्रोत पर हार मानकर दोबारा कोशिश करने से पहले कितना इंतज़ार करना है।</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="one">%1$ds इंतज़ार, %2$d कोशिश</item>
+        <item quantity="other">%1$ds इंतज़ार, %2$d कोशिशें</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">लिंक पढ़ना</string>
+    <string name="fetch_settings_reading_links_description">कौन सा रीडर पता लगाए कि लिंक में क्या है। यहाँ जो भी चुना जाए, डाउनलोड हमेशा yt-dlp से ही होते हैं।</string>
+    <string name="fetch_settings_force_ipv4_description">इसे तभी चालू करें जब आपके नेटवर्क पर लिंक अटक जाते हों। यह टूटे हुए IPv6 रास्ते से बचाता है, और बाकी हर जगह धीमा है।</string>
+    <string name="fetch_settings_force_ipv4">IPv4 ज़रूरी करें</string>
+    <string name="fetch_mode_fast_label">तेज़</string>
+    <string name="fetch_mode_fast_description">जल्दी हार मान लेता है। अच्छे नेटवर्क पर सबसे तेज़, पर दूसरी कोशिश की ज़रूरत ज़्यादा पड़ती है।</string>
+    <string name="fetch_mode_balanced_label">संतुलित</string>
+    <string name="fetch_mode_balanced_description">रफ़्तार और कमज़ोर कनेक्शन झेलने के बीच का रास्ता।</string>
+    <string name="fetch_mode_thorough_label">पूरी तरह</string>
+    <string name="fetch_mode_thorough_description">ज़्यादा इंतज़ार और ज़्यादा कोशिशें। सबसे धीमा, पर कमज़ोर नेटवर्क पर टिक जाता है।</string>
+    <string name="listing_source_ytdlp_description">वही इंजन जो डाउनलोड करता है। जिन साइटों को यह समझता है उन सब पर काम करता है, और खुद को अपडेट करता रहता है, इसलिए साइटें बदलने पर भी चलता रहता है।</string>
+    <string name="listing_source_newpipe_label">भीतर बने रीडर को प्राथमिकता दें</string>
+    <string name="listing_source_newpipe_description">इंजन चलाने के बजाय एक ही अनुरोध में प्लेलिस्ट और चैनल की सूची बनाता है, जो जानी-पहचानी साइटों पर तेज़ है। बाकी सब के लिए, और जब भी कोई लिंक न पढ़ पाए, yt-dlp पर लौट आता है।</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">वापस</string>
+    <string name="tools_title">उपकरण</string>
+    <string name="tools_empty">यहाँ अभी कुछ नहीं है।</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">वापस</string>
+    <string name="direct_share_save_as">इस रूप में सहेजें</string>
+    <string name="direct_share_video">वीडियो</string>
+    <string name="direct_share_audio_only">सिर्फ़ ऑडियो</string>
+    <string name="direct_share_title">Hazel इंस्टेंट</string>
+    <string name="direct_share_intro">Hazel इंस्टेंट को लिंक साझा करते ही डाउनलोड तुरंत शुरू हो जाता है, न कोई शीट न कोई सवाल। ये वही जवाब हैं जो वह इस्तेमाल करता है।</string>
+    <string name="direct_share_video_description">तस्वीर और आवाज़, एक ही फ़ाइल में जुड़े हुए।</string>
+    <string name="direct_share_audio_description">सिर्फ़ आवाज़, स्रोत के पास जो सबसे अच्छा हो उसमें।</string>
+    <string name="direct_share_quality_title">क्वालिटी की सीमा</string>
+    <string name="direct_share_quality_description">यह एक ऊपरी हद है, कोई तय आकार नहीं। हर स्रोत एक जैसी ऊँचाइयाँ नहीं देता, इसलिए इससे नीचे जो सबसे बड़ी हो वही ली जाती है, और कोई न हो तो सबसे छोटी उपलब्ध।</string>
+    <string name="direct_share_output_title">आउटपुट</string>
+    <string name="direct_share_output_description">वह फ़ाइल जो डिवाइस पर आती है। डिफ़ॉल्ट वही रखता है जो स्रोत पहले से देता है, और यही सबसे तेज़ विकल्प है क्योंकि कुछ भी दोबारा एनकोड नहीं होता।</string>
+    <string name="direct_share_filename_template">फ़ाइल नाम टेम्पलेट</string>
+    <string name="direct_share_audio_language">ऑडियो की भाषा</string>
+    <string name="direct_share_audio_language_default">स्रोत की अपनी</string>
+    <string name="direct_share_extras_title">अतिरिक्त</string>
+    <string name="direct_share_extras_description">जब स्रोत के पास हों तब लागू होते हैं। जो उसके पास न हो वह उस डाउनलोड में छोड़ दिया जाता है, उसे विफल नहीं किया जाता।</string>
+    <string name="direct_share_cover_art">कवर तस्वीर</string>
+    <string name="direct_share_cover_art_description">थंबनेल को फ़ाइल के अंदर लिखता है, जहाँ कंटेनर उसे रख सकता हो।</string>
+    <string name="direct_share_chapters">अध्याय</string>
+    <string name="direct_share_subtitles">उपशीर्षक</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">बंद</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="one">%1$d श्रेणी काटी गई</item>
+        <item quantity="other">%1$d श्रेणियाँ काटी गईं</item>
+    </plurals>
+    <string name="direct_share_signins_title">साइन इन</string>
+    <string name="direct_share_signins_description">इंस्टेंट साझा करने पर उसी साइट की सहेजी हुई कुकीज़ इस्तेमाल होती हैं जिसका लिंक है, ठीक वैसे ही जैसे शीट से शुरू किए डाउनलोड में। साझा करते समय कुछ नहीं पूछा जाता, इसलिए लॉगिन के पीछे वाला लिंक तभी चलेगा जब साइन इन पहले से सहेजा और चालू हो।</string>
+    <string name="direct_share_cookies">कुकीज़</string>
+    <string name="direct_share_cookies_on">चालू, हर इंस्टेंट साझा में इस्तेमाल होती हैं</string>
+    <string name="direct_share_cookies_off">बंद</string>
+    <string name="direct_share_change">%1$s बदलें</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">वापस</string>
+    <string name="storage_locations_downloads">डाउनलोड</string>
+    <string name="storage_locations_title">डाउनलोड</string>
+    <string name="storage_locations_subtitle">डाउनलोड कहाँ सहेजे जाते हैं, और किन सीमाओं में चलते हैं</string>
+    <string name="storage_locations_limits">सीमाएँ</string>
+    <string name="storage_locations_wifi_only_description">डाउनलोड मोबाइल डेटा पर चलने के बजाय इंतज़ार करते हैं</string>
+    <string name="storage_locations_speed_limit_description">डाउनलोड कितनी तेज़ी से चल सकता है</string>
+    <string name="storage_locations_internal_note">सारी फ़ाइलें आपके डिवाइस के आंतरिक स्टोरेज में रखी जाती हैं। आप उन्हें किसी भी फ़ाइल मैनेजर ऐप से कभी भी देख सकते हैं।</string>
+    <string name="storage_locations_wifi_only">सिर्फ़ वाई-फ़ाई</string>
+    <string name="storage_locations_speed_limit">गति सीमा</string>
+
+</resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -468,10 +468,13 @@
     <string name="appearance_title">दिखावट</string>
 
     <!-- Language picker -->
-    <string name="language_title">भाषा</string>
+    <string name="language_title">ऐप की भाषा</string>
     <string name="language_system">सिस्टम की भाषा</string>
-    <string name="language_system_description">डिवाइस की भाषा के अनुसार चलें</string>
-    <string name="language_close">बंद करें</string>
+    <string name="language_system_description">डिवाइस के अनुसार</string>
+    <string name="language_current">अभी: %1$s</string>
+    <string name="language_selected">चुनी गई: %1$s</string>
+    <string name="language_cancel">रद्द करें</string>
+    <string name="language_confirm">पक्का करें</string>
     <string name="language_changed_title">भाषा बदल गई</string>
     <string name="language_changed_body">Hazel अब इस भाषा में है। ऐप का जो हिस्सा अनूदित नहीं है, वह अंग्रेज़ी में ही रहेगा।</string>
     <string name="language_changed_ok">ठीक है</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -475,10 +475,13 @@
     <string name="appearance_title">Aparência</string>
 
     <!-- Language picker -->
-    <string name="language_title">Idioma</string>
+    <string name="language_title">Idioma do aplicativo</string>
     <string name="language_system">Padrão do sistema</string>
-    <string name="language_system_description">Seguir o idioma do aparelho</string>
-    <string name="language_close">Fechar</string>
+    <string name="language_system_description">Seguir o aparelho</string>
+    <string name="language_current">Atual: %1$s</string>
+    <string name="language_selected">Escolhido: %1$s</string>
+    <string name="language_cancel">Cancelar</string>
+    <string name="language_confirm">Confirmar</string>
     <string name="language_changed_title">Idioma alterado</string>
     <string name="language_changed_body">O Hazel agora está neste idioma. O que ainda não foi traduzido continua em inglês.</string>
     <string name="language_changed_ok">OK</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,568 @@
+<resources>
+    <string name="direct_share_label">Instantâneo</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">Início</string>
+    <string name="nav_history">Downloads</string>
+    <string name="nav_more">Mais</string>
+    <string name="nav_incognito_on">Anônimo ativado, os downloads não são registrados</string>
+    <string name="nav_incognito_off">Anônimo desativado</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">Pesquise ou cole um link</string>
+    <string name="download_clear">Limpar</string>
+    <string name="download_show_large_artwork">Mostrar imagens grandes</string>
+    <string name="download_show_list">Mostrar como lista</string>
+    <string name="download_instant_source">Instantâneo · lendo de %1$s</string>
+    <string name="download_incognito_title">Você está anônimo</string>
+    <string name="download_incognito_body">Os downloads não entram no seu histórico e os links não são lembrados. Os arquivos continuam sendo salvos normalmente.</string>
+    <string name="download_download_all">Baixar tudo</string>
+    <string name="download_saved_aside">Seus downloads estão salvos. Encontre-os na aba Downloads.</string>
+    <string name="download_options">Opções de download</string>
+    <string name="download_pause">Pausar</string>
+    <string name="download_resume">Retomar</string>
+    <string name="download_cancel">Cancelar</string>
+    <string name="download_paused">Pausado</string>
+    <string name="download_processing">Processando</string>
+    <string name="download_waiting_wifi">Aguardando o Wi-Fi</string>
+    <string name="download_saved">Salvo</string>
+    <string name="download_queued">Na fila</string>
+    <string name="download_downloaded">Baixado</string>
+    <string name="download_failed">Falhou</string>
+    <string name="download_remove_link">Remover o link</string>
+    <string name="download_cancel_action">Cancelar o download</string>
+    <string name="download_resume_action">Retomar o download</string>
+    <plurals name="download_links">
+        <item quantity="one">%d link</item>
+        <item quantity="many">%d de links</item>
+        <item quantity="other">%d links</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">Pesquise ou cole um link</string>
+    <string name="search_back">Voltar</string>
+    <string name="search_more">Mais</string>
+    <string name="search_add_link">Adicionar outro link</string>
+    <string name="search_clear">Apagar</string>
+    <string name="search_clear_results">Limpar os resultados</string>
+    <string name="search_clear_history">Apagar o histórico de pesquisa</string>
+    <string name="search_empty_history">Os links que você usar vão aparecer aqui</string>
+    <string name="search_no_matches">Nenhum link corresponde</string>
+    <string name="search_remove">Remover</string>
+    <string name="search_all">Pesquisar tudo</string>
+    <string name="search_forget">Esquecer</string>
+    <string name="search_edit_before">Editar antes de pesquisar</string>
+    <string name="search_paste_and_fetch">Colar e buscar</string>
+    <string name="search_nothing_to_paste">Não há nada para colar</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">Já foi baixado</string>
+    <string name="already_downloaded_body">Este link já está salvo neste aparelho.</string>
+    <string name="already_downloaded_video">Vídeo</string>
+    <string name="already_downloaded_audio">Áudio</string>
+    <string name="already_downloaded_keep">Manter</string>
+    <string name="already_downloaded_play">Reproduzir</string>
+    <string name="already_downloaded_download_again">Baixar de novo</string>
+    <string name="already_downloaded_just_now">Agora mesmo</string>
+    <string name="already_downloaded_yesterday">Ontem</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="one">%d min</item>
+        <item quantity="many">%d min</item>
+        <item quantity="other">%d min</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="one">%d h</item>
+        <item quantity="many">%d h</item>
+        <item quantity="other">%d h</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="one">%d dia</item>
+        <item quantity="many">%d de dias</item>
+        <item quantity="other">%d dias</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="one">%d mês</item>
+        <item quantity="many">%d de meses</item>
+        <item quantity="other">%d meses</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">É preciso entrar</string>
+    <string name="no_results_error_title">Não foi possível ler este link</string>
+    <string name="no_results_sign_in_body">A fonte exige uma conta antes de entregar isto. Ao entrar, os cookies do site são salvos e a tentativa é refeita.</string>
+    <string name="no_results_continue_body">Os detalhes não puderam ser lidos, mas o download em si ainda pode funcionar. Seguir em frente oferece a melhor qualidade disponível.</string>
+    <string name="no_results_refused_body">A fonte recusou o pedido.</string>
+    <string name="no_results_engine_report">O que o motor relatou</string>
+    <string name="no_results_copy_log">Copiar o registro</string>
+    <string name="no_results_sign_in">Entrar</string>
+    <string name="no_results_try_anyway">Tentar mesmo assim</string>
+    <string name="no_results_close">Fechar</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">Primeiros passos</string>
+    <string name="guide_step_paste_link">Cole um link no campo de pesquisa para baixá-lo. Você pode adicionar vários links e playlists</string>
+    <string name="guide_step_pick_format">Toque em um cartão para escolher o formato exato. Todas as qualidades disponíveis são listadas com o tamanho e o codec.</string>
+    <string name="guide_step_share_instant">Compartilhe um link com o Hazel Instantâneo de qualquer aplicativo para baixar na hora, na qualidade que você definiu.</string>
+    <string name="guide_step_finished_downloads">Os arquivos prontos aparecem em Downloads. Toque em qualquer linha para abri-lo no reprodutor padrão do aparelho.</string>
+    <string name="guide_step_battery_unrestricted">Defina o uso da bateria como irrestrito, senão o Android pode interromper os downloads quando você sair do aplicativo.</string>
+    <string name="guide_battery_settings">Configurações de bateria</string>
+    <string name="guide_close">Fechar</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">Baixar</string>
+    <string name="format_sheet_subtitle">Ajustar o download</string>
+    <string name="format_sheet_play">Reproduzir</string>
+    <string name="format_sheet_ok">OK</string>
+    <string name="format_sheet_download">Baixar</string>
+    <string name="format_sheet_tab_audio">Áudio</string>
+    <string name="format_sheet_tab_video">Vídeo</string>
+    <string name="format_sheet_label_title">Título</string>
+    <string name="format_sheet_label_author">Autor</string>
+    <string name="format_sheet_label_container">Contêiner</string>
+    <string name="format_sheet_video_quality">Qualidade do vídeo</string>
+    <string name="format_sheet_audio_quality">Qualidade do áudio</string>
+    <string name="format_sheet_no_video_stream">Esta fonte não tem uma faixa de vídeo separada.</string>
+    <string name="format_sheet_no_audio_stream">Esta fonte não tem uma faixa de áudio separada.</string>
+    <string name="format_sheet_adjust_video">Ajustar o vídeo</string>
+    <string name="format_sheet_adjust_audio">Ajustar o áudio</string>
+    <string name="format_sheet_thumbnail">Miniatura</string>
+    <string name="format_sheet_chapters">Capítulos</string>
+    <string name="format_sheet_subtitles">Legendas</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">Idioma do áudio</string>
+    <string name="format_sheet_change_audio_language">Mudar o idioma do áudio</string>
+    <string name="format_sheet_filename_template">Modelo do nome do arquivo</string>
+    <string name="format_sheet_change_field">Mudar</string>
+    <string name="format_sheet_save_dir">Pasta</string>
+    <string name="format_sheet_save_location">Onde salvar</string>
+    <string name="format_sheet_save_location_title">Onde salvar</string>
+    <string name="format_sheet_save_location_body">Abra esta pasta no seu gerenciador de arquivos, ou escolha outra para salvar os downloads.</string>
+    <string name="format_sheet_open_folder">Abrir a pasta</string>
+    <string name="format_sheet_reset">Redefinir</string>
+    <string name="format_sheet_change">Mudar</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">Converter para</string>
+    <string name="converter_label_saved_to">Salvo em</string>
+    <string name="converter_hazel_storage">O armazenamento do próprio Hazel</string>
+    <string name="converter_storage_warning">Sem acesso ao armazenamento o arquivo fica dentro do Hazel, onde outros aplicativos não conseguem vê-lo.</string>
+    <string name="converter_back">Voltar</string>
+    <string name="converter_title">Conversor offline</string>
+    <string name="converter_subtitle">De vídeo para áudio, nada sai do telefone</string>
+    <string name="converter_choose_video">Escolha um arquivo de vídeo</string>
+    <string name="converter_ready">Pronto</string>
+    <string name="converter_choose_video_hint">Qualquer coisa do telefone ou de um cartão SD</string>
+    <string name="converter_change">Mudar</string>
+    <string name="converter_converting">Convertendo</string>
+    <string name="converter_convert">Converter</string>
+    <string name="converter_saved">Salvo</string>
+    <string name="converter_open_folder">Abrir a pasta</string>
+    <string name="converter_convert_another">Converter outro</string>
+    <string name="converter_error_title">Isso não foi convertido</string>
+    <string name="converter_dismiss">Dispensar</string>
+    <string name="converter_save_as_title">Salvar como</string>
+    <string name="converter_save_as_body">Dá nome ao arquivo, e também é escrito na etiqueta de título dele.</string>
+    <string name="converter_label_name">Nome</string>
+    <string name="converter_start">Começar</string>
+    <string name="converter_format_sheet_title">Converter para</string>
+    <string name="converter_heading_common">Os três que valem a pena</string>
+    <string name="converter_heading_other">Todo o resto</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">Mais</string>
+    <string name="more_battery_title">Downloads em segundo plano</string>
+    <string name="more_battery_body">Os downloads continuam sozinhos em segundo plano. Ainda assim, alguns telefones os interrompem para economizar bateria. Permita o uso irrestrito para descartar isso.</string>
+    <string name="more_downloads">Downloads</string>
+    <string name="more_appearance">Aparência</string>
+    <string name="more_language">Idioma</string>
+    <string name="more_cookies">Cookies</string>
+    <string name="more_link_reading">Leitura de links</string>
+    <string name="more_hazel_instant">Hazel Instantâneo</string>
+    <string name="more_temporary_files">Arquivos temporários</string>
+    <string name="more_converter">Converter vídeo em áudio offline</string>
+    <string name="more_engine_update">Atualização do motor yt-dlp</string>
+    <string name="more_support">Apoiar o Hazel</string>
+    <string name="more_license">Licença</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">Voltar</string>
+    <string name="sponsor_title">Apoiar o Hazel</string>
+    <string name="sponsor_hero_title">Gratuito, e vai continuar assim</string>
+    <string name="sponsor_hero_body">O Hazel é feito à noite e nos fins de semana, e é dado de graça porque um baixador que cobra pelo download é um baixador pior. Os sites mudam o tempo todo, e acompanhar essas mudanças é o trabalho.</string>
+    <string name="sponsor_hero_closing">Se o aplicativo te poupou uma tarde, qualquer uma das opções abaixo devolve esse tempo. Se não poupou, as formas que não custam nada ajudam do mesmo jeito.</string>
+    <string name="sponsor_section_ways">Formas de apoiar</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">Mensal ou uma vez só, cancele quando quiser. Tudo é cuidado pelo GitHub.</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">Uma vez só, sem precisar de conta.</string>
+    <string name="sponsor_kofi_soon">Abre em breve</string>
+    <string name="sponsor_section_free">Não custa nada, ajuda igual</string>
+    <string name="sponsor_star_title">Dê uma estrela ao projeto</string>
+    <string name="sponsor_star_subtitle">O único número que as pessoas olham antes de experimentar um aplicativo.</string>
+    <string name="sponsor_share_title">Conte para alguém</string>
+    <string name="sponsor_share_subtitle">O boca a boca é todo o marketing deste aplicativo.</string>
+    <string name="sponsor_issues_title">Avise o que quebrar</string>
+    <string name="sponsor_issues_subtitle">Um site que parou de funcionar é uma correção que mais ninguém consegue escrever.</string>
+    <string name="sponsor_source_title">Leia o código</string>
+    <string name="sponsor_source_subtitle">Cada linha dele é pública, e pull requests são bem-vindas.</string>
+    <string name="sponsor_footer">Sem anúncios, sem medir nada do que você baixa e sem nenhum recurso guardado para poucos. Apoiar muda quanto tempo entra no Hazel, não o que ele vai fazer por você.</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">Atualização do yt-dlp</string>
+    <string name="update_back">Voltar</string>
+    <string name="update_check_action">Procurar atualizações</string>
+    <string name="update_status_up_to_date">Você está em dia</string>
+    <string name="update_status_checking">Procurando atualizações...</string>
+    <string name="update_status_available">Atualização disponível</string>
+    <string name="update_status_installing">Instalando o yt-dlp...</string>
+    <string name="update_status_installed">Motor atualizado</string>
+    <string name="update_status_failed">A atualização falhou</string>
+    <string name="update_subtitle_idle">O Hazel está usando a versão mais recente do yt-dlp</string>
+    <string name="update_subtitle_checking">Contatando o GitHub...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s está disponível</string>
+    <string name="update_subtitle_updating">Baixando o yt-dlp %1$s</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s já está em uso</string>
+    <string name="update_installed_version">Versão instalada</string>
+    <string name="update_version_unknown">Desconhecida</string>
+    <string name="update_new_version">Nova versão</string>
+    <string name="update_installing_binary">Instalando o binário</string>
+    <string name="update_installing_body">Baixando do GitHub e substituindo o motor. Mantenha o aplicativo aberto.</string>
+    <string name="update_action_update_now">Atualizar agora</string>
+    <string name="update_action_installing">Instalando...</string>
+    <string name="update_action_done">Pronto</string>
+    <string name="update_action_retry">Tentar de novo</string>
+    <string name="update_action_check">Procurar atualizações</string>
+    <string name="update_action_checking">Procurando...</string>
+    <string name="update_info_heading">Informações</string>
+    <string name="update_info_component">Componente</string>
+    <string name="update_info_repository">Repositório</string>
+    <string name="update_info_binary_size">Tamanho do binário</string>
+    <string name="update_info_distribution">Distribuição</string>
+    <string name="update_info_github_releases">GitHub Releases</string>
+    <string name="update_release_channel">Canal de versões</string>
+    <string name="update_view_changelog">Ver o registro de mudanças</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">Escolha a filtragem do SponsorBlock</string>
+    <string name="options_sponsorblock_ok">OK</string>
+    <string name="options_sponsorblock_cancel">Cancelar</string>
+    <string name="options_chapters_title">Capítulos</string>
+    <string name="options_chapters_in_videos">Capítulos nos vídeos</string>
+    <string name="options_chapters_split">Dividir por capítulos</string>
+    <string name="options_chapters_split_body">Dividir grava um arquivo por capítulo em vez de um só.</string>
+    <string name="options_chapters_dismiss">Dispensar</string>
+    <string name="options_subtitles_title">Legendas</string>
+    <string name="options_subtitles_embed">Embutir as legendas</string>
+    <string name="options_subtitles_save">Salvar as legendas</string>
+    <string name="options_subtitles_save_auto">Salvar as legendas automáticas</string>
+    <string name="options_subtitles_languages_label">Idiomas das legendas</string>
+    <string name="options_subtitles_dismiss">Dispensar</string>
+    <string name="options_subtitles_languages_title">Idiomas das legendas</string>
+    <string name="options_subtitles_languages_hint">Um seletor de idioma do yt-dlp, por exemplo en.*,.*-orig para o inglês mais a faixa original. Use all para todos os idiomas que a fonte oferecer.</string>
+    <string name="options_filename_title">Modelo do nome do arquivo</string>
+    <string name="options_filename_hint">Modelo de saída do yt-dlp. Use %(title)s, %(uploader)s, %(id)s e %(ext)s.</string>
+    <string name="options_text_input_save">Salvar</string>
+    <string name="options_text_input_cancel">Cancelar</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">Voltar</string>
+    <string name="cleanup_title">Arquivos temporários</string>
+    <string name="cleanup_header_description">Arquivos de trabalho guardados pelo aplicativo. Seus downloads não estão incluídos e nunca são removidos daqui.</string>
+    <string name="cleanup_action_clear_everything">Limpar tudo</string>
+    <string name="cleanup_category_link_data_label">Cache de dados de links</string>
+    <string name="cleanup_category_link_data_description">Dados do reprodutor que o yt-dlp guarda para que um link lido uma segunda vez seja mais rápido. Pode limpar sem risco.</string>
+    <string name="cleanup_category_partial_downloads_label">Downloads incompletos</string>
+    <string name="cleanup_category_partial_downloads_description">Fragmentos deixados por um download cancelado ou que falhou antes de salvar o arquivo.</string>
+    <string name="cleanup_category_conversions_label">Conversões incompletas</string>
+    <string name="cleanup_category_conversions_description">Arquivos de trabalho do conversor de áudio que nunca chegaram à sua pasta de música.</string>
+    <string name="cleanup_category_engine_label">Arquivos do motor yt-dlp</string>
+    <string name="cleanup_category_engine_description">O baixador e o ambiente dele. Limpar libera mais espaço, mas o próximo download terá que descompactá-los de novo.</string>
+    <string name="cleanup_category_other_cache_label">Outros arquivos em cache</string>
+    <string name="cleanup_category_other_cache_description">Miniaturas e tudo o mais guardado em cache enquanto você navega pelos links.</string>
+    <string name="cleanup_confirm_category_title">Limpar estes arquivos?</string>
+    <string name="cleanup_confirm_category_safe">%1$s serão liberados. Nada do que você salvou é afetado.</string>
+    <string name="cleanup_confirm_category_unsafe">%1$s serão liberados, e o próximo download vai demorar mais enquanto eles são descompactados de novo.</string>
+    <string name="cleanup_confirm_clear">Limpar</string>
+    <string name="cleanup_confirm_cancel">Cancelar</string>
+    <string name="cleanup_confirm_all_title">Limpar tudo?</string>
+    <string name="cleanup_confirm_all_body">%1$s serão liberados. Seus downloads e logins salvos são mantidos, mas o próximo download vai demorar mais enquanto o motor é descompactado de novo.</string>
+    <string name="cleanup_confirm_all_confirm">Limpar tudo</string>
+    <string name="cleanup_confirm_all_cancel">Cancelar</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">Downloads</string>
+    <string name="history_layout_grid">Mostrar imagens grandes</string>
+    <string name="history_layout_list">Mostrar como lista</string>
+    <string name="history_search_action">Pesquisar nos downloads</string>
+    <string name="history_sort_action">Ordenar</string>
+    <string name="history_menu_action">Mais</string>
+    <string name="history_menu_clear">Apagar o histórico</string>
+    <string name="history_search_placeholder">Pesquisar nos downloads</string>
+    <string name="history_search_clear">Limpar a pesquisa</string>
+    <string name="history_empty_initial">Nada foi baixado ainda</string>
+    <string name="history_empty_filtered">Nada corresponde a isso</string>
+    <string name="history_clear_dialog_title">Apagar o histórico</string>
+    <string name="history_clear_dialog_body">A lista é esvaziada. Seus arquivos baixados não são tocados.</string>
+    <string name="history_clear_dialog_confirm">Apagar</string>
+    <string name="history_clear_dialog_cancel">Cancelar</string>
+    <string name="history_delete_dialog_title">Excluir o arquivo</string>
+    <string name="history_delete_dialog_body">%1$s será excluído do seu aparelho.</string>
+    <string name="history_toast_file_deleted">Arquivo excluído</string>
+    <string name="history_toast_file_delete_failed">Não foi possível excluir o arquivo</string>
+    <string name="history_delete_dialog_confirm">Excluir</string>
+    <string name="history_delete_dialog_cancel">Cancelar</string>
+    <string name="history_card_options">Opções</string>
+    <string name="history_card_properties">Propriedades</string>
+    <string name="history_card_remove">Remover da lista</string>
+    <string name="history_card_delete">Excluir o arquivo</string>
+    <string name="history_tag_deleted">Excluído</string>
+    <string name="history_row_options">Opções</string>
+    <string name="history_row_properties">Propriedades</string>
+    <string name="history_row_remove">Remover da lista</string>
+    <string name="history_row_delete">Excluir o arquivo</string>
+    <string name="history_toast_file_gone">Este arquivo não está mais no seu aparelho</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">Propriedades</string>
+    <string name="properties_status">Situação</string>
+    <string name="properties_status_present">Neste aparelho</string>
+    <string name="properties_status_deleted">Excluído deste aparelho</string>
+    <string name="properties_kind">Tipo</string>
+    <string name="properties_kind_video">Vídeo</string>
+    <string name="properties_kind_audio">Áudio</string>
+    <string name="properties_quality">Qualidade</string>
+    <string name="properties_resolution">Resolução</string>
+    <string name="properties_length">Duração</string>
+    <string name="properties_codec">Codec</string>
+    <string name="properties_bitrate">Taxa de bits</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">Tamanho</string>
+    <string name="properties_container">Contêiner</string>
+    <string name="properties_type">Formato</string>
+    <string name="properties_embedded">Embutido</string>
+    <string name="properties_file">Arquivo</string>
+    <string name="properties_saved_to">Salvo em</string>
+    <string name="properties_downloaded">Baixado</string>
+    <string name="properties_source">Origem</string>
+    <string name="properties_link_copied_opened">Link copiado e aberto</string>
+    <string name="properties_link_copied">Link copiado</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">Voltar</string>
+    <string name="cookies_title">Cookies</string>
+    <string name="cookies_menu">Mais</string>
+    <string name="cookies_menu_import">Importar da área de transferência</string>
+    <string name="cookies_menu_export">Exportar para a área de transferência</string>
+    <string name="cookies_menu_delete_all">Excluir tudo</string>
+    <string name="cookies_imported_title">Cookies importados</string>
+    <string name="cookies_toast_imported">Cookies importados</string>
+    <string name="cookies_toast_no_data">A área de transferência não tem dados de cookies</string>
+    <string name="cookies_toast_nothing_to_export">Não há nada para exportar</string>
+    <string name="cookies_toast_exported">Copiado para a área de transferência</string>
+    <string name="cookies_toast_entry_copied">Copiado para a área de transferência</string>
+    <string name="cookies_use_title">Usar cookies</string>
+    <string name="cookies_use_description">Passar os logins salvos para o baixador</string>
+    <string name="cookies_new">Novo cookie</string>
+    <string name="cookies_empty_title">Nenhum cookie salvo</string>
+    <string name="cookies_empty_body">Adicione um para baixar conteúdo com restrição de idade, privado ou só para membros.</string>
+    <string name="cookies_delete_title">Excluir os cookies</string>
+    <string name="cookies_delete_body">Remover o login salvo de %1$s?</string>
+    <string name="cookies_delete_confirm">Excluir</string>
+    <string name="cookies_delete_cancel">Cancelar</string>
+    <string name="cookies_delete_all_title">Excluir todos os cookies</string>
+    <string name="cookies_delete_all_body">Todos os logins salvos serão removidos. Isso não pode ser desfeito.</string>
+    <string name="cookies_delete_all_confirm">Excluir tudo</string>
+    <string name="cookies_delete_all_cancel">Cancelar</string>
+    <string name="cookies_row_fallback_name">Cookies</string>
+    <string name="cookies_sheet_title">Cookies</string>
+    <string name="cookies_sheet_copy">Copiar os cookies</string>
+    <string name="cookies_sheet_delete">Excluir os cookies</string>
+    <string name="cookies_field_title">Título</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">Salvar</string>
+    <string name="cookies_sheet_get">Obter cookies</string>
+    <string name="cookies_sheet_update">Atualizar</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">Melhor qualidade</string>
+    <string name="batch_type_sheet_title">Tipo de download preferido</string>
+    <string name="batch_type_sheet_subtitle">Como estes links vão ser baixados</string>
+    <string name="batch_type_audio">Áudio</string>
+    <string name="batch_type_video">Vídeo</string>
+    <string name="batch_format_title">Formato</string>
+    <string name="batch_format_subtitle">Escolha o formato</string>
+    <string name="batch_container_title">Contêiner</string>
+    <string name="batch_container_subtitle">O arquivo em que estes links são salvos</string>
+    <string name="batch_save_dir_title">Onde salvar</string>
+    <string name="batch_open_folder">Abrir esta pasta</string>
+    <string name="batch_change_folder">Mudar de pasta</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">Miniatura</string>
+    <string name="batch_bar_chapters">Capítulos</string>
+    <string name="batch_bar_subtitles">Legendas</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">Modelo do nome do arquivo</string>
+    <string name="batch_bar_download_type">Tipo de download preferido</string>
+    <string name="batch_bar_quality">Qualidade: %1$s</string>
+    <string name="batch_bar_save_location">Onde salvar</string>
+    <string name="batch_bar_container">Contêiner</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">Baixar</string>
+    <string name="batch_header_subtitle">Ajustar o download</string>
+    <string name="batch_download_action">Baixar</string>
+    <string name="batch_stop_selecting">Parar de selecionar</string>
+    <string name="batch_start_selecting">Selecionar links</string>
+    <string name="batch_list_options">Opções da lista</string>
+    <string name="batch_menu_select_links">Selecionar links</string>
+    <string name="batch_menu_select_all">Selecionar tudo</string>
+    <string name="batch_menu_invert">Inverter a seleção</string>
+    <string name="batch_menu_remove_selected">Remover os selecionados</string>
+    <string name="batch_menu_done">Pronto</string>
+    <plurals name="batch_selected">
+        <item quantity="one">%d selecionado</item>
+        <item quantity="many">%d de selecionados</item>
+        <item quantity="other">%d selecionados</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="one">%d link</item>
+        <item quantity="many">%d de links</item>
+        <item quantity="other">%d links</item>
+    </plurals>
+    <string name="batch_card_download_type">Tipo de download para este link</string>
+    <string name="batch_card_remove">Remover</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">Não se sabe onde este arquivo está</string>
+    <string name="media_open_chooser">Abrir com</string>
+    <string name="media_open_no_app">Nada neste aparelho consegue abri-lo</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">Download cancelado</string>
+    <string name="notification_channel_progress_description">Progresso do download, mostra um ícone na barra de status</string>
+    <string name="notification_channel_complete_description">Avisos de download concluído</string>
+    <string name="notification_action_pause">Pausar</string>
+    <string name="notification_action_resume">Retomar</string>
+    <string name="notification_action_cancel">Cancelar</string>
+    <string name="notification_action_sign_in">Entrar</string>
+    <string name="notification_wifi_title">Aguardando o Wi-Fi</string>
+    <string name="notification_wifi_text">Os downloads estão limitados ao Wi-Fi. Eles começam quando você voltar para o Wi-Fi.</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">Fechar</string>
+    <string name="cookie_webview_desktop_site">Versão para computador</string>
+    <string name="cookie_webview_no_cookies">Nenhum cookie foi coletado</string>
+    <string name="cookie_webview_done">"  OK"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">Ordenar os formatos</string>
+    <string name="format_selection_change">Mudar de formato</string>
+    <string name="format_selection_title">Formato</string>
+    <string name="format_selection_subtitle">Escolha o formato</string>
+    <string name="format_selection_confirm">OK</string>
+    <string name="format_selection_loading">Lendo o resto dos formatos</string>
+    <string name="format_sort_quality">Qualidade</string>
+    <string name="format_sort_file_size">Tamanho do arquivo</string>
+    <string name="format_sort_container">Contêiner</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">Idioma do áudio</string>
+    <string name="audio_language_subtitle">Escolha a trilha sonora</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">Voltar</string>
+    <string name="appearance_title">Aparência</string>
+
+    <!-- Language picker -->
+    <string name="language_title">Idioma</string>
+    <string name="language_system">Padrão do sistema</string>
+    <string name="language_system_description">Seguir o idioma do aparelho</string>
+    <string name="language_close">Fechar</string>
+    <string name="language_changed_title">Idioma alterado</string>
+    <string name="language_changed_body">O Hazel agora está neste idioma. O que ainda não foi traduzido continua em inglês.</string>
+    <string name="language_changed_ok">OK</string>
+    <string name="appearance_dark_theme">Tema escuro</string>
+    <string name="appearance_accent_color">Cor de destaque</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">Cor de destaque</string>
+    <string name="accent_picker_close">Fechar</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">Voltar</string>
+    <string name="fetch_settings_title">Leitura de links</string>
+    <string name="fetch_settings_timeout_description">Quanto esperar por uma fonte lenta antes de desistir e tentar de novo.</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="one">%1$ds de espera, %2$d tentativa</item>
+        <item quantity="many">%1$ds de espera, %2$d de tentativas</item>
+        <item quantity="other">%1$ds de espera, %2$d tentativas</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">Leitura de links</string>
+    <string name="fetch_settings_reading_links_description">Qual leitor descobre o que um link contém. Os downloads sempre usam o yt-dlp, seja qual for a opção escolhida aqui.</string>
+    <string name="fetch_settings_force_ipv4_description">Ative isto só se os links travarem na sua rede. Serve para contornar uma rota IPv6 quebrada, e é mais lento em todo o resto.</string>
+    <string name="fetch_settings_force_ipv4">Forçar IPv4</string>
+    <string name="fetch_mode_fast_label">Rápido</string>
+    <string name="fetch_mode_fast_description">Desiste logo. O mais rápido em uma boa rede, mas é mais provável precisar de uma segunda tentativa.</string>
+    <string name="fetch_mode_balanced_label">Equilibrado</string>
+    <string name="fetch_mode_balanced_description">Um meio-termo entre velocidade e aguentar uma conexão ruim.</string>
+    <string name="fetch_mode_thorough_label">Minucioso</string>
+    <string name="fetch_mode_thorough_description">Espera mais e tenta mais vezes. O mais lento, mas sobrevive a uma rede fraca.</string>
+    <string name="listing_source_ytdlp_description">O mesmo motor que faz o download. Funciona em todos os sites que ele suporta, e se atualiza sozinho, então continua funcionando conforme os sites mudam.</string>
+    <string name="listing_source_newpipe_label">Preferir o leitor interno</string>
+    <string name="listing_source_newpipe_description">Lista playlists e canais em um único pedido em vez de iniciar o motor, o que é mais rápido nos sites que ele conhece. Recorre ao yt-dlp para todo o resto, e sempre que não conseguir ler um link.</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">Voltar</string>
+    <string name="tools_title">Ferramentas</string>
+    <string name="tools_empty">Ainda não há nada aqui.</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">Voltar</string>
+    <string name="direct_share_save_as">Salvar como</string>
+    <string name="direct_share_video">Vídeo</string>
+    <string name="direct_share_audio_only">Só áudio</string>
+    <string name="direct_share_title">Hazel Instantâneo</string>
+    <string name="direct_share_intro">Compartilhar um link com o Hazel Instantâneo começa o download na hora, sem painel e sem perguntas. Estas são as respostas que ele usa.</string>
+    <string name="direct_share_video_description">Imagem e som, unidos em um só arquivo.</string>
+    <string name="direct_share_audio_description">Só o som, no melhor que a fonte oferecer.</string>
+    <string name="direct_share_quality_title">Limite de qualidade</string>
+    <string name="direct_share_quality_description">Um teto, não um tamanho exato. As fontes não oferecem todas as mesmas alturas, então é pega a maior que couber abaixo disto, e a menor disponível quando nenhuma couber.</string>
+    <string name="direct_share_output_title">Saída</string>
+    <string name="direct_share_output_description">O arquivo que chega ao aparelho. Padrão mantém o que a fonte já fornece, que é a opção mais rápida porque nada é recodificado.</string>
+    <string name="direct_share_filename_template">Modelo do nome do arquivo</string>
+    <string name="direct_share_audio_language">Idioma do áudio</string>
+    <string name="direct_share_audio_language_default">Padrão da fonte</string>
+    <string name="direct_share_extras_title">Extras</string>
+    <string name="direct_share_extras_description">Aplicados quando a fonte os tem. O que ela não tiver é pulado naquele download em vez de fazê-lo falhar.</string>
+    <string name="direct_share_cover_art">Capa</string>
+    <string name="direct_share_cover_art_description">Grava a miniatura dentro do arquivo, quando o contêiner pode carregar uma.</string>
+    <string name="direct_share_chapters">Capítulos</string>
+    <string name="direct_share_subtitles">Legendas</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">Desligado</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="one">%1$d categoria cortada</item>
+        <item quantity="many">%1$d de categorias cortadas</item>
+        <item quantity="other">%1$d categorias cortadas</item>
+    </plurals>
+    <string name="direct_share_signins_title">Logins</string>
+    <string name="direct_share_signins_description">Um compartilhamento instantâneo usa os cookies salvos do site a que o link pertence, igual a um download iniciado pelo painel. Nada é perguntado na hora de compartilhar, então um link atrás de login só funciona se o acesso já estiver salvo e ligado.</string>
+    <string name="direct_share_cookies">Cookies</string>
+    <string name="direct_share_cookies_on">Ligado, usados em todo compartilhamento instantâneo</string>
+    <string name="direct_share_cookies_off">Desligado</string>
+    <string name="direct_share_change">Mudar %1$s</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">Voltar</string>
+    <string name="storage_locations_downloads">Downloads</string>
+    <string name="storage_locations_title">Downloads</string>
+    <string name="storage_locations_subtitle">Onde os downloads são salvos, e os limites sob os quais eles rodam</string>
+    <string name="storage_locations_limits">Limites</string>
+    <string name="storage_locations_wifi_only_description">Os downloads esperam em vez de usar os dados móveis</string>
+    <string name="storage_locations_speed_limit_description">A que velocidade um download pode ir</string>
+    <string name="storage_locations_internal_note">Todos os arquivos ficam no armazenamento interno do seu aparelho. Você pode acessá-los quando quiser com qualquer gerenciador de arquivos.</string>
+    <string name="storage_locations_wifi_only">Só no Wi-Fi</string>
+    <string name="storage_locations_speed_limit">Limite de velocidade</string>
+
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,550 @@
+<resources>
+    <string name="direct_share_label">即时下载</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">首页</string>
+    <string name="nav_history">下载</string>
+    <string name="nav_more">更多</string>
+    <string name="nav_incognito_on">无痕模式已开启，下载不会被记录</string>
+    <string name="nav_incognito_off">无痕模式已关闭</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">搜索或粘贴链接</string>
+    <string name="download_clear">清空</string>
+    <string name="download_show_large_artwork">显示大图</string>
+    <string name="download_show_list">以列表显示</string>
+    <string name="download_instant_source">即时下载 · 正在读取 %1$s</string>
+    <string name="download_incognito_title">你正在无痕模式中</string>
+    <string name="download_incognito_body">下载不会加入历史记录，链接也不会被记住。文件仍会照常保存。</string>
+    <string name="download_download_all">全部下载</string>
+    <string name="download_saved_aside">你的下载已保存，可在「下载」标签页中找到。</string>
+    <string name="download_options">下载选项</string>
+    <string name="download_pause">暂停</string>
+    <string name="download_resume">继续</string>
+    <string name="download_cancel">取消</string>
+    <string name="download_paused">已暂停</string>
+    <string name="download_processing">正在处理</string>
+    <string name="download_waiting_wifi">等待 Wi-Fi</string>
+    <string name="download_saved">已保存</string>
+    <string name="download_queued">排队中</string>
+    <string name="download_downloaded">已下载</string>
+    <string name="download_failed">失败</string>
+    <string name="download_remove_link">移除链接</string>
+    <string name="download_cancel_action">取消下载</string>
+    <string name="download_resume_action">继续下载</string>
+    <plurals name="download_links">
+        <item quantity="other">%d 个链接</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">搜索或粘贴链接</string>
+    <string name="search_back">返回</string>
+    <string name="search_more">更多</string>
+    <string name="search_add_link">再添加一个链接</string>
+    <string name="search_clear">清除</string>
+    <string name="search_clear_results">清空结果</string>
+    <string name="search_clear_history">清除搜索记录</string>
+    <string name="search_empty_history">你用过的链接会显示在这里</string>
+    <string name="search_no_matches">没有匹配的链接</string>
+    <string name="search_remove">移除</string>
+    <string name="search_all">全部搜索</string>
+    <string name="search_forget">忘记</string>
+    <string name="search_edit_before">搜索前先编辑</string>
+    <string name="search_paste_and_fetch">粘贴并读取</string>
+    <string name="search_nothing_to_paste">没有可粘贴的内容</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">已经下载过</string>
+    <string name="already_downloaded_body">这个链接已经保存在本设备上。</string>
+    <string name="already_downloaded_video">视频</string>
+    <string name="already_downloaded_audio">音频</string>
+    <string name="already_downloaded_keep">保留</string>
+    <string name="already_downloaded_play">播放</string>
+    <string name="already_downloaded_download_again">再下载一次</string>
+    <string name="already_downloaded_just_now">刚刚</string>
+    <string name="already_downloaded_yesterday">昨天</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="other">%d 分钟</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="other">%d 小时</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="other">%d 天</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="other">%d 个月</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">需要登录</string>
+    <string name="no_results_error_title">无法读取这个链接</string>
+    <string name="no_results_sign_in_body">来源要求先有账号才肯交出内容。登录后会保存该站点的 Cookie 并重试。</string>
+    <string name="no_results_continue_body">详细信息读取失败，但下载本身仍可能成功。继续的话会使用可得的最佳画质。</string>
+    <string name="no_results_refused_body">来源拒绝了这次请求。</string>
+    <string name="no_results_engine_report">引擎的报告</string>
+    <string name="no_results_copy_log">复制日志</string>
+    <string name="no_results_sign_in">登录</string>
+    <string name="no_results_try_anyway">仍然尝试</string>
+    <string name="no_results_close">关闭</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">开始使用</string>
+    <string name="guide_step_paste_link">把链接粘贴到搜索框即可下载。你可以添加多个链接和播放列表</string>
+    <string name="guide_step_pick_format">点按卡片可以挑选具体格式。所有可用画质都会连同体积和编码一起列出。</string>
+    <string name="guide_step_share_instant">从任意应用把链接分享给 Hazel 即时下载，就会按你设定的画质立刻下载。</string>
+    <string name="guide_step_finished_downloads">完成的文件会出现在「下载」中。点按任意一行即可用设备的默认播放器打开。</string>
+    <string name="guide_step_battery_unrestricted">请把电池用量设为不受限制，否则你离开应用时 Android 可能会中止下载。</string>
+    <string name="guide_battery_settings">电池设置</string>
+    <string name="guide_close">关闭</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">下载</string>
+    <string name="format_sheet_subtitle">调整下载</string>
+    <string name="format_sheet_play">播放</string>
+    <string name="format_sheet_ok">确定</string>
+    <string name="format_sheet_download">下载</string>
+    <string name="format_sheet_tab_audio">音频</string>
+    <string name="format_sheet_tab_video">视频</string>
+    <string name="format_sheet_label_title">标题</string>
+    <string name="format_sheet_label_author">作者</string>
+    <string name="format_sheet_label_container">封装格式</string>
+    <string name="format_sheet_video_quality">视频画质</string>
+    <string name="format_sheet_audio_quality">音频质量</string>
+    <string name="format_sheet_no_video_stream">这个来源没有单独的视频流。</string>
+    <string name="format_sheet_no_audio_stream">这个来源没有单独的音频流。</string>
+    <string name="format_sheet_adjust_video">调整视频</string>
+    <string name="format_sheet_adjust_audio">调整音频</string>
+    <string name="format_sheet_thumbnail">缩略图</string>
+    <string name="format_sheet_chapters">章节</string>
+    <string name="format_sheet_subtitles">字幕</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">音轨语言</string>
+    <string name="format_sheet_change_audio_language">更改音轨语言</string>
+    <string name="format_sheet_filename_template">文件名模板</string>
+    <string name="format_sheet_change_field">更改</string>
+    <string name="format_sheet_save_dir">保存目录</string>
+    <string name="format_sheet_save_location">保存位置</string>
+    <string name="format_sheet_save_location_title">保存位置</string>
+    <string name="format_sheet_save_location_body">在文件管理器中打开这个文件夹，或者另选一个用来保存下载。</string>
+    <string name="format_sheet_open_folder">打开文件夹</string>
+    <string name="format_sheet_reset">重置</string>
+    <string name="format_sheet_change">更改</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">转换为</string>
+    <string name="converter_label_saved_to">保存到</string>
+    <string name="converter_hazel_storage">Hazel 自己的存储空间</string>
+    <string name="converter_storage_warning">没有存储权限时文件会留在 Hazel 内部，其他应用看不到它。</string>
+    <string name="converter_back">返回</string>
+    <string name="converter_title">离线转换器</string>
+    <string name="converter_subtitle">视频转音频，任何内容都不会离开手机</string>
+    <string name="converter_choose_video">选择一个视频文件</string>
+    <string name="converter_ready">就绪</string>
+    <string name="converter_choose_video_hint">手机或 SD 卡上的任意文件</string>
+    <string name="converter_change">更改</string>
+    <string name="converter_converting">正在转换</string>
+    <string name="converter_convert">转换</string>
+    <string name="converter_saved">已保存</string>
+    <string name="converter_open_folder">打开文件夹</string>
+    <string name="converter_convert_another">再转换一个</string>
+    <string name="converter_error_title">这个没能转换成功</string>
+    <string name="converter_dismiss">知道了</string>
+    <string name="converter_save_as_title">另存为</string>
+    <string name="converter_save_as_body">决定文件的名字，同时也会写进它的标题标签。</string>
+    <string name="converter_label_name">名称</string>
+    <string name="converter_start">开始</string>
+    <string name="converter_format_sheet_title">转换为</string>
+    <string name="converter_heading_common">值得一用的三种</string>
+    <string name="converter_heading_other">其余全部</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">更多</string>
+    <string name="more_battery_title">后台下载</string>
+    <string name="more_battery_body">下载会自己在后台继续。不过有些手机仍会为了省电中途掐断它们。允许不受限制的用量即可排除这一点。</string>
+    <string name="more_downloads">下载</string>
+    <string name="more_appearance">外观</string>
+    <string name="more_language">语言</string>
+    <string name="more_cookies">Cookie</string>
+    <string name="more_link_reading">链接读取</string>
+    <string name="more_hazel_instant">Hazel 即时下载</string>
+    <string name="more_temporary_files">临时文件</string>
+    <string name="more_converter">离线把视频转成音频</string>
+    <string name="more_engine_update">yt-dlp 引擎更新</string>
+    <string name="more_support">支持 Hazel</string>
+    <string name="more_license">许可证</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">返回</string>
+    <string name="sponsor_title">支持 Hazel</string>
+    <string name="sponsor_hero_title">免费，而且会一直免费</string>
+    <string name="sponsor_hero_body">Hazel 是在晚上和周末做出来的，它免费送出，因为一个对下载收费的下载器是更差的下载器。站点在不断变化，跟上它们才是真正的工作。</string>
+    <string name="sponsor_hero_closing">如果这个应用替你省下了一个下午，下面任何一种方式都能把那段时间还回去。如果没有，那些不花钱的方式一样有帮助。</string>
+    <string name="sponsor_section_ways">支持的方式</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">按月或只付一次，随时可以取消。全程由 GitHub 处理。</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">只付一次，不需要账号。</string>
+    <string name="sponsor_kofi_soon">即将开放</string>
+    <string name="sponsor_section_free">不花一分钱，帮助一样大</string>
+    <string name="sponsor_star_title">给项目点个星</string>
+    <string name="sponsor_star_subtitle">人们在试一个应用之前，只会看这一个数字。</string>
+    <string name="sponsor_share_title">告诉别人</string>
+    <string name="sponsor_share_subtitle">口口相传就是这个应用的全部宣传。</string>
+    <string name="sponsor_issues_title">报告出错的地方</string>
+    <string name="sponsor_issues_subtitle">一个用不了的站点，别人写不出这个修复。</string>
+    <string name="sponsor_source_title">阅读源代码</string>
+    <string name="sponsor_source_subtitle">每一行都是公开的，也欢迎提交 pull request。</string>
+    <string name="sponsor_footer">没有广告，不统计你下载了什么，也没有任何功能被留给少数人。支持改变的是投入 Hazel 的时间，而不是它会为你做什么。</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">yt-dlp 更新</string>
+    <string name="update_back">返回</string>
+    <string name="update_check_action">检查更新</string>
+    <string name="update_status_up_to_date">已是最新</string>
+    <string name="update_status_checking">正在检查更新...</string>
+    <string name="update_status_available">有可用更新</string>
+    <string name="update_status_installing">正在安装 yt-dlp...</string>
+    <string name="update_status_installed">引擎已更新</string>
+    <string name="update_status_failed">更新失败</string>
+    <string name="update_subtitle_idle">Hazel 正在使用最新的 yt-dlp 构建</string>
+    <string name="update_subtitle_checking">正在连接 GitHub...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s 已可用</string>
+    <string name="update_subtitle_updating">正在下载 yt-dlp %1$s</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s 已投入使用</string>
+    <string name="update_installed_version">已安装版本</string>
+    <string name="update_version_unknown">未知</string>
+    <string name="update_new_version">新版本</string>
+    <string name="update_installing_binary">正在安装可执行文件</string>
+    <string name="update_installing_body">正在从 GitHub 下载并替换引擎。请保持应用打开。</string>
+    <string name="update_action_update_now">立即更新</string>
+    <string name="update_action_installing">正在安装...</string>
+    <string name="update_action_done">完成</string>
+    <string name="update_action_retry">重试</string>
+    <string name="update_action_check">检查更新</string>
+    <string name="update_action_checking">正在检查...</string>
+    <string name="update_info_heading">信息</string>
+    <string name="update_info_component">组件</string>
+    <string name="update_info_repository">仓库</string>
+    <string name="update_info_binary_size">文件大小</string>
+    <string name="update_info_distribution">分发方式</string>
+    <string name="update_info_github_releases">GitHub Releases</string>
+    <string name="update_release_channel">发布渠道</string>
+    <string name="update_view_changelog">查看更新日志</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">选择 SponsorBlock 过滤</string>
+    <string name="options_sponsorblock_ok">确定</string>
+    <string name="options_sponsorblock_cancel">取消</string>
+    <string name="options_chapters_title">章节</string>
+    <string name="options_chapters_in_videos">视频中的章节</string>
+    <string name="options_chapters_split">按章节分割</string>
+    <string name="options_chapters_split_body">分割后会为每一章写一个文件，而不是单独一个文件。</string>
+    <string name="options_chapters_dismiss">知道了</string>
+    <string name="options_subtitles_title">字幕</string>
+    <string name="options_subtitles_embed">把字幕嵌入文件</string>
+    <string name="options_subtitles_save">保存字幕</string>
+    <string name="options_subtitles_save_auto">保存自动生成的字幕</string>
+    <string name="options_subtitles_languages_label">字幕语言</string>
+    <string name="options_subtitles_dismiss">知道了</string>
+    <string name="options_subtitles_languages_title">字幕语言</string>
+    <string name="options_subtitles_languages_hint">yt-dlp 的语言选择器，例如 en.*,.*-orig 表示英语加上原始音轨。用 all 表示来源提供的每一种语言。</string>
+    <string name="options_filename_title">文件名模板</string>
+    <string name="options_filename_hint">yt-dlp 的输出模板。可以使用 %(title)s、%(uploader)s、%(id)s 和 %(ext)s。</string>
+    <string name="options_text_input_save">保存</string>
+    <string name="options_text_input_cancel">取消</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">返回</string>
+    <string name="cleanup_title">临时文件</string>
+    <string name="cleanup_header_description">应用保留的工作文件。你的下载不包含在内，也永远不会从这里被清掉。</string>
+    <string name="cleanup_action_clear_everything">全部清除</string>
+    <string name="cleanup_category_link_data_label">链接数据缓存</string>
+    <string name="cleanup_category_link_data_description">yt-dlp 保留的播放器数据，让同一个链接第二次读取时更快。清除是安全的。</string>
+    <string name="cleanup_category_partial_downloads_label">未完成的下载</string>
+    <string name="cleanup_category_partial_downloads_description">下载在保存文件之前被取消或失败时留下的碎片。</string>
+    <string name="cleanup_category_conversions_label">未完成的转换</string>
+    <string name="cleanup_category_conversions_description">音频转换器留下的、从未移入你音乐文件夹的工作文件。</string>
+    <string name="cleanup_category_engine_label">yt-dlp 引擎文件</string>
+    <string name="cleanup_category_engine_description">下载器和它的运行环境。清除能腾出最多空间，但下次下载时必须重新解包。</string>
+    <string name="cleanup_category_other_cache_label">其他缓存文件</string>
+    <string name="cleanup_category_other_cache_description">缩略图，以及浏览链接时缓存下来的其他内容。</string>
+    <string name="cleanup_confirm_category_title">清除这些文件？</string>
+    <string name="cleanup_confirm_category_safe">将腾出 %1$s。你保存过的任何东西都不受影响。</string>
+    <string name="cleanup_confirm_category_unsafe">将腾出 %1$s，下次下载会因为要重新解包而变慢。</string>
+    <string name="cleanup_confirm_clear">清除</string>
+    <string name="cleanup_confirm_cancel">取消</string>
+    <string name="cleanup_confirm_all_title">全部清除？</string>
+    <string name="cleanup_confirm_all_body">将腾出 %1$s。你的下载和已保存的登录信息都会保留，但下次下载会因为要重新解包引擎而变慢。</string>
+    <string name="cleanup_confirm_all_confirm">全部清除</string>
+    <string name="cleanup_confirm_all_cancel">取消</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">下载</string>
+    <string name="history_layout_grid">显示大图</string>
+    <string name="history_layout_list">以列表显示</string>
+    <string name="history_search_action">搜索下载</string>
+    <string name="history_sort_action">排序</string>
+    <string name="history_menu_action">更多</string>
+    <string name="history_menu_clear">清除历史记录</string>
+    <string name="history_search_placeholder">搜索下载</string>
+    <string name="history_search_clear">清除搜索</string>
+    <string name="history_empty_initial">还没有下载任何内容</string>
+    <string name="history_empty_filtered">没有匹配的内容</string>
+    <string name="history_clear_dialog_title">清除历史记录</string>
+    <string name="history_clear_dialog_body">列表会被清空。你下载的文件不会被动过。</string>
+    <string name="history_clear_dialog_confirm">清除</string>
+    <string name="history_clear_dialog_cancel">取消</string>
+    <string name="history_delete_dialog_title">删除文件</string>
+    <string name="history_delete_dialog_body">%1$s 将从你的设备上删除。</string>
+    <string name="history_toast_file_deleted">文件已删除</string>
+    <string name="history_toast_file_delete_failed">无法删除这个文件</string>
+    <string name="history_delete_dialog_confirm">删除</string>
+    <string name="history_delete_dialog_cancel">取消</string>
+    <string name="history_card_options">选项</string>
+    <string name="history_card_properties">属性</string>
+    <string name="history_card_remove">从列表中移除</string>
+    <string name="history_card_delete">删除文件</string>
+    <string name="history_tag_deleted">已删除</string>
+    <string name="history_row_options">选项</string>
+    <string name="history_row_properties">属性</string>
+    <string name="history_row_remove">从列表中移除</string>
+    <string name="history_row_delete">删除文件</string>
+    <string name="history_toast_file_gone">这个文件已经不在你的设备上了</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">属性</string>
+    <string name="properties_status">状态</string>
+    <string name="properties_status_present">在本设备上</string>
+    <string name="properties_status_deleted">已从本设备删除</string>
+    <string name="properties_kind">类型</string>
+    <string name="properties_kind_video">视频</string>
+    <string name="properties_kind_audio">音频</string>
+    <string name="properties_quality">画质</string>
+    <string name="properties_resolution">分辨率</string>
+    <string name="properties_length">时长</string>
+    <string name="properties_codec">编码</string>
+    <string name="properties_bitrate">码率</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">大小</string>
+    <string name="properties_container">封装格式</string>
+    <string name="properties_type">文件类型</string>
+    <string name="properties_embedded">已嵌入</string>
+    <string name="properties_file">文件</string>
+    <string name="properties_saved_to">保存到</string>
+    <string name="properties_downloaded">下载时间</string>
+    <string name="properties_source">来源</string>
+    <string name="properties_link_copied_opened">链接已复制并打开</string>
+    <string name="properties_link_copied">链接已复制</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">返回</string>
+    <string name="cookies_title">Cookie</string>
+    <string name="cookies_menu">更多</string>
+    <string name="cookies_menu_import">从剪贴板导入</string>
+    <string name="cookies_menu_export">导出到剪贴板</string>
+    <string name="cookies_menu_delete_all">全部删除</string>
+    <string name="cookies_imported_title">导入的 Cookie</string>
+    <string name="cookies_toast_imported">Cookie 已导入</string>
+    <string name="cookies_toast_no_data">剪贴板里没有 Cookie 数据</string>
+    <string name="cookies_toast_nothing_to_export">没有可导出的内容</string>
+    <string name="cookies_toast_exported">已复制到剪贴板</string>
+    <string name="cookies_toast_entry_copied">已复制到剪贴板</string>
+    <string name="cookies_use_title">使用 Cookie</string>
+    <string name="cookies_use_description">把已保存的登录信息交给下载器</string>
+    <string name="cookies_new">新建 Cookie</string>
+    <string name="cookies_empty_title">没有保存任何 Cookie</string>
+    <string name="cookies_empty_body">添加一个，就能下载有年龄限制、私密或仅会员可见的内容。</string>
+    <string name="cookies_delete_title">删除 Cookie</string>
+    <string name="cookies_delete_body">要移除 %1$s 的已保存登录信息吗？</string>
+    <string name="cookies_delete_confirm">删除</string>
+    <string name="cookies_delete_cancel">取消</string>
+    <string name="cookies_delete_all_title">删除全部 Cookie</string>
+    <string name="cookies_delete_all_body">所有已保存的登录信息都会被移除。此操作无法撤销。</string>
+    <string name="cookies_delete_all_confirm">全部删除</string>
+    <string name="cookies_delete_all_cancel">取消</string>
+    <string name="cookies_row_fallback_name">Cookie</string>
+    <string name="cookies_sheet_title">Cookie</string>
+    <string name="cookies_sheet_copy">复制 Cookie</string>
+    <string name="cookies_sheet_delete">删除 Cookie</string>
+    <string name="cookies_field_title">标题</string>
+    <string name="cookies_field_url">网址</string>
+    <string name="cookies_sheet_save">保存</string>
+    <string name="cookies_sheet_get">获取 Cookie</string>
+    <string name="cookies_sheet_update">更新</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">最佳画质</string>
+    <string name="batch_type_sheet_title">首选下载类型</string>
+    <string name="batch_type_sheet_subtitle">这些链接会以什么形式下载</string>
+    <string name="batch_type_audio">音频</string>
+    <string name="batch_type_video">视频</string>
+    <string name="batch_format_title">格式</string>
+    <string name="batch_format_subtitle">选择格式</string>
+    <string name="batch_container_title">封装格式</string>
+    <string name="batch_container_subtitle">这些链接会保存成哪种文件</string>
+    <string name="batch_save_dir_title">保存位置</string>
+    <string name="batch_open_folder">打开这个文件夹</string>
+    <string name="batch_change_folder">更换文件夹</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">缩略图</string>
+    <string name="batch_bar_chapters">章节</string>
+    <string name="batch_bar_subtitles">字幕</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">文件名模板</string>
+    <string name="batch_bar_download_type">首选下载类型</string>
+    <string name="batch_bar_quality">画质：%1$s</string>
+    <string name="batch_bar_save_location">保存位置</string>
+    <string name="batch_bar_container">封装格式</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">下载</string>
+    <string name="batch_header_subtitle">调整下载</string>
+    <string name="batch_download_action">下载</string>
+    <string name="batch_stop_selecting">结束选择</string>
+    <string name="batch_start_selecting">选择链接</string>
+    <string name="batch_list_options">列表选项</string>
+    <string name="batch_menu_select_links">选择链接</string>
+    <string name="batch_menu_select_all">全选</string>
+    <string name="batch_menu_invert">反选</string>
+    <string name="batch_menu_remove_selected">移除所选</string>
+    <string name="batch_menu_done">完成</string>
+    <plurals name="batch_selected">
+        <item quantity="other">已选 %d 个</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="other">%d 个链接</item>
+    </plurals>
+    <string name="batch_card_download_type">这个链接的下载类型</string>
+    <string name="batch_card_remove">移除</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">不知道这个文件在哪里</string>
+    <string name="media_open_chooser">打开方式</string>
+    <string name="media_open_no_app">这台设备上没有能打开它的应用</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">下载已取消</string>
+    <string name="notification_channel_progress_description">下载进度，在状态栏显示图标</string>
+    <string name="notification_channel_complete_description">下载完成提醒</string>
+    <string name="notification_action_pause">暂停</string>
+    <string name="notification_action_resume">继续</string>
+    <string name="notification_action_cancel">取消</string>
+    <string name="notification_action_sign_in">登录</string>
+    <string name="notification_wifi_title">等待 Wi-Fi</string>
+    <string name="notification_wifi_text">下载被限制为仅使用 Wi-Fi。回到 Wi-Fi 后就会开始。</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">关闭</string>
+    <string name="cookie_webview_desktop_site">桌面版网站</string>
+    <string name="cookie_webview_no_cookies">没有取到任何 Cookie</string>
+    <string name="cookie_webview_done">"  确定"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">格式排序</string>
+    <string name="format_selection_change">更改格式</string>
+    <string name="format_selection_title">格式</string>
+    <string name="format_selection_subtitle">选择格式</string>
+    <string name="format_selection_confirm">确定</string>
+    <string name="format_selection_loading">正在读取其余的格式</string>
+    <string name="format_sort_quality">画质</string>
+    <string name="format_sort_file_size">文件大小</string>
+    <string name="format_sort_container">封装格式</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">音轨语言</string>
+    <string name="audio_language_subtitle">选择音轨</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">返回</string>
+    <string name="appearance_title">外观</string>
+
+    <!-- Language picker -->
+    <string name="language_title">语言</string>
+    <string name="language_system">跟随系统</string>
+    <string name="language_system_description">使用设备的语言</string>
+    <string name="language_close">关闭</string>
+    <string name="language_changed_title">语言已更改</string>
+    <string name="language_changed_body">Hazel 现在使用这种语言。应用中尚未翻译的部分仍会显示英文。</string>
+    <string name="language_changed_ok">确定</string>
+    <string name="appearance_dark_theme">深色主题</string>
+    <string name="appearance_accent_color">强调色</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">强调色</string>
+    <string name="accent_picker_close">关闭</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">返回</string>
+    <string name="fetch_settings_title">链接读取</string>
+    <string name="fetch_settings_timeout_description">在放弃并重试之前，要等一个慢来源多久。</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="other">超时 %1$d 秒，重试 %2$d 次</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">链接读取</string>
+    <string name="fetch_settings_reading_links_description">由哪个读取器判断一个链接里有什么。无论这里选哪个，下载始终使用 yt-dlp。</string>
+    <string name="fetch_settings_force_ipv4_description">只有当链接在你的网络上卡住时才打开它。它能绕开出问题的 IPv6 路由，在其他情况下都更慢。</string>
+    <string name="fetch_settings_force_ipv4">强制使用 IPv4</string>
+    <string name="fetch_mode_fast_label">快速</string>
+    <string name="fetch_mode_fast_description">很快就放弃。在好网络上最快，但更容易需要第二次尝试。</string>
+    <string name="fetch_mode_balanced_label">均衡</string>
+    <string name="fetch_mode_balanced_description">在速度和容忍差连接之间取一个中间点。</string>
+    <string name="fetch_mode_thorough_label">彻底</string>
+    <string name="fetch_mode_thorough_description">等得更久，重试更多。最慢，但能撑过弱网络。</string>
+    <string name="listing_source_ytdlp_description">和执行下载的是同一个引擎。它支持的每个站点都能用，而且会自我更新，所以站点变化时它也能继续工作。</string>
+    <string name="listing_source_newpipe_label">优先使用内置读取器</string>
+    <string name="listing_source_newpipe_description">用一次请求就列出播放列表和频道，而不必启动引擎，在它认识的站点上更快。其余情况，以及任何读不出链接的时候，都会回退到 yt-dlp。</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">返回</string>
+    <string name="tools_title">工具</string>
+    <string name="tools_empty">这里暂时还没有内容。</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">返回</string>
+    <string name="direct_share_save_as">保存为</string>
+    <string name="direct_share_video">视频</string>
+    <string name="direct_share_audio_only">仅音频</string>
+    <string name="direct_share_title">Hazel 即时下载</string>
+    <string name="direct_share_intro">把链接分享给 Hazel 即时下载会立刻开始下载，没有面板也没有提问。这些就是它使用的答案。</string>
+    <string name="direct_share_video_description">画面和声音，合并成一个文件。</string>
+    <string name="direct_share_audio_description">只要声音，用来源提供的最好音质。</string>
+    <string name="direct_share_quality_title">画质上限</string>
+    <string name="direct_share_quality_description">这是一个上限，不是确切尺寸。各个来源提供的分辨率并不相同，所以会取不超过它的最高一档，都不满足时则取可得的最低一档。</string>
+    <string name="direct_share_output_title">输出</string>
+    <string name="direct_share_output_description">最终落到设备上的文件。默认保留来源本来就提供的格式，这也是最快的选项，因为不需要重新编码。</string>
+    <string name="direct_share_filename_template">文件名模板</string>
+    <string name="direct_share_audio_language">音轨语言</string>
+    <string name="direct_share_audio_language_default">来源默认</string>
+    <string name="direct_share_extras_title">附加内容</string>
+    <string name="direct_share_extras_description">来源有的时候才会应用。它没有的部分会在那次下载中跳过，而不会让下载失败。</string>
+    <string name="direct_share_cover_art">封面图</string>
+    <string name="direct_share_cover_art_description">把缩略图写进文件，前提是封装格式能容纳它。</string>
+    <string name="direct_share_chapters">章节</string>
+    <string name="direct_share_subtitles">字幕</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">关闭</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="other">已剪掉 %1$d 个类别</item>
+    </plurals>
+    <string name="direct_share_signins_title">登录信息</string>
+    <string name="direct_share_signins_description">即时分享会使用链接所属站点已保存的 Cookie，和从面板发起的下载一样。分享时不会有任何询问，所以需要登录才能看的链接，只有在登录信息已经保存并开启时才能下载。</string>
+    <string name="direct_share_cookies">Cookie</string>
+    <string name="direct_share_cookies_on">已开启，每次即时分享都会使用</string>
+    <string name="direct_share_cookies_off">关闭</string>
+    <string name="direct_share_change">更改%1$s</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">返回</string>
+    <string name="storage_locations_downloads">下载</string>
+    <string name="storage_locations_title">下载</string>
+    <string name="storage_locations_subtitle">下载保存在哪里，以及它们受哪些限制</string>
+    <string name="storage_locations_limits">限制</string>
+    <string name="storage_locations_wifi_only_description">下载会等待，而不使用移动数据</string>
+    <string name="storage_locations_speed_limit_description">允许下载达到多快</string>
+    <string name="storage_locations_internal_note">所有文件都保存在设备的内部存储中。你随时可以用任何文件管理器应用访问它们。</string>
+    <string name="storage_locations_wifi_only">仅 Wi-Fi</string>
+    <string name="storage_locations_speed_limit">速度限制</string>
+
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -461,10 +461,13 @@
     <string name="appearance_title">外观</string>
 
     <!-- Language picker -->
-    <string name="language_title">语言</string>
+    <string name="language_title">应用语言</string>
     <string name="language_system">跟随系统</string>
-    <string name="language_system_description">使用设备的语言</string>
-    <string name="language_close">关闭</string>
+    <string name="language_system_description">跟随设备</string>
+    <string name="language_current">当前：%1$s</string>
+    <string name="language_selected">已选：%1$s</string>
+    <string name="language_cancel">取消</string>
+    <string name="language_confirm">确认</string>
     <string name="language_changed_title">语言已更改</string>
     <string name="language_changed_body">Hazel 现在使用这种语言。应用中尚未翻译的部分仍会显示英文。</string>
     <string name="language_changed_ok">确定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,10 +500,15 @@
     <string name="appearance_title">Appearance</string>
 
     <!-- Language picker -->
-    <string name="language_title">Language</string>
+    <string name="language_title">App language</string>
     <string name="language_system">System default</string>
-    <string name="language_system_description">Follow the device language</string>
-    <string name="language_close">Close</string>
+    <string name="language_system_description">Follow the device</string>
+    <!-- Under the sheet title. %1$s is the language the app is in right now. -->
+    <string name="language_current">Current: %1$s</string>
+    <!-- Replaces it once a different card is picked. %1$s is that language. -->
+    <string name="language_selected">Selected: %1$s</string>
+    <string name="language_cancel">Cancel</string>
+    <string name="language_confirm">Confirm</string>
     <string name="language_changed_title">Language changed</string>
     <string name="language_changed_body">Hazel is now in this language. Anything the app has not been translated into stays in English.</string>
     <string name="language_changed_ok">OK</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="more_battery_body">Downloads keep running in the background on their own. Some phones still cut them short to save battery. Allow unrestricted use to rule that out.</string>
     <string name="more_downloads">Downloads</string>
     <string name="more_appearance">Appearance</string>
+    <string name="more_language">Language</string>
     <string name="more_cookies">Cookies</string>
     <string name="more_link_reading">Link Reading</string>
     <string name="more_hazel_instant">Hazel Instant</string>
@@ -497,6 +498,15 @@
     <!-- AppearanceScreen -->
     <string name="appearance_back">Back</string>
     <string name="appearance_title">Appearance</string>
+
+    <!-- Language picker -->
+    <string name="language_title">Language</string>
+    <string name="language_system">System default</string>
+    <string name="language_system_description">Follow the device language</string>
+    <string name="language_close">Close</string>
+    <string name="language_changed_title">Language changed</string>
+    <string name="language_changed_body">Hazel is now in this language. Anything the app has not been translated into stays in English.</string>
+    <string name="language_changed_ok">OK</string>
     <string name="appearance_dark_theme">Dark Theme</string>
     <string name="appearance_accent_color">Accent Color</string>
 

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     The languages Hazel ships.
+
+     Android 13 and later reads this to decide whether the app gets an entry in the system
+     language settings, and which languages that entry offers. Without it the app is absent
+     from that screen entirely, so a person who expects to set an app's language where they
+     set every other app's would find nothing.
+
+     English leads because it is the source the rest are translated from, and it is what a
+     language with no folder of its own falls back to.
+-->
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="es" />
+    <locale android:name="zh-CN" />
+    <locale android:name="hi" />
+    <locale android:name="pt-BR" />
+    <locale android:name="fr" />
+    <locale android:name="ru" />
+    <locale android:name="de" />
+    <locale android:name="ja" />
+    <locale android:name="in" />
+</locale-config>


### PR DESCRIPTION
Hazel now speaks six languages, and can be set to one the phone is not in.

## Languages

Spanish, Hindi, Simplified Chinese, Brazilian Portuguese, French and German, each a
complete `values-xx/strings.xml` at 470 entries, one commit per language. Russian, Japanese
and Indonesian are listed in the picker and in `locales_config.xml` but have no file yet, so
they fall back to English until one lands.

Nothing has to be chosen. With no answer stored Android already resolves every string
against the device language, so a phone set to Spanish opens a Spanish app on first launch.

`python tools/check.py translations` passes for all six: key sets match the source exactly,
no invented or missing keys, placeholders and inline markup carry through unchanged,
apostrophes escaped, and plural categories are the ones each language actually defines,
checked against the CLDR table the tool carries. Spanish, Portuguese and French therefore
have `one`, `many` and `other`; German and Hindi have `one` and `other`; Chinese has `other`
alone.

## The picker

A row under More, showing the current language on the right. It opens as a bottom sheet of
cards, two to a row, each naming the language in itself with the English underneath, because
somebody hunting for their own language is looking for the word they would write.

Choosing a card does not change anything. The heading says what the app is in now and
switches to what has been picked, and only Confirm commits it. A language is the one setting
where a mis-tap leaves you unable to read the screen you would use to undo it, so it is
worth the extra tap. A short note follows in the language just chosen.

## How the choice is stored

From Android 13 the platform owns it: `LocaleManager` keeps the choice, it appears in the
system language settings beside every other app, and it survives clearing the app's data.
`locales_config.xml` is what makes the app appear there at all. Below 13 there is nowhere
else to put it, so the tag goes to `SharedPreferences` and the activity's context is wrapped
as it is built. Preferences rather than the DataStore the rest of the settings use, because
this is read in `attachBaseContext`, before anything can suspend.

`AppCompatDelegate.setApplicationLocales` is the usual answer and is not used here: the
project has no `appcompat` dependency and `MainActivity` is a plain `ComponentActivity`, so
below API 33 nothing would apply the locale, and making it an `AppCompatActivity` collides
with the splash theme.

## Two fixes found by testing on a device

**The screen appeared to crash and restart.** Changing the language relaunched the activity,
so the splash theme flashed and the screen redrew from nothing. The PID was unchanged
throughout and there was no exception; it only looked like a crash. The activity now
declares `configChanges="locale|layoutDirection"`, so Compose republishes the configuration
and the screen arrives in the new language without going away first.

**The confirmation note never appeared on Android 13 and later.** The flag lived only in
composition, and the platform rebuilt the activity on the spot, taking it with it. It is
saved now, so it survives.

## Verification

`assembleDebug` and all 27 unit tests pass. `check.py resources` and `check.py translations`
pass. Walked on a physical device: the picker, a draft selection, Confirm, the note, and the
whole app in Hindi and in German.
