### PR TITLE
feat: Add Russian, Japanese, and Indonesian translations

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,0 +1,553 @@
+<resources>
+    <string name="direct_share_label">Instan</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">Beranda</string>
+    <string name="nav_history">Unduhan</string>
+    <string name="nav_more">Lainnya</string>
+    <string name="nav_incognito_on">Mode samaran aktif, unduhan tidak dicatat</string>
+    <string name="nav_incognito_off">Mode samaran nonaktif</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">Cari atau masukkan URL</string>
+    <string name="download_clear">Hapus</string>
+    <string name="download_show_large_artwork">Tampilkan gambar besar</string>
+    <string name="download_show_list">Tampilkan sebagai daftar</string>
+    <string name="download_instant_source">Instan · membaca dari %1$s</string>
+    <string name="download_incognito_title">Anda dalam mode samaran</string>
+    <string name="download_incognito_body">Unduhan tidak ditambahkan ke riwayat dan tautan tidak diingat. File tetap disimpan seperti biasa.</string>
+    <string name="download_download_all">Unduh semua</string>
+    <string name="download_saved_aside">Unduhan Anda telah disimpan. Temukan di tab Unduhan.</string>
+    <string name="download_options">Opsi unduhan</string>
+    <string name="download_pause">Jeda</string>
+    <string name="download_resume">Lanjutkan</string>
+    <string name="download_cancel">Batal</string>
+    <string name="download_paused">Dijeda</string>
+    <string name="download_processing">Memproses</string>
+    <string name="download_waiting_wifi">Menunggu Wi-Fi</string>
+    <string name="download_saved">Tersimpan</string>
+    <string name="download_queued">Dalam antrean</string>
+    <string name="download_downloaded">Selesai diunduh</string>
+    <string name="download_failed">Gagal</string>
+    <string name="download_remove_link">Hapus tautan</string>
+    <string name="download_cancel_action">Batalkan unduhan</string>
+    <string name="download_resume_action">Lanjutkan unduhan</string>
+    <plurals name="download_links">
+        <item quantity="other">%d tautan</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">Cari atau masukkan URL</string>
+    <string name="search_back">Kembali</string>
+    <string name="search_more">Lainnya</string>
+    <string name="search_add_link">Tambah tautan lain</string>
+    <string name="search_clear">Hapus</string>
+    <string name="search_clear_results">Hapus hasil</string>
+    <string name="search_clear_history">Hapus riwayat pencarian</string>
+    <string name="search_empty_history">Tautan yang Anda gunakan akan muncul di sini</string>
+    <string name="search_no_matches">Tidak ada tautan yang cocok</string>
+    <string name="search_remove">Hapus</string>
+    <string name="search_all">Cari semua</string>
+    <string name="search_forget">Lupakan</string>
+    <string name="search_edit_before">Edit sebelum mencari</string>
+    <string name="search_paste_and_fetch">Tempel dan ambil</string>
+    <string name="search_nothing_to_paste">Tidak ada yang bisa ditempel</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">Sudah diunduh</string>
+    <string name="already_downloaded_body">Tautan ini sudah tersimpan di perangkat ini.</string>
+    <string name="already_downloaded_video">Video</string>
+    <string name="already_downloaded_audio">Audio</string>
+    <string name="already_downloaded_keep">Simpan saja</string>
+    <string name="already_downloaded_play">Putar</string>
+    <string name="already_downloaded_download_again">Unduh lagi</string>
+    <string name="already_downloaded_just_now">Baru saja</string>
+    <string name="already_downloaded_yesterday">Kemarin</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="other">%d mnt</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="other">%d jam</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="other">%d hari</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="other">%d bln</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">Perlu masuk</string>
+    <string name="no_results_error_title">Tidak dapat membaca tautan ini</string>
+    <string name="no_results_sign_in_body">Sumber memerlukan akun sebelum dapat diakses. Masuk akan menyimpan cookie untuk situs tersebut dan mencoba lagi.</string>
+    <string name="no_results_continue_body">Rincian tidak dapat dibaca, tetapi unduhan mungkin tetap berhasil. Melanjutkan akan menggunakan kualitas terbaik yang tersedia.</string>
+    <string name="no_results_refused_body">Sumber menolak permintaan.</string>
+    <string name="no_results_engine_report">Laporan mesin</string>
+    <string name="no_results_copy_log">Salin log</string>
+    <string name="no_results_sign_in">Masuk</string>
+    <string name="no_results_try_anyway">Tetap coba</string>
+    <string name="no_results_close">Tutup</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">Memulai</string>
+    <string name="guide_step_paste_link">Tempel tautan ke bidang pencarian untuk mengunduhnya. Anda dapat menambahkan beberapa tautan dan daftar putar</string>
+    <string name="guide_step_pick_format">Ketuk kartu untuk memilih format yang tepat. Semua kualitas yang tersedia tercantum beserta ukuran dan codec.</string>
+    <string name="guide_step_share_instant">Bagikan tautan ke Hazel Instan dari aplikasi apa pun untuk mengunduh langsung pada kualitas yang Anda tentukan.</string>
+    <string name="guide_step_finished_downloads">File yang selesai akan muncul di Unduhan. Ketuk baris mana saja untuk membukanya di pemutar default perangkat.</string>
+    <string name="guide_step_battery_unrestricted">Atur penggunaan baterai ke tanpa batas, jika tidak Android dapat menghentikan unduhan saat Anda keluar dari aplikasi.</string>
+    <string name="guide_battery_settings">Pengaturan baterai</string>
+    <string name="guide_close">Tutup</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">Unduh</string>
+    <string name="format_sheet_subtitle">Sesuaikan unduhan</string>
+    <string name="format_sheet_play">Putar</string>
+    <string name="format_sheet_ok">OK</string>
+    <string name="format_sheet_download">Unduh</string>
+    <string name="format_sheet_tab_audio">Audio</string>
+    <string name="format_sheet_tab_video">Video</string>
+    <string name="format_sheet_label_title">Judul</string>
+    <string name="format_sheet_label_author">Pembuat</string>
+    <string name="format_sheet_label_container">Wadah</string>
+    <string name="format_sheet_video_quality">Kualitas video</string>
+    <string name="format_sheet_audio_quality">Kualitas audio</string>
+    <string name="format_sheet_no_video_stream">Sumber ini tidak memiliki aliran video terpisah.</string>
+    <string name="format_sheet_no_audio_stream">Sumber ini tidak memiliki aliran audio terpisah.</string>
+    <string name="format_sheet_adjust_video">Sesuaikan video</string>
+    <string name="format_sheet_adjust_audio">Sesuaikan audio</string>
+    <string name="format_sheet_thumbnail">Gambar mini</string>
+    <string name="format_sheet_chapters">Bab</string>
+    <string name="format_sheet_subtitles">Subtitel</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">Bahasa audio</string>
+    <string name="format_sheet_change_audio_language">Ubah bahasa audio</string>
+    <string name="format_sheet_filename_template">Templat nama file</string>
+    <string name="format_sheet_change_field">Ubah</string>
+    <string name="format_sheet_save_dir">Folder penyimpanan</string>
+    <string name="format_sheet_save_location">Lokasi penyimpanan</string>
+    <string name="format_sheet_save_location_title">Lokasi penyimpanan</string>
+    <string name="format_sheet_save_location_body">Buka folder ini di pengelola file Anda, atau pilih folder lain untuk menyimpan unduhan.</string>
+    <string name="format_sheet_open_folder">Buka folder</string>
+    <string name="format_sheet_reset">Reset</string>
+    <string name="format_sheet_change">Ubah</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">Konversi ke</string>
+    <string name="converter_label_saved_to">Disimpan ke</string>
+    <string name="converter_hazel_storage">Penyimpanan internal Hazel</string>
+    <string name="converter_storage_warning">Tanpa akses penyimpanan, file tetap berada di dalam Hazel dan tidak dapat dilihat oleh aplikasi lain.</string>
+    <string name="converter_back">Kembali</string>
+    <string name="converter_title">Pengonversi Offline</string>
+    <string name="converter_subtitle">Video ke audio, tidak ada yang keluar dari ponsel</string>
+    <string name="converter_choose_video">Pilih file video</string>
+    <string name="converter_ready">Siap</string>
+    <string name="converter_choose_video_hint">File apa pun di ponsel atau kartu SD</string>
+    <string name="converter_change">Ubah</string>
+    <string name="converter_converting">Mengonversi</string>
+    <string name="converter_convert">Konversi</string>
+    <string name="converter_saved">Tersimpan</string>
+    <string name="converter_open_folder">Buka folder</string>
+    <string name="converter_convert_another">Konversi lainnya</string>
+    <string name="converter_error_title">Gagal mengonversi</string>
+    <string name="converter_dismiss">Tutup</string>
+    <string name="converter_save_as_title">Simpan sebagai</string>
+    <string name="converter_save_as_body">Menamai file dan dituliskan ke dalam tag judulnya.</string>
+    <string name="converter_label_name">Nama</string>
+    <string name="converter_start">Mulai</string>
+    <string name="converter_format_sheet_title">Konversi ke</string>
+    <string name="converter_heading_common">Tiga format utama</string>
+    <string name="converter_heading_other">Format lainnya</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">Lainnya</string>
+    <string name="more_battery_title">Unduhan latar belakang</string>
+    <string name="more_battery_body">Unduhan tetap berjalan di latar belakang secara mandiri. Beberapa ponsel membatasinya untuk menghemat baterai. Izinkan penggunaan tanpa batas untuk menghindarinya.</string>
+    <string name="more_downloads">Unduhan</string>
+    <string name="more_appearance">Tampilan</string>
+    <string name="more_language">Bahasa</string>
+    <string name="more_cookies">Cookie</string>
+    <string name="more_link_reading">Pembacaan Tautan</string>
+    <string name="more_hazel_instant">Hazel Instan</string>
+    <string name="more_temporary_files">File Sementara</string>
+    <string name="more_converter">Konversi offline video ke audio</string>
+    <string name="more_engine_update">Pembaruan Mesin yt-dlp</string>
+    <string name="more_support">Dukung Hazel</string>
+    <string name="more_license">Lisensi</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">Kembali</string>
+    <string name="sponsor_title">Dukung Hazel</string>
+    <string name="sponsor_hero_title">Gratis, dan akan selalu begitu</string>
+    <string name="sponsor_hero_body">Hazel dikembangkan di waktu luang dan akhir pekan, dan diberikan gratis karena aplikasi pengunduh berbayar adalah aplikasi yang buruk. Situs web selalu berubah, dan menyesuaikan dengannya membutuhkan waktu.</string>
+    <string name="sponsor_hero_closing">Jika aplikasi ini menghemat waktu Anda, dukungan di bawah ini sangat berarti bagi kelanjutannya. Jika tidak, bantuan tanpa biaya juga sama berharganya.</string>
+    <string name="sponsor_section_ways">Cara mendukung</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">Bulanan atau sekali bayar, dapat dibatalkan kapan saja. Dikelola sepenuhnya oleh GitHub.</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">Sekali bayar, tidak perlu akun.</string>
+    <string name="sponsor_kofi_soon">Segera hadir</string>
+    <string name="sponsor_section_free">Tanpa biaya, sangat membantu</string>
+    <string name="sponsor_star_title">Beri bintang pada proyek</string>
+    <string name="sponsor_star_subtitle">Angka utama yang dilihat orang sebelum mencoba aplikasi.</string>
+    <string name="sponsor_share_title">Beri tahu orang lain</string>
+    <string name="sponsor_share_subtitle">Rekomendasi dari mulut ke mulut adalah seluruh pemasaran aplikasi ini.</string>
+    <string name="sponsor_issues_title">Laporkan kendala</string>
+    <string name="sponsor_issues_subtitle">Situs yang berhenti berfungsi adalah masalah yang perlu Anda laporkan agar bisa diperbaiki.</string>
+    <string name="sponsor_source_title">Lihat kode sumber</string>
+    <string name="sponsor_source_subtitle">Setiap baris kode bersifat terbuka, dan kontribusi sangat disambut.</string>
+    <string name="sponsor_footer">Tanpa iklan, tanpa pelacakan unduhan Anda, dan tanpa fitur yang ditahan untuk siapa pun. Dukungan memengaruhi seberapa banyak waktu yang diberikan untuk Hazel, bukan apa yang dapat dilakukannya untuk Anda.</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">Pembaruan yt-dlp</string>
+    <string name="update_back">Kembali</string>
+    <string name="update_check_action">Periksa pembaruan</string>
+    <string name="update_status_up_to_date">Versi terbaru sudah terpasang</string>
+    <string name="update_status_checking">Memeriksa pembaruan...</string>
+    <string name="update_status_available">Pembaruan Tersedia</string>
+    <string name="update_status_installing">Memasang yt-dlp...</string>
+    <string name="update_status_installed">Mesin Diperbarui</string>
+    <string name="update_status_failed">Pembaruan Gagal</string>
+    <string name="update_subtitle_idle">Hazel menggunakan versi yt-dlp terbaru</string>
+    <string name="update_subtitle_checking">Menghubungi GitHub...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s tersedia</string>
+    <string name="update_subtitle_updating">Mengunduh yt-dlp %1$s</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s sekarang digunakan</string>
+    <string name="update_installed_version">Versi Terpasang</string>
+    <string name="update_version_unknown">Tidak diketahui</string>
+    <string name="update_new_version">Versi Baru</string>
+    <string name="update_installing_binary">Memasang Biner</string>
+    <string name="update_installing_body">Mengunduh dari GitHub dan mengganti mesin. Biarkan aplikasi tetap terbuka.</string>
+    <string name="update_action_update_now">Perbarui Sekarang</string>
+    <string name="update_action_installing">Memasang...</string>
+    <string name="update_action_done">Selesai</string>
+    <string name="update_action_retry">Coba Lagi</string>
+    <string name="update_action_check">Periksa Pembaruan</string>
+    <string name="update_action_checking">Memeriksa...</string>
+    <string name="update_info_heading">Informasi</string>
+    <string name="update_info_component">Komponen</string>
+    <string name="update_info_repository">Repositori</string>
+    <string name="update_info_binary_size">Ukuran Biner</string>
+    <string name="update_info_distribution">Distribusi</string>
+    <string name="update_info_github_releases">Rilis GitHub</string>
+    <string name="update_release_channel">Saluran Rilis</string>
+    <string name="update_view_changelog">Lihat Catatan Perubahan</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">Pilih penyaringan SponsorBlock</string>
+    <string name="options_sponsorblock_ok">OK</string>
+    <string name="options_sponsorblock_cancel">Batal</string>
+    <string name="options_chapters_title">Bab</string>
+    <string name="options_chapters_in_videos">Bab dalam video</string>
+    <string name="options_chapters_split">Bagi berdasarkan bab</string>
+    <string name="options_chapters_split_body">Pembagian akan menyimpan satu file per bab alih-alih satu file tunggal.</string>
+    <string name="options_chapters_dismiss">Tutup</string>
+    <string name="options_subtitles_title">Subtitel</string>
+    <string name="options_subtitles_embed">Sematkan subtitel</string>
+    <string name="options_subtitles_save">Simpan subtitel</string>
+    <string name="options_subtitles_save_auto">Simpan subtitel otomatis</string>
+    <string name="options_subtitles_languages_label">Bahasa subtitel</string>
+    <string name="options_subtitles_dismiss">Tutup</string>
+    <string name="options_subtitles_languages_title">Bahasa subtitel</string>
+    <string name="options_subtitles_languages_hint">Pemilih bahasa yt-dlp, mis. en.*,.*-orig untuk bahasa Inggris ditambah trek asli. Gunakan all untuk semua bahasa yang ditawarkan sumber.</string>
+    <string name="options_filename_title">Templat nama file</string>
+    <string name="options_filename_hint">Templat keluaran yt-dlp. Gunakan %(title)s, %(uploader)s, %(id)s, dan %(ext)s.</string>
+    <string name="options_text_input_save">Simpan</string>
+    <string name="options_text_input_cancel">Batal</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">Kembali</string>
+    <string name="cleanup_title">File Sementara</string>
+    <string name="cleanup_header_description">File kerja yang disimpan oleh aplikasi. Unduhan Anda tidak termasuk dan tidak akan pernah dihapus dari sini.</string>
+    <string name="cleanup_action_clear_everything">Hapus semua</string>
+    <string name="cleanup_category_link_data_label">Cache data tautan</string>
+    <string name="cleanup_category_link_data_description">Data pemutar yang disimpan yt-dlp agar pembacaan tautan untuk kedua kalinya lebih cepat. Aman untuk dihapus.</string>
+    <string name="cleanup_category_partial_downloads_label">Unduhan belum selesai</string>
+    <string name="cleanup_category_partial_downloads_description">Fragmen tersisa dari unduhan yang dibatalkan atau gagal sebelum file disimpan.</string>
+    <string name="cleanup_category_conversions_label">Konversi belum selesai</string>
+    <string name="cleanup_category_conversions_description">File kerja dari pengonversi audio yang belum dipindahkan ke folder musik Anda.</string>
+    <string name="cleanup_category_engine_label">File mesin yt-dlp</string>
+    <string name="cleanup_category_engine_description">Pengunduh dan lingkungan eksekusinya. Menghapusnya membebaskan paling banyak ruang, tetapi unduhan berikutnya harus mengekstraknya kembali.</string>
+    <string name="cleanup_category_other_cache_label">File cache lainnya</string>
+    <string name="cleanup_category_other_cache_description">Gambar mini dan file lain yang di-cache saat menjelajahi tautan.</string>
+    <string name="cleanup_confirm_category_title">Hapus file-file ini?</string>
+    <string name="cleanup_confirm_category_safe">%1$s ruang akan dikosongkan. File yang telah disimpan tidak akan terpengaruh.</string>
+    <string name="cleanup_confirm_category_unsafe">%1$s ruang akan dikosongkan, dan unduhan berikutnya akan membutuhkan waktu lebih lama karena komponen harus diekstrak ulang.</string>
+    <string name="cleanup_confirm_clear">Hapus</string>
+    <string name="cleanup_confirm_cancel">Batal</string>
+    <string name="cleanup_confirm_all_title">Hapus semua?</string>
+    <string name="cleanup_confirm_all_body">%1$s ruang akan dikosongkan. Unduhan dan sesi masuk Anda akan tetap tersimpan, tetapi unduhan berikutnya akan membutuhkan waktu lebih lama karena mesin harus diekstrak ulang.</string>
+    <string name="cleanup_confirm_all_confirm">Hapus semua</string>
+    <string name="cleanup_confirm_all_cancel">Batal</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">Unduhan</string>
+    <string name="history_layout_grid">Tampilkan gambar besar</string>
+    <string name="history_layout_list">Tampilkan sebagai daftar</string>
+    <string name="history_search_action">Cari unduhan</string>
+    <string name="history_sort_action">Urutkan</string>
+    <string name="history_menu_action">Lainnya</string>
+    <string name="history_menu_clear">Hapus riwayat</string>
+    <string name="history_search_placeholder">Cari unduhan</string>
+    <string name="history_search_clear">Hapus pencarian</string>
+    <string name="history_empty_initial">Belum ada yang diunduh</string>
+    <string name="history_empty_filtered">Tidak ada yang cocok</string>
+    <string name="history_clear_dialog_title">Hapus riwayat</string>
+    <string name="history_clear_dialog_body">Daftar akan dikosongkan. File yang telah diunduh tidak akan terpengaruh.</string>
+    <string name="history_clear_dialog_confirm">Hapus</string>
+    <string name="history_clear_dialog_cancel">Batal</string>
+    <string name="history_delete_dialog_title">Hapus file</string>
+    <string name="history_delete_dialog_body">%1$s akan dihapus dari perangkat Anda.</string>
+    <string name="history_toast_file_deleted">File dihapus</string>
+    <string name="history_toast_file_delete_failed">Tidak dapat menghapus file</string>
+    <string name="history_delete_dialog_confirm">Hapus</string>
+    <string name="history_delete_dialog_cancel">Batal</string>
+    <string name="history_card_options">Opsi</string>
+    <string name="history_card_properties">Properti</string>
+    <string name="history_card_remove">Hapus dari daftar</string>
+    <string name="history_card_delete">Hapus file</string>
+    <string name="history_tag_deleted">Dihapus</string>
+    <string name="history_row_options">Opsi</string>
+    <string name="history_row_properties">Properti</string>
+    <string name="history_row_remove">Hapus dari daftar</string>
+    <string name="history_row_delete">Hapus file</string>
+    <string name="history_toast_file_gone">File ini sudah tidak ada di perangkat Anda</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">Properti</string>
+    <string name="properties_status">Status</string>
+    <string name="properties_status_present">Ada di perangkat ini</string>
+    <string name="properties_status_deleted">Dihapus dari perangkat ini</string>
+    <string name="properties_kind">Jenis</string>
+    <string name="properties_kind_video">Video</string>
+    <string name="properties_kind_audio">Audio</string>
+    <string name="properties_quality">Kualitas</string>
+    <string name="properties_resolution">Resolusi</string>
+    <string name="properties_length">Durasi</string>
+    <string name="properties_codec">Codec</string>
+    <string name="properties_bitrate">Bitrate</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">Ukuran</string>
+    <string name="properties_container">Wadah</string>
+    <string name="properties_type">Tipe</string>
+    <string name="properties_embedded">Tertanam</string>
+    <string name="properties_file">File</string>
+    <string name="properties_saved_to">Disimpan ke</string>
+    <string name="properties_downloaded">Waktu diunduh</string>
+    <string name="properties_source">Sumber</string>
+    <string name="properties_link_copied_opened">Tautan disalin dan dibuka</string>
+    <string name="properties_link_copied">Tautan disalin</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">Kembali</string>
+    <string name="cookies_title">Cookie</string>
+    <string name="cookies_menu">Lainnya</string>
+    <string name="cookies_menu_import">Impor dari papan klip</string>
+    <string name="cookies_menu_export">Ekspor ke papan klip</string>
+    <string name="cookies_menu_delete_all">Hapus semua</string>
+    <string name="cookies_imported_title">Cookie yang diimpor</string>
+    <string name="cookies_toast_imported">Cookie berhasil diimpor</string>
+    <string name="cookies_toast_no_data">Papan klip tidak berisi data cookie</string>
+    <string name="cookies_toast_nothing_to_export">Tidak ada yang bisa diekspor</string>
+    <string name="cookies_toast_exported">Disalin ke papan klip</string>
+    <string name="cookies_toast_entry_copied">Disalin ke papan klip</string>
+    <string name="cookies_use_title">Gunakan cookie</string>
+    <string name="cookies_use_description">Teruskan sesi masuk yang tersimpan ke pengunduh</string>
+    <string name="cookies_new">Cookie baru</string>
+    <string name="cookies_empty_title">Belum ada cookie yang tersimpan</string>
+    <string name="cookies_empty_body">Tambahkan untuk mengunduh media dengan pembatasan usia, privat, atau khusus anggota.</string>
+    <string name="cookies_delete_title">Hapus cookie</string>
+    <string name="cookies_delete_body">Hapus informasi masuk yang tersimpan untuk %1$s?</string>
+    <string name="cookies_delete_confirm">Hapus</string>
+    <string name="cookies_delete_cancel">Batal</string>
+    <string name="cookies_delete_all_title">Hapus semua cookie</string>
+    <string name="cookies_delete_all_body">Semua sesi masuk yang tersimpan akan dihapus. Tindakan ini tidak dapat dibatalkan.</string>
+    <string name="cookies_delete_all_confirm">Hapus semua</string>
+    <string name="cookies_delete_all_cancel">Batal</string>
+    <string name="cookies_row_fallback_name">Cookie</string>
+    <string name="cookies_sheet_title">Cookie</string>
+    <string name="cookies_sheet_copy">Salin cookie</string>
+    <string name="cookies_sheet_delete">Hapus cookie</string>
+    <string name="cookies_field_title">Judul</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">Simpan</string>
+    <string name="cookies_sheet_get">Dapatkan cookie</string>
+    <string name="cookies_sheet_update">Perbarui</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">Kualitas terbaik</string>
+    <string name="batch_type_sheet_title">Jenis unduhan yang diinginkan</string>
+    <string name="batch_type_sheet_subtitle">Format unduhan tautan-tautan ini</string>
+    <string name="batch_type_audio">Audio</string>
+    <string name="batch_type_video">Video</string>
+    <string name="batch_format_title">Format</string>
+    <string name="batch_format_subtitle">Pilih format</string>
+    <string name="batch_container_title">Wadah</string>
+    <string name="batch_container_subtitle">Format file penyimpanan tautan-tautan ini</string>
+    <string name="batch_save_dir_title">Lokasi penyimpanan</string>
+    <string name="batch_open_folder">Buka folder ini</string>
+    <string name="batch_change_folder">Ubah folder</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">Gambar mini</string>
+    <string name="batch_bar_chapters">Bab</string>
+    <string name="batch_bar_subtitles">Subtitel</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">Templat nama file</string>
+    <string name="batch_bar_download_type">Jenis unduhan yang diinginkan</string>
+    <string name="batch_bar_quality">Kualitas: %1$s</string>
+    <string name="batch_bar_save_location">Lokasi penyimpanan</string>
+    <string name="batch_bar_container">Wadah</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">Unduh</string>
+    <string name="batch_header_subtitle">Sesuaikan unduhan</string>
+    <string name="batch_download_action">Unduh</string>
+    <string name="batch_stop_selecting">Selesai memilih</string>
+    <string name="batch_start_selecting">Pilih tautan</string>
+    <string name="batch_list_options">Opsi daftar</string>
+    <string name="batch_menu_select_links">Pilih tautan</string>
+    <string name="batch_menu_select_all">Pilih semua</string>
+    <string name="batch_menu_invert">Balikkan pilihan</string>
+    <string name="batch_menu_remove_selected">Hapus yang dipilih</string>
+    <string name="batch_menu_done">Selesai</string>
+    <plurals name="batch_selected">
+        <item quantity="other">%d dipilih</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="other">%d tautan</item>
+    </plurals>
+    <string name="batch_card_download_type">Jenis unduhan untuk tautan ini</string>
+    <string name="batch_card_remove">Hapus</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">Lokasi file ini tidak diketahui</string>
+    <string name="media_open_chooser">Buka dengan</string>
+    <string name="media_open_no_app">Tidak ada aplikasi di perangkat ini yang dapat membukanya</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">Unduhan dibatalkan</string>
+    <string name="notification_channel_progress_description">Kemajuan unduhan, menampilkan ikon di bilah status</string>
+    <string name="notification_channel_complete_description">Pemberitahuan penyelesaian unduhan</string>
+    <string name="notification_action_pause">Jeda</string>
+    <string name="notification_action_resume">Lanjutkan</string>
+    <string name="notification_action_cancel">Batal</string>
+    <string name="notification_action_sign_in">Masuk</string>
+    <string name="notification_wifi_title">Menunggu Wi-Fi</string>
+    <string name="notification_wifi_text">Unduhan diatur hanya untuk Wi-Fi. Unduhan akan dimulai setelah terhubung kembali ke Wi-Fi.</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">Tutup</string>
+    <string name="cookie_webview_desktop_site">Situs desktop</string>
+    <string name="cookie_webview_no_cookies">Tidak ada cookie yang dikumpulkan</string>
+    <string name="cookie_webview_done">"  OK"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">Urutkan format</string>
+    <string name="format_selection_change">Ubah format</string>
+    <string name="format_selection_title">Format</string>
+    <string name="format_selection_subtitle">Pilih format</string>
+    <string name="format_selection_confirm">OK</string>
+    <string name="format_selection_loading">Membaca format lainnya</string>
+    <string name="format_sort_quality">Kualitas</string>
+    <string name="format_sort_file_size">Ukuran file</string>
+    <string name="format_sort_container">Wadah</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">Bahasa audio</string>
+    <string name="audio_language_subtitle">Pilih trek suara</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">Kembali</string>
+    <string name="appearance_title">Tampilan</string>
+
+    <!-- Language picker -->
+    <string name="language_title">Bahasa aplikasi</string>
+    <string name="language_system">Default sistem</string>
+    <string name="language_system_description">Ikuti perangkat</string>
+    <string name="language_current">Saat ini: %1$s</string>
+    <string name="language_selected">Dipilih: %1$s</string>
+    <string name="language_cancel">Batal</string>
+    <string name="language_confirm">Konfirmasi</string>
+    <string name="language_changed_title">Bahasa diubah</string>
+    <string name="language_changed_body">Hazel sekarang menggunakan bahasa ini. Bagian yang belum diterjemahkan akan tetap menggunakan bahasa Inggris.</string>
+    <string name="language_changed_ok">OK</string>
+    <string name="appearance_dark_theme">Tema Gelap</string>
+    <string name="appearance_accent_color">Warna Aksen</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">Warna Aksen</string>
+    <string name="accent_picker_close">Tutup</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">Kembali</string>
+    <string name="fetch_settings_title">Pembacaan Tautan</string>
+    <string name="fetch_settings_timeout_description">Berapa lama menunggu sumber yang lambat sebelum menyerah dan mencoba lagi.</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="other">Batas waktu %1$d dtk, %2$d percobaan</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">Membaca tautan</string>
+    <string name="fetch_settings_reading_links_description">Pembaca mana yang mengidentifikasi isi tautan. Unduhan selalu menggunakan yt-dlp, apa pun yang dipilih di sini.</string>
+    <string name="fetch_settings_force_ipv4_description">Hanya aktifkan jika tautan terhenti di jaringan Anda. Ini mengatasi rute IPv6 yang bermasalah, dan lebih lambat di tempat lain.</string>
+    <string name="fetch_settings_force_ipv4">Paksa IPv4</string>
+    <string name="fetch_mode_fast_label">Cepat</string>
+    <string name="fetch_mode_fast_description">Cepat menyerah. Paling cepat di jaringan yang baik, tetapi lebih mungkin memerlukan percobaan kedua.</string>
+    <string name="fetch_mode_balanced_label">Seimbang</string>
+    <string name="fetch_mode_balanced_description">Jalan tengah antara kecepatan dan toleransi koneksi yang kurang baik.</string>
+    <string name="fetch_mode_thorough_label">Menyeluruh</string>
+    <string name="fetch_mode_thorough_description">Menunggu lebih lama dan mencoba lebih banyak. Paling lambat, tetapi tahan di jaringan yang lemah.</string>
+    <string name="listing_source_ytdlp_description">Mesin yang sama dengan yang melakukan pengunduhan. Bekerja di setiap situs yang didukungnya, dan memperbarui diri sendiri, sehingga tetap berfungsi saat situs berubah.</string>
+    <string name="listing_source_newpipe_label">Pilih pembaca bawaan</string>
+    <string name="listing_source_newpipe_description">Mendaftar daftar putar dan saluran dalam satu permintaan tanpa memulai mesin, yang lebih cepat di situs yang dikenalnya. Beralih kembali ke yt-dlp untuk hal lain dan setiap kali tidak dapat membaca tautan.</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">Kembali</string>
+    <string name="tools_title">Alat</string>
+    <string name="tools_empty">Belum ada apa-apa di sini.</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">Kembali</string>
+    <string name="direct_share_save_as">Simpan sebagai</string>
+    <string name="direct_share_video">Video</string>
+    <string name="direct_share_audio_only">Hanya audio</string>
+    <string name="direct_share_title">Hazel Instan</string>
+    <string name="direct_share_intro">Membagikan tautan ke Hazel Instan langsung memulai pengunduhan tanpa lembar dialog dan pertanyaan. Pengaturan berikut yang akan digunakan.</string>
+    <string name="direct_share_video_description">Gambar dan suara, digabungkan menjadi satu file.</string>
+    <string name="direct_share_audio_description">Hanya suara, dengan kualitas terbaik yang ditawarkan sumber.</string>
+    <string name="direct_share_quality_title">Batas kualitas</string>
+    <string name="direct_share_quality_description">Batas maksimum, bukan ukuran pasti. Tidak semua sumber menawarkan resolusi yang sama, jadi resolusi tertinggi yang sesuai batas ini akan diambil, atau yang terkecil jika tidak ada yang cocok.</string>
+    <string name="direct_share_output_title">Keluaran</string>
+    <string name="direct_share_output_description">File yang disimpan di perangkat. Standar mempertahankan format yang disediakan sumber, yang merupakan opsi tercepat karena tidak perlu pengkodean ulang.</string>
+    <string name="direct_share_filename_template">Templat nama file</string>
+    <string name="direct_share_audio_language">Bahasa audio</string>
+    <string name="direct_share_audio_language_default">Default sumber</string>
+    <string name="direct_share_extras_title">Tambahan</string>
+    <string name="direct_share_extras_description">Diterapkan jika sumber memilikinya. Apa pun yang tidak tersedia akan dilewati alih-alih menggagalkan unduhan.</string>
+    <string name="direct_share_cover_art">Gambar sampul</string>
+    <string name="direct_share_cover_art_description">Menyematkan gambar mini ke dalam file, jika format wadah mendukungnya.</string>
+    <string name="direct_share_chapters">Bab</string>
+    <string name="direct_share_subtitles">Subtitel</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">Mati</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="other">%1$d kategori dipotong</item>
+    </plurals>
+    <string name="direct_share_signins_title">Sesi masuk</string>
+    <string name="direct_share_signins_description">Berbagi instan menggunakan cookie tersimpan untuk situs tautan tersebut, sama seperti unduhan yang dimulai dari menu. Tidak ada pertanyaan saat berbagi, jadi tautan di balik login hanya berfungsi jika sesi masuk sudah disimpan dan diaktifkan.</string>
+    <string name="direct_share_cookies">Cookie</string>
+    <string name="direct_share_cookies_on">Aktif, digunakan untuk setiap berbagi instan</string>
+    <string name="direct_share_cookies_off">Mati</string>
+    <string name="direct_share_change">Ubah %1$s</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">Kembali</string>
+    <string name="storage_locations_downloads">Unduhan</string>
+    <string name="storage_locations_title">Unduhan</string>
+    <string name="storage_locations_subtitle">Tempat unduhan disimpan, dan batas operasionalnya</string>
+    <string name="storage_locations_limits">Batas</string>
+    <string name="storage_locations_wifi_only_description">Unduhan menunggu alih-alih menggunakan data seluler</string>
+    <string name="storage_locations_speed_limit_description">Batas kecepatan unduhan yang diizinkan</string>
+    <string name="storage_locations_internal_note">Semua file disimpan di penyimpanan internal perangkat Anda. Anda dapat mengaksesnya kapan saja menggunakan aplikasi pengelola file.</string>
+    <string name="storage_locations_wifi_only">Hanya Wi-Fi</string>
+    <string name="storage_locations_speed_limit">Batas kecepatan</string>
+
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,553 @@
+<resources>
+    <string name="direct_share_label">即時</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">ホーム</string>
+    <string name="nav_history">ダウンロード</string>
+    <string name="nav_more">その他</string>
+    <string name="nav_incognito_on">シークレットモード有効、ダウンロードは記録されません</string>
+    <string name="nav_incognito_off">シークレットモード無効</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">検索またはURLを入力</string>
+    <string name="download_clear">消去</string>
+    <string name="download_show_large_artwork">大きいサムネイルを表示</string>
+    <string name="download_show_list">リスト形式で表示</string>
+    <string name="download_instant_source">即時 · %1$s から読み込み中</string>
+    <string name="download_incognito_title">シークレットモード</string>
+    <string name="download_incognito_body">ダウンロードは履歴に追加されず、リンクも保存されません。ファイル自体は通常どおり保存されます。</string>
+    <string name="download_download_all">すべてダウンロード</string>
+    <string name="download_saved_aside">ダウンロードが完了しました。「ダウンロード」タブで確認できます。</string>
+    <string name="download_options">ダウンロードオプション</string>
+    <string name="download_pause">一時停止</string>
+    <string name="download_resume">再開</string>
+    <string name="download_cancel">キャンセル</string>
+    <string name="download_paused">一時停止中</string>
+    <string name="download_processing">処理中</string>
+    <string name="download_waiting_wifi">Wi-Fi待機中</string>
+    <string name="download_saved">保存済み</string>
+    <string name="download_queued">待機中</string>
+    <string name="download_downloaded">ダウンロード完了</string>
+    <string name="download_failed">失敗</string>
+    <string name="download_remove_link">リンクを削除</string>
+    <string name="download_cancel_action">ダウンロードをキャンセル</string>
+    <string name="download_resume_action">ダウンロードを再開</string>
+    <plurals name="download_links">
+        <item quantity="other">%d 件のリンク</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">検索またはURLを入力</string>
+    <string name="search_back">戻る</string>
+    <string name="search_more">その他</string>
+    <string name="search_add_link">リンクを追加</string>
+    <string name="search_clear">消去</string>
+    <string name="search_clear_results">検索結果を消去</string>
+    <string name="search_clear_history">検索履歴を削除</string>
+    <string name="search_empty_history">使用したリンクがここに表示されます</string>
+    <string name="search_no_matches">一致するリンクがありません</string>
+    <string name="search_remove">削除</string>
+    <string name="search_all">すべて検索</string>
+    <string name="search_forget">履歴から削除</string>
+    <string name="search_edit_before">検索前に編集</string>
+    <string name="search_paste_and_fetch">貼り付けて取得</string>
+    <string name="search_nothing_to_paste">クリップボードは空です</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">ダウンロード済み</string>
+    <string name="already_downloaded_body">このリンクはすでにこの端末に保存されています。</string>
+    <string name="already_downloaded_video">動画</string>
+    <string name="already_downloaded_audio">音声</string>
+    <string name="already_downloaded_keep">そのままにする</string>
+    <string name="already_downloaded_play">再生</string>
+    <string name="already_downloaded_download_again">再ダウンロード</string>
+    <string name="already_downloaded_just_now">たった今</string>
+    <string name="already_downloaded_yesterday">昨日</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="other">%d 分</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="other">%d 時間</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="other">%d 日</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="other">%d か月</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">ログインが必要です</string>
+    <string name="no_results_error_title">リンクを読み込めませんでした</string>
+    <string name="no_results_sign_in_body">このソースを取得するにはアカウントが必要です。ログインするとCookieが保存され、再試行されます。</string>
+    <string name="no_results_continue_body">詳細は読み込めませんでしたが、ダウンロード自体は可能な場合があります。続行すると利用可能な最高画質で取得します。</string>
+    <string name="no_results_refused_body">ソースによってリクエストが拒否されました。</string>
+    <string name="no_results_engine_report">エンジンのレポート</string>
+    <string name="no_results_copy_log">ログをコピー</string>
+    <string name="no_results_sign_in">ログイン</string>
+    <string name="no_results_try_anyway">それでも試す</string>
+    <string name="no_results_close">閉じる</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">はじめに</string>
+    <string name="guide_step_paste_link">検索バーにリンクを貼り付けてダウンロードします。複数のリンクやプレイリストの追加も可能です</string>
+    <string name="guide_step_pick_format">カードをタップして詳細な形式を選択します。利用可能なすべての画質がサイズとコーデック付きで表示されます。</string>
+    <string name="guide_step_share_instant">任意のアプリからHazel 即時にリンクを共有すると、設定した画質ですぐにダウンロードできます。</string>
+    <string name="guide_step_finished_downloads">完了したファイルは「ダウンロード」に表示されます。タップすると端末の標準プレーヤーで開きます。</string>
+    <string name="guide_step_battery_unrestricted">バッテリー使用を「無制限」に設定してください。制限されている場合、アプリを離れた際にAndroidがダウンロードを停止することがあります。</string>
+    <string name="guide_battery_settings">バッテリー設定</string>
+    <string name="guide_close">閉じる</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">ダウンロード</string>
+    <string name="format_sheet_subtitle">ダウンロードを調整</string>
+    <string name="format_sheet_play">再生</string>
+    <string name="format_sheet_ok">OK</string>
+    <string name="format_sheet_download">ダウンロード</string>
+    <string name="format_sheet_tab_audio">音声</string>
+    <string name="format_sheet_tab_video">動画</string>
+    <string name="format_sheet_label_title">タイトル</string>
+    <string name="format_sheet_label_author">作成者</string>
+    <string name="format_sheet_label_container">コンテナ</string>
+    <string name="format_sheet_video_quality">動画の画質</string>
+    <string name="format_sheet_audio_quality">音質</string>
+    <string name="format_sheet_no_video_stream">このソースには個別の映像ストリームがありません。</string>
+    <string name="format_sheet_no_audio_stream">このソースには個別の音声ストリームがありません。</string>
+    <string name="format_sheet_adjust_video">動画設定</string>
+    <string name="format_sheet_adjust_audio">音声設定</string>
+    <string name="format_sheet_thumbnail">サムネイル</string>
+    <string name="format_sheet_chapters">チャプター</string>
+    <string name="format_sheet_subtitles">字幕</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">音声の言語</string>
+    <string name="format_sheet_change_audio_language">音声の言語を変更</string>
+    <string name="format_sheet_filename_template">ファイル名テンプレート</string>
+    <string name="format_sheet_change_field">変更</string>
+    <string name="format_sheet_save_dir">保存フォルダ</string>
+    <string name="format_sheet_save_location">保存場所</string>
+    <string name="format_sheet_save_location_title">保存場所</string>
+    <string name="format_sheet_save_location_body">ファイルマネージャーでこのフォルダを開くか、ダウンロードを保存する別のフォルダを選択してください。</string>
+    <string name="format_sheet_open_folder">フォルダを開く</string>
+    <string name="format_sheet_reset">リセット</string>
+    <string name="format_sheet_change">変更</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">変換先形式</string>
+    <string name="converter_label_saved_to">保存先</string>
+    <string name="converter_hazel_storage">Hazel 専用ストレージ</string>
+    <string name="converter_storage_warning">ストレージへのアクセス権限がない場合、ファイルはHazel内部に保存され、他のアプリからは参照できません。</string>
+    <string name="converter_back">戻る</string>
+    <string name="converter_title">オフライン変換</string>
+    <string name="converter_subtitle">動画を音声に変換、データは端末外に送信されません</string>
+    <string name="converter_choose_video">動画ファイルを選択</string>
+    <string name="converter_ready">準備完了</string>
+    <string name="converter_choose_video_hint">端末内またはSDカード内のファイル</string>
+    <string name="converter_change">変更</string>
+    <string name="converter_converting">変換中</string>
+    <string name="converter_convert">変換</string>
+    <string name="converter_saved">保存完了</string>
+    <string name="converter_open_folder">フォルダを開く</string>
+    <string name="converter_convert_another">別のファイルを変換</string>
+    <string name="converter_error_title">変換できませんでした</string>
+    <string name="converter_dismiss">閉じる</string>
+    <string name="converter_save_as_title">名前を付けて保存</string>
+    <string name="converter_save_as_body">ファイル名を設定し、タイトルタグにも記録されます。</string>
+    <string name="converter_label_name">名前</string>
+    <string name="converter_start">開始</string>
+    <string name="converter_format_sheet_title">変換先形式</string>
+    <string name="converter_heading_common">よく使われる3つの形式</string>
+    <string name="converter_heading_other">その他の形式</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">その他</string>
+    <string name="more_battery_title">バックグラウンドダウンロード</string>
+    <string name="more_battery_body">ダウンロードはバックグラウンドで自律して継続します。一部の端末では節電のために中断されることがあるため、「無制限」に設定してください。</string>
+    <string name="more_downloads">ダウンロード</string>
+    <string name="more_appearance">外観</string>
+    <string name="more_language">言語</string>
+    <string name="more_cookies">Cookie</string>
+    <string name="more_link_reading">リンクの読み込み</string>
+    <string name="more_hazel_instant">Hazel 即時</string>
+    <string name="more_temporary_files">一時ファイル</string>
+    <string name="more_converter">動画から音声へのオフライン変換</string>
+    <string name="more_engine_update">yt-dlp エンジンの更新</string>
+    <string name="more_support">Hazel を支援</string>
+    <string name="more_license">ライセンス</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">戻る</string>
+    <string name="sponsor_title">Hazel を支援</string>
+    <string name="sponsor_hero_title">完全無料、これからもずっと</string>
+    <string name="sponsor_hero_body">Hazelは夜間や週末に開発されており、完全無料で提供されています。サイト側の仕様変更は頻繁に発生し、それに対応し続けることが主な開発作業です。</string>
+    <string name="sponsor_hero_closing">このアプリが役立ったと感じたら、以下の方法で支援していただけると幸いです。費用のかからない支援方法も同様に大きな力になります。</string>
+    <string name="sponsor_section_ways">支援方法</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">毎月または1回限り、いつでもキャンセル可能。GitHubを通じて安全に処理されます。</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">1回限りの支援。アカウント登録は不要です。</string>
+    <string name="sponsor_kofi_soon">近日対応予定</string>
+    <string name="sponsor_section_free">無料でできる支援</string>
+    <string name="sponsor_star_title">プロジェクトにStarをつける</string>
+    <string name="sponsor_star_subtitle">アプリを試す前に多くの人が確認する重要な指標です。</string>
+    <string name="sponsor_share_title">友達に教える</string>
+    <string name="sponsor_share_subtitle">口コミがこのアプリの唯一のプロモーションです。</string>
+    <string name="sponsor_issues_title">問題を報告する</string>
+    <string name="sponsor_issues_subtitle">機能しなくなったサイトの報告は、問題解決のための貴重な情報です。</string>
+    <string name="sponsor_source_title">ソースコードを見る</string>
+    <string name="sponsor_source_subtitle">すべてのコードが公開されており、プルリクエストを歓迎しています。</string>
+    <string name="sponsor_footer">広告なし、ダウンロードデータの追跡なし、機能制限なし。支援の有無は開発時間に関わるものであり、アプリの機能が変わることはありません。</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">yt-dlp の更新</string>
+    <string name="update_back">戻る</string>
+    <string name="update_check_action">更新を確認</string>
+    <string name="update_status_up_to_date">最新の状態です</string>
+    <string name="update_status_checking">更新を確認中...</string>
+    <string name="update_status_available">利用可能な更新があります</string>
+    <string name="update_status_installing">yt-dlp をインストール中...</string>
+    <string name="update_status_installed">エンジンを更新しました</string>
+    <string name="update_status_failed">更新に失敗しました</string>
+    <string name="update_subtitle_idle">Hazel は最新の yt-dlp ビルドを使用しています</string>
+    <string name="update_subtitle_checking">GitHub に接続中...</string>
+    <string name="update_subtitle_available">yt-dlp %1$s が利用可能です</string>
+    <string name="update_subtitle_updating">yt-dlp %1$s をダウンロード中</string>
+    <string name="update_subtitle_installed">yt-dlp %1$s を使用中</string>
+    <string name="update_installed_version">インストール済みバージョン</string>
+    <string name="update_version_unknown">不明</string>
+    <string name="update_new_version">新しいバージョン</string>
+    <string name="update_installing_binary">バイナリをインストール中</string>
+    <string name="update_installing_body">GitHubからダウンロードしてエンジンを置き換えています。アプリを開いたままにしてください。</string>
+    <string name="update_action_update_now">今すぐ更新</string>
+    <string name="update_action_installing">インストール中...</string>
+    <string name="update_action_done">完了</string>
+    <string name="update_action_retry">再試行</string>
+    <string name="update_action_check">更新を確認</string>
+    <string name="update_action_checking">確認中...</string>
+    <string name="update_info_heading">情報</string>
+    <string name="update_info_component">コンポーネント</string>
+    <string name="update_info_repository">リポジトリ</string>
+    <string name="update_info_binary_size">ファイルサイズ</string>
+    <string name="update_info_distribution">配布形式</string>
+    <string name="update_info_github_releases">GitHub Releases</string>
+    <string name="update_release_channel">配信チャンネル</string>
+    <string name="update_view_changelog">更新履歴を見る</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">SponsorBlock フィルタの選択</string>
+    <string name="options_sponsorblock_ok">OK</string>
+    <string name="options_sponsorblock_cancel">キャンセル</string>
+    <string name="options_chapters_title">チャプター</string>
+    <string name="options_chapters_in_videos">動画内にチャプターを含める</string>
+    <string name="options_chapters_split">チャプターごとに分割</string>
+    <string name="options_chapters_split_body">分割すると、1つのファイルではなくチャプターごとに個別のファイルとして保存されます。</string>
+    <string name="options_chapters_dismiss">閉じる</string>
+    <string name="options_subtitles_title">字幕</string>
+    <string name="options_subtitles_embed">字幕を埋め込む</string>
+    <string name="options_subtitles_save">字幕を保存</string>
+    <string name="options_subtitles_save_auto">自動生成字幕を保存</string>
+    <string name="options_subtitles_languages_label">字幕の言語</string>
+    <string name="options_subtitles_dismiss">閉じる</string>
+    <string name="options_subtitles_languages_title">字幕の言語</string>
+    <string name="options_subtitles_languages_hint">yt-dlp の言語指定（例: 英語と元言語なら en.*,.*-orig）。すべての言語なら all を使用します。</string>
+    <string name="options_filename_title">ファイル名テンプレート</string>
+    <string name="options_filename_hint">yt-dlp の出力テンプレート。%(title)s、%(uploader)s、%(id)s、%(ext)s が使用できます。</string>
+    <string name="options_text_input_save">保存</string>
+    <string name="options_text_input_cancel">キャンセル</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">戻る</string>
+    <string name="cleanup_title">一時ファイル</string>
+    <string name="cleanup_header_description">アプリが保持している作業用ファイルです。ダウンロードしたファイルは含まれず、ここから削除されることはありません。</string>
+    <string name="cleanup_action_clear_everything">すべて削除</string>
+    <string name="cleanup_category_link_data_label">リンクデータキャッシュ</string>
+    <string name="cleanup_category_link_data_description">同じリンクを再度開く際の高速化のために保持されているデータです。安全に消去できます。</string>
+    <string name="cleanup_category_partial_downloads_label">未完了のダウンロード</string>
+    <string name="cleanup_category_partial_downloads_description">保存前にキャンセルまたは失敗したダウンロードの残骸ファイルです。</string>
+    <string name="cleanup_category_conversions_label">未完了の変換</string>
+    <string name="cleanup_category_conversions_description">音声変換機能で音楽フォルダに移動されなかった作業ファイルです。</string>
+    <string name="cleanup_category_engine_label">yt-dlp エンジンファイル</string>
+    <string name="cleanup_category_engine_description">ダウンローダーとその実行環境です。消去すると最大の容量が解放されますが、次回ダウンロード時に再展開が必要になります。</string>
+    <string name="cleanup_category_other_cache_label">その他のキャッシュファイル</string>
+    <string name="cleanup_category_other_cache_description">リンク閲覧時にキャッシュされたサムネイルなどです。</string>
+    <string name="cleanup_confirm_category_title">これらの一時ファイルを削除しますか？</string>
+    <string name="cleanup_confirm_category_safe">%1$s が解放されます。保存済みのファイルには影響ありません。</string>
+    <string name="cleanup_confirm_category_unsafe">%1$s が解放されます。次回ダウンロード時に再展開するため時間がかかります。</string>
+    <string name="cleanup_confirm_clear">削除</string>
+    <string name="cleanup_confirm_cancel">キャンセル</string>
+    <string name="cleanup_confirm_all_title">すべて削除しますか？</string>
+    <string name="cleanup_confirm_all_body">%1$s が解放されます。ダウンロードや保存されたログイン情報は保持されますが、エンジンの再展開のため次回ダウンロードに時間がかかります。</string>
+    <string name="cleanup_confirm_all_confirm">すべて削除</string>
+    <string name="cleanup_confirm_all_cancel">キャンセル</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">ダウンロード</string>
+    <string name="history_layout_grid">大きいサムネイルを表示</string>
+    <string name="history_layout_list">リスト形式で表示</string>
+    <string name="history_search_action">ダウンロードを検索</string>
+    <string name="history_sort_action">並べ替え</string>
+    <string name="history_menu_action">その他</string>
+    <string name="history_menu_clear">履歴を削除</string>
+    <string name="history_search_placeholder">ダウンロードを検索</string>
+    <string name="history_search_clear">検索をクリア</string>
+    <string name="history_empty_initial">まだダウンロードはありません</string>
+    <string name="history_empty_filtered">一致する項目がありません</string>
+    <string name="history_clear_dialog_title">履歴を削除</string>
+    <string name="history_clear_dialog_body">リストが空になります。ダウンロード済みのファイルは削除されません。</string>
+    <string name="history_clear_dialog_confirm">削除</string>
+    <string name="history_clear_dialog_cancel">キャンセル</string>
+    <string name="history_delete_dialog_title">ファイルを削除</string>
+    <string name="history_delete_dialog_body">%1$s を端末から削除します。</string>
+    <string name="history_toast_file_deleted">ファイルを削除しました</string>
+    <string name="history_toast_file_delete_failed">ファイルを削除できませんでした</string>
+    <string name="history_delete_dialog_confirm">削除</string>
+    <string name="history_delete_dialog_cancel">キャンセル</string>
+    <string name="history_card_options">オプション</string>
+    <string name="history_card_properties">プロパティ</string>
+    <string name="history_card_remove">リストから削除</string>
+    <string name="history_card_delete">ファイルを削除</string>
+    <string name="history_tag_deleted">削除済み</string>
+    <string name="history_row_options">オプション</string>
+    <string name="history_row_properties">プロパティ</string>
+    <string name="history_row_remove">リストから削除</string>
+    <string name="history_row_delete">ファイルを削除</string>
+    <string name="history_toast_file_gone">このファイルは端末上に見つかりません</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">プロパティ</string>
+    <string name="properties_status">状態</string>
+    <string name="properties_status_present">端末上に存在</string>
+    <string name="properties_status_deleted">端末から削除済み</string>
+    <string name="properties_kind">種類</string>
+    <string name="properties_kind_video">動画</string>
+    <string name="properties_kind_audio">音声</string>
+    <string name="properties_quality">品質</string>
+    <string name="properties_resolution">解像度</string>
+    <string name="properties_length">長さ</string>
+    <string name="properties_codec">コーデック</string>
+    <string name="properties_bitrate">ビットレート</string>
+    <string name="properties_bitrate_value">%1$d kbps</string>
+    <string name="properties_size">サイズ</string>
+    <string name="properties_container">コンテナ</string>
+    <string name="properties_type">タイプ</string>
+    <string name="properties_embedded">埋め込み</string>
+    <string name="properties_file">ファイル</string>
+    <string name="properties_saved_to">保存先</string>
+    <string name="properties_downloaded">ダウンロード日時</string>
+    <string name="properties_source">ソース</string>
+    <string name="properties_link_copied_opened">リンクをコピーして開きました</string>
+    <string name="properties_link_copied">リンクをコピーしました</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">戻る</string>
+    <string name="cookies_title">Cookie</string>
+    <string name="cookies_menu">その他</string>
+    <string name="cookies_menu_import">クリップボードからインポート</string>
+    <string name="cookies_menu_export">クリップボードにエクスポート</string>
+    <string name="cookies_menu_delete_all">すべて削除</string>
+    <string name="cookies_imported_title">インポートされたCookie</string>
+    <string name="cookies_toast_imported">Cookieをインポートしました</string>
+    <string name="cookies_toast_no_data">クリップボードにCookieデータがありません</string>
+    <string name="cookies_toast_nothing_to_export">エクスポートするデータがありません</string>
+    <string name="cookies_toast_exported">クリップボードにコピーしました</string>
+    <string name="cookies_toast_entry_copied">クリップボードにコピーしました</string>
+    <string name="cookies_use_title">Cookieを使用</string>
+    <string name="cookies_use_description">保存されたログイン情報をダウンローダーに渡す</string>
+    <string name="cookies_new">新しいCookie</string>
+    <string name="cookies_empty_title">保存されたCookieはありません</string>
+    <string name="cookies_empty_body">年齢制限付き、非公開、またはメンバー限定のコンテンツをダウンロードするには追加してください。</string>
+    <string name="cookies_delete_title">Cookieを削除</string>
+    <string name="cookies_delete_body">%1$s の保存済みログイン情報を削除しますか？</string>
+    <string name="cookies_delete_confirm">削除</string>
+    <string name="cookies_delete_cancel">キャンセル</string>
+    <string name="cookies_delete_all_title">すべてのCookieを削除</string>
+    <string name="cookies_delete_all_body">保存されたすべてのログイン情報が削除されます。この操作は元に戻せません。</string>
+    <string name="cookies_delete_all_confirm">すべて削除</string>
+    <string name="cookies_delete_all_cancel">キャンセル</string>
+    <string name="cookies_row_fallback_name">Cookie</string>
+    <string name="cookies_sheet_title">Cookie</string>
+    <string name="cookies_sheet_copy">Cookieをコピー</string>
+    <string name="cookies_sheet_delete">Cookieを削除</string>
+    <string name="cookies_field_title">タイトル</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">保存</string>
+    <string name="cookies_sheet_get">Cookieを取得</string>
+    <string name="cookies_sheet_update">更新</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">最高画質</string>
+    <string name="batch_type_sheet_title">優先ダウンロード形式</string>
+    <string name="batch_type_sheet_subtitle">これらのリンクをどの形式でダウンロードするか</string>
+    <string name="batch_type_audio">音声</string>
+    <string name="batch_type_video">動画</string>
+    <string name="batch_format_title">形式</string>
+    <string name="batch_format_subtitle">形式を選択</string>
+    <string name="batch_container_title">コンテナ</string>
+    <string name="batch_container_subtitle">これらのリンクを保存するファイル形式</string>
+    <string name="batch_save_dir_title">保存場所</string>
+    <string name="batch_open_folder">このフォルダを開く</string>
+    <string name="batch_change_folder">フォルダを変更</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">サムネイル</string>
+    <string name="batch_bar_chapters">チャプター</string>
+    <string name="batch_bar_subtitles">字幕</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">ファイル名テンプレート</string>
+    <string name="batch_bar_download_type">優先ダウンロード形式</string>
+    <string name="batch_bar_quality">画質: %1$s</string>
+    <string name="batch_bar_save_location">保存場所</string>
+    <string name="batch_bar_container">コンテナ</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">ダウンロード</string>
+    <string name="batch_header_subtitle">ダウンロードを調整</string>
+    <string name="batch_download_action">ダウンロード</string>
+    <string name="batch_stop_selecting">選択を終了</string>
+    <string name="batch_start_selecting">リンクを選択</string>
+    <string name="batch_list_options">リストのオプション</string>
+    <string name="batch_menu_select_links">リンクを選択</string>
+    <string name="batch_menu_select_all">すべて選択</string>
+    <string name="batch_menu_invert">選択を反転</string>
+    <string name="batch_menu_remove_selected">選択した項目を削除</string>
+    <string name="batch_menu_done">完了</string>
+    <plurals name="batch_selected">
+        <item quantity="other">%d 件選択中</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="other">%d 件のリンク</item>
+    </plurals>
+    <string name="batch_card_download_type">このリンクのダウンロード形式</string>
+    <string name="batch_card_remove">削除</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">このファイルの保存場所は不明です</string>
+    <string name="media_open_chooser">アプリで開く</string>
+    <string name="media_open_no_app">このファイルを開けるアプリがありません</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">ダウンロードがキャンセルされました</string>
+    <string name="notification_channel_progress_description">ダウンロードの進行状況（ステータスバーにアイコン表示）</string>
+    <string name="notification_channel_complete_description">ダウンロード完了通知</string>
+    <string name="notification_action_pause">一時停止</string>
+    <string name="notification_action_resume">再開</string>
+    <string name="notification_action_cancel">キャンセル</string>
+    <string name="notification_action_sign_in">ログイン</string>
+    <string name="notification_wifi_title">Wi-Fi待機中</string>
+    <string name="notification_wifi_text">ダウンロードはWi-Fi接続時のみに設定されています。Wi-Fi接続時に開始されます。</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">閉じる</string>
+    <string name="cookie_webview_desktop_site">PC版サイト</string>
+    <string name="cookie_webview_no_cookies">Cookie は取得されませんでした</string>
+    <string name="cookie_webview_done">"  OK"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">形式を並べ替え</string>
+    <string name="format_selection_change">形式を変更</string>
+    <string name="format_selection_title">形式</string>
+    <string name="format_selection_subtitle">形式を選択</string>
+    <string name="format_selection_confirm">OK</string>
+    <string name="format_selection_loading">残りの形式を読み込み中</string>
+    <string name="format_sort_quality">画質</string>
+    <string name="format_sort_file_size">ファイルサイズ</string>
+    <string name="format_sort_container">コンテナ</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">音声の言語</string>
+    <string name="audio_language_subtitle">音声トラックを選択</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">戻る</string>
+    <string name="appearance_title">外観</string>
+
+    <!-- Language picker -->
+    <string name="language_title">アプリの言語</string>
+    <string name="language_system">システムのデフォルト</string>
+    <string name="language_system_description">端末の設定に従う</string>
+    <string name="language_current">現在: %1$s</string>
+    <string name="language_selected">選択中: %1$s</string>
+    <string name="language_cancel">キャンセル</string>
+    <string name="language_confirm">確認</string>
+    <string name="language_changed_title">言語が変更されました</string>
+    <string name="language_changed_body">Hazel の言語が変更されました。まだ翻訳されていない部分は英語のまま表示されます。</string>
+    <string name="language_changed_ok">OK</string>
+    <string name="appearance_dark_theme">ダークテーマ</string>
+    <string name="appearance_accent_color">アクセントカラー</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">アクセントカラー</string>
+    <string name="accent_picker_close">閉じる</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">戻る</string>
+    <string name="fetch_settings_title">リンクの読み込み</string>
+    <string name="fetch_settings_timeout_description">応答が遅いソースに対して、諦めて再試行するまでの待機時間です。</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="other">タイムアウト %1$d 秒、試行 %2$d 回</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">リンクの解析</string>
+    <string name="fetch_settings_reading_links_description">リンクの内容をどのリーダーで解析するかを指定します。実際のダウンロードには、ここでの設定にかかわらず常に yt-dlp が使用されます。</string>
+    <string name="fetch_settings_force_ipv4_description">お使いのネットワークでリンクが応答しなくなる場合のみオンにしてください。不安定なIPv6ルーティングを回避しますが、それ以外の環境では遅くなります。</string>
+    <string name="fetch_settings_force_ipv4">IPv4 を強制</string>
+    <string name="fetch_mode_fast_label">高速</string>
+    <string name="fetch_mode_fast_description">すぐに諦めます。良好なネットワークでは最速ですが、再試行が必要になる可能性が高くなります。</string>
+    <string name="fetch_mode_balanced_label">標準</string>
+    <string name="fetch_mode_balanced_description">速度と接続の安定性とのバランスをとった設定です。</string>
+    <string name="fetch_mode_thorough_label">慎重</string>
+    <string name="fetch_mode_thorough_description">長く待機し、再試行回数を増やします。時間はかかりますが、不安定な通信環境でも成功しやすくなります。</string>
+    <string name="listing_source_ytdlp_description">ダウンロードを行うエンジンと同じものです。サポートされているすべてのサイトで動作し、自動更新されるため、サイトの変更にも継続して対応できます。</string>
+    <string name="listing_source_newpipe_label">内蔵リーダーを優先</string>
+    <string name="listing_source_newpipe_description">エンジンを起動せずに1回のリクエストでプレイリストやチャンネルを取得するため、対応サイトでは高速です。その他のサイトや読み込めない場合は yt-dlp にフォールバックします。</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">戻る</string>
+    <string name="tools_title">ツール</string>
+    <string name="tools_empty">ここにはまだ何もありません。</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">戻る</string>
+    <string name="direct_share_save_as">保存形式</string>
+    <string name="direct_share_video">動画</string>
+    <string name="direct_share_audio_only">音声のみ</string>
+    <string name="direct_share_title">Hazel 即時</string>
+    <string name="direct_share_intro">Hazel 即時にリンクを共有すると、確認画面やダイアログなしですぐにダウンロードが開始されます。以下の設定が使用されます。</string>
+    <string name="direct_share_video_description">映像と音声を1つのファイルに結合します。</string>
+    <string name="direct_share_audio_description">音声のみを、ソースが提供する最高音質で保存します。</string>
+    <string name="direct_share_quality_title">画質の上限</string>
+    <string name="direct_share_quality_description">固定サイズではなく上限です。すべてのソースが同じ解像度を提供するわけではないため、これ以下の最大のものが選択され、該当するものがない場合は利用可能な最小のものが選択されます。</string>
+    <string name="direct_share_output_title">出力</string>
+    <string name="direct_share_output_description">端末に保存されるファイルです。デフォルトはソースが提供する形式をそのまま保持するため、再エンコード不要で最も高速です。</string>
+    <string name="direct_share_filename_template">ファイル名テンプレート</string>
+    <string name="direct_share_audio_language">音声の言語</string>
+    <string name="direct_share_audio_language_default">ソースのデフォルト</string>
+    <string name="direct_share_extras_title">追加要素</string>
+    <string name="direct_share_extras_description">ソースに存在する場合に適用されます。存在しない要素はエラーにせずスキップされます。</string>
+    <string name="direct_share_cover_art">カバーアート</string>
+    <string name="direct_share_cover_art_description">コンテナが対応している場合、サムネイルをファイル内に埋め込みます。</string>
+    <string name="direct_share_chapters">チャプター</string>
+    <string name="direct_share_subtitles">字幕</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">オフ</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="other">%1$d 個のカテゴリをカット</item>
+    </plurals>
+    <string name="direct_share_signins_title">ログイン情報</string>
+    <string name="direct_share_signins_description">即時共有では、通常ダウンロードと同様に保存済みCookieが使用されます。共有時に確認は表示されないため、ログインが必要なリンクは事前にログイン情報が保存され有効化されている必要があります。</string>
+    <string name="direct_share_cookies">Cookie</string>
+    <string name="direct_share_cookies_on">オン、すべての即時共有で使用</string>
+    <string name="direct_share_cookies_off">オフ</string>
+    <string name="direct_share_change">%1$s を変更</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">戻る</string>
+    <string name="storage_locations_downloads">ダウンロード</string>
+    <string name="storage_locations_title">ダウンロード</string>
+    <string name="storage_locations_subtitle">ダウンロードの保存場所と動作制限</string>
+    <string name="storage_locations_limits">制限</string>
+    <string name="storage_locations_wifi_only_description">モバイルデータ通信を使用せず待機します</string>
+    <string name="storage_locations_speed_limit_description">ダウンロードの最大許容速度</string>
+    <string name="storage_locations_internal_note">すべてのファイルはお使いの端末の内部ストレージに保存されます。ファイルマネージャーアプリからいつでもアクセスできます。</string>
+    <string name="storage_locations_wifi_only">Wi-Fi のみ</string>
+    <string name="storage_locations_speed_limit">速度制限</string>
+
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,580 @@
+<resources>
+    <string name="direct_share_label">Мгновенно</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">Главная</string>
+    <string name="nav_history">Загрузки</string>
+    <string name="nav_more">Ещё</string>
+    <string name="nav_incognito_on">Инкогнито включено, загрузки не сохраняются</string>
+    <string name="nav_incognito_off">Инкогнито выключено</string>
+
+    <!-- DownloadScreen -->
+    <string name="download_search_hint">Поиск или вставка URL</string>
+    <string name="download_clear">Очистить</string>
+    <string name="download_show_large_artwork">Крупные обложки</string>
+    <string name="download_show_list">Показать списком</string>
+    <string name="download_instant_source">Мгновенно · чтение из %1$s</string>
+    <string name="download_incognito_title">Режим инкогнито</string>
+    <string name="download_incognito_body">Загрузки не добавляются в историю, а ссылки не запоминаются. Сами файлы сохраняются как обычно.</string>
+    <string name="download_download_all">Скачать всё</string>
+    <string name="download_saved_aside">Загрузки сохранены. Их можно найти во вкладке «Загрузки».</string>
+    <string name="download_options">Параметры загрузки</string>
+    <string name="download_pause">Пауза</string>
+    <string name="download_resume">Продолжить</string>
+    <string name="download_cancel">Отмена</string>
+    <string name="download_paused">Приостановлено</string>
+    <string name="download_processing">Обработка</string>
+    <string name="download_waiting_wifi">Ожидание Wi-Fi</string>
+    <string name="download_saved">Сохранено</string>
+    <string name="download_queued">В очереди</string>
+    <string name="download_downloaded">Загружено</string>
+    <string name="download_failed">Ошибка</string>
+    <string name="download_remove_link">Удалить ссылку</string>
+    <string name="download_cancel_action">Отменить загрузку</string>
+    <string name="download_resume_action">Возобновить загрузку</string>
+    <plurals name="download_links">
+        <item quantity="one">%d ссылка</item>
+        <item quantity="few">%d ссылки</item>
+        <item quantity="many">%d ссылок</item>
+        <item quantity="other">%d ссылок</item>
+    </plurals>
+
+    <!-- SearchScreen -->
+    <string name="search_hint">Поиск или вставка URL</string>
+    <string name="search_back">Назад</string>
+    <string name="search_more">Ещё</string>
+    <string name="search_add_link">Добавить ещё ссылку</string>
+    <string name="search_clear">Очистить</string>
+    <string name="search_clear_results">Очистить результаты</string>
+    <string name="search_clear_history">Очистить историю поиска</string>
+    <string name="search_empty_history">Здесь появятся использованные ссылки</string>
+    <string name="search_no_matches">Нет подходящих ссылок</string>
+    <string name="search_remove">Удалить</string>
+    <string name="search_all">Искать везде</string>
+    <string name="search_forget">Забыть</string>
+    <string name="search_edit_before">Изменить перед поиском</string>
+    <string name="search_paste_and_fetch">Вставить и загрузить</string>
+    <string name="search_nothing_to_paste">Буфер обмена пуст</string>
+
+    <!-- AlreadyDownloadedDialog -->
+    <string name="already_downloaded_title">Уже загружено</string>
+    <string name="already_downloaded_body">Эта ссылка уже сохранена на этом устройстве.</string>
+    <string name="already_downloaded_video">Видео</string>
+    <string name="already_downloaded_audio">Аудио</string>
+    <string name="already_downloaded_keep">Оставить</string>
+    <string name="already_downloaded_play">Воспроизвести</string>
+    <string name="already_downloaded_download_again">Скачать снова</string>
+    <string name="already_downloaded_just_now">Только что</string>
+    <string name="already_downloaded_yesterday">Вчера</string>
+    <plurals name="already_downloaded_minutes">
+        <item quantity="one">%d мин</item>
+        <item quantity="few">%d мин</item>
+        <item quantity="many">%d мин</item>
+        <item quantity="other">%d мин</item>
+    </plurals>
+    <plurals name="already_downloaded_hours">
+        <item quantity="one">%d ч</item>
+        <item quantity="few">%d ч</item>
+        <item quantity="many">%d ч</item>
+        <item quantity="other">%d ч</item>
+    </plurals>
+    <plurals name="already_downloaded_days">
+        <item quantity="one">%d день</item>
+        <item quantity="few">%d дня</item>
+        <item quantity="many">%d дней</item>
+        <item quantity="other">%d дней</item>
+    </plurals>
+    <plurals name="already_downloaded_months">
+        <item quantity="one">%d мес.</item>
+        <item quantity="few">%d месяца</item>
+        <item quantity="many">%d месяцев</item>
+        <item quantity="other">%d месяцев</item>
+    </plurals>
+
+    <!-- NoResultsDialog -->
+    <string name="no_results_sign_in_title">Требуется вход</string>
+    <string name="no_results_error_title">Не удалось прочитать ссылку</string>
+    <string name="no_results_sign_in_body">Для доступа требуется аккаунт. Вход сохранит файлы cookie сайта и повторит попытку.</string>
+    <string name="no_results_continue_body">Не удалось прочитать сведения, но сама загрузка может сработать. Продолжение загрузит наилучшее доступное качество.</string>
+    <string name="no_results_refused_body">Источник отклонил запрос.</string>
+    <string name="no_results_engine_report">Отчёт движка</string>
+    <string name="no_results_copy_log">Копировать журнал</string>
+    <string name="no_results_sign_in">Войти</string>
+    <string name="no_results_try_anyway">Всё равно попробовать</string>
+    <string name="no_results_close">Закрыть</string>
+
+    <!-- UserGuideDialog -->
+    <string name="guide_title">Начало работы</string>
+    <string name="guide_step_paste_link">Вставьте ссылку в поле поиска, чтобы скачать её. Можно добавлять несколько ссылок и плейлисты</string>
+    <string name="guide_step_pick_format">Нажмите на карточку для выбора точного формата. Все доступные варианты перечислены с размером и кодеком.</string>
+    <string name="guide_step_share_instant">Поделитесь ссылкой в Hazel Мгновенно из любого приложения для быстрой загрузки с заданным качеством.</string>
+    <string name="guide_step_finished_downloads">Готовые файлы появляются в «Загрузках». Нажмите на строку, чтобы открыть файл в проигрывателе по умолчанию.</string>
+    <string name="guide_step_battery_unrestricted">Установите работу от батареи без ограничений, иначе Android может остановить загрузку при выходе из приложения.</string>
+    <string name="guide_battery_settings">Настройки батареи</string>
+    <string name="guide_close">Закрыть</string>
+
+    <!-- FormatSheet -->
+    <string name="format_sheet_title">Загрузка</string>
+    <string name="format_sheet_subtitle">Настроить загрузку</string>
+    <string name="format_sheet_play">Воспроизвести</string>
+    <string name="format_sheet_ok">ОК</string>
+    <string name="format_sheet_download">Скачать</string>
+    <string name="format_sheet_tab_audio">Аудио</string>
+    <string name="format_sheet_tab_video">Видео</string>
+    <string name="format_sheet_label_title">Название</string>
+    <string name="format_sheet_label_author">Автор</string>
+    <string name="format_sheet_label_container">Контейнер</string>
+    <string name="format_sheet_video_quality">Качество видео</string>
+    <string name="format_sheet_audio_quality">Качество аудио</string>
+    <string name="format_sheet_no_video_stream">У этого источника нет отдельного видеопотока.</string>
+    <string name="format_sheet_no_audio_stream">У этого источника нет отдельного аудиопотока.</string>
+    <string name="format_sheet_adjust_video">Настроить видео</string>
+    <string name="format_sheet_adjust_audio">Настроить аудио</string>
+    <string name="format_sheet_thumbnail">Обложка</string>
+    <string name="format_sheet_chapters">Разделы</string>
+    <string name="format_sheet_subtitles">Субтитры</string>
+    <string name="format_sheet_sponsorblock">SponsorBlock</string>
+    <string name="format_sheet_audio_language">Язык аудио</string>
+    <string name="format_sheet_change_audio_language">Сменить язык аудио</string>
+    <string name="format_sheet_filename_template">Шаблон имени файла</string>
+    <string name="format_sheet_change_field">Изменить</string>
+    <string name="format_sheet_save_dir">Папка сохранения</string>
+    <string name="format_sheet_save_location">Место сохранения</string>
+    <string name="format_sheet_save_location_title">Место сохранения</string>
+    <string name="format_sheet_save_location_body">Откройте эту папку в файловом менеджере или выберите другую для сохранения загрузок.</string>
+    <string name="format_sheet_open_folder">Открыть папку</string>
+    <string name="format_sheet_reset">Сбросить</string>
+    <string name="format_sheet_change">Изменить</string>
+
+    <!-- ConverterScreen -->
+    <string name="converter_label_convert_to">Конвертировать в</string>
+    <string name="converter_label_saved_to">Сохранено в</string>
+    <string name="converter_hazel_storage">Хранилище Hazel</string>
+    <string name="converter_storage_warning">Без доступа к памяти файл останется внутри Hazel, и другие приложения не увидят его.</string>
+    <string name="converter_back">Назад</string>
+    <string name="converter_title">Офлайн-конвертер</string>
+    <string name="converter_subtitle">Видео в аудио, всё происходит на устройстве</string>
+    <string name="converter_choose_video">Выберите видеофайл</string>
+    <string name="converter_ready">Готово</string>
+    <string name="converter_choose_video_hint">Любой файл на телефоне или SD-карте</string>
+    <string name="converter_change">Изменить</string>
+    <string name="converter_converting">Конвертация</string>
+    <string name="converter_convert">Конвертировать</string>
+    <string name="converter_saved">Сохранено</string>
+    <string name="converter_open_folder">Открыть папку</string>
+    <string name="converter_convert_another">Конвертировать ещё</string>
+    <string name="converter_error_title">Конвертация не удалась</string>
+    <string name="converter_dismiss">Закрыть</string>
+    <string name="converter_save_as_title">Сохранить как</string>
+    <string name="converter_save_as_body">Задаёт имя файла и записывается в тег заголовка.</string>
+    <string name="converter_label_name">Имя</string>
+    <string name="converter_start">Начать</string>
+    <string name="converter_format_sheet_title">Конвертировать в</string>
+    <string name="converter_heading_common">Три основных формата</string>
+    <string name="converter_heading_other">Все остальные</string>
+
+    <!-- MoreScreen -->
+    <string name="more_title">Ещё</string>
+    <string name="more_battery_title">Фоновые загрузки</string>
+    <string name="more_battery_body">Загрузки продолжаются в фоновом режиме. Некоторые устройства могут прерывать их для экономии батареи. Разрешите работу без ограничений, чтобы избежать этого.</string>
+    <string name="more_downloads">Загрузки</string>
+    <string name="more_appearance">Внешний вид</string>
+    <string name="more_language">Язык</string>
+    <string name="more_cookies">Файлы cookie</string>
+    <string name="more_link_reading">Чтение ссылок</string>
+    <string name="more_hazel_instant">Hazel Мгновенно</string>
+    <string name="more_temporary_files">Временные файлы</string>
+    <string name="more_converter">Офлайн-конвертер видео в аудио</string>
+    <string name="more_engine_update">Обновление движка yt-dlp</string>
+    <string name="more_support">Поддержать Hazel</string>
+    <string name="more_license">Лицензия</string>
+
+    <!-- SponsorScreen -->
+    <string name="sponsor_back">Назад</string>
+    <string name="sponsor_title">Поддержать Hazel</string>
+    <string name="sponsor_hero_title">Бесплатно и навсегда</string>
+    <string name="sponsor_hero_body">Hazel создаётся по вечерам и выходным. Приложение остаётся бесплатным, ведь платный загрузчик только хуже. Сайты постоянно меняются, и адаптация к ним требует времени.</string>
+    <string name="sponsor_hero_closing">Если приложение сэкономило вам время, любая поддержка поможет его развитию. Если нет, бесплатные способы поддержать проект помогут ничуть не меньше.</string>
+    <string name="sponsor_section_ways">Способы поддержки</string>
+    <string name="sponsor_github_title">GitHub Sponsors</string>
+    <string name="sponsor_github_subtitle">Ежемесячно или единоразово, с возможностью отмены в любой момент. Всё обрабатывается через GitHub.</string>
+    <string name="sponsor_kofi_title">Ko-fi</string>
+    <string name="sponsor_kofi_subtitle">Разовый платёж без обязательной регистрации.</string>
+    <string name="sponsor_kofi_soon">Скоро появится</string>
+    <string name="sponsor_section_free">Бесплатно и столь же полезно</string>
+    <string name="sponsor_star_title">Поставить звезду проекту</string>
+    <string name="sponsor_star_subtitle">Главный показатель, на который обращают внимание перед установкой.</string>
+    <string name="sponsor_share_title">Рассказать другим</string>
+    <string name="sponsor_share_subtitle">Рекомендации пользователей — единственный способ распространения приложения.</string>
+    <string name="sponsor_issues_title">Сообщить об ошибке</string>
+    <string name="sponsor_issues_subtitle">Если сайт перестал работать, никто кроме вас не сможет об этом сообщить.</string>
+    <string name="sponsor_source_title">Посмотреть исходный код</string>
+    <string name="sponsor_source_subtitle">Каждая строка кода открыта, а предложения изменений приветствуются.</string>
+    <string name="sponsor_footer">Без рекламы, без сбора данных о загрузках и без ограничений функционала. Поддержка влияет лишь на то, сколько времени уделяется Hazel, но не меняет возможности приложения для вас.</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_title">Обновление yt-dlp</string>
+    <string name="update_back">Назад</string>
+    <string name="update_check_action">Проверить обновления</string>
+    <string name="update_status_up_to_date">Установлена последняя версия</string>
+    <string name="update_status_checking">Проверка обновлений...</string>
+    <string name="update_status_available">Доступно обновление</string>
+    <string name="update_status_installing">Установка yt-dlp...</string>
+    <string name="update_status_installed">Движок обновлён</string>
+    <string name="update_status_failed">Ошибка обновления</string>
+    <string name="update_subtitle_idle">Hazel использует актуальную сборку yt-dlp</string>
+    <string name="update_subtitle_checking">Подключение к GitHub...</string>
+    <string name="update_subtitle_available">Доступна версия yt-dlp %1$s</string>
+    <string name="update_subtitle_updating">Загрузка yt-dlp %1$s</string>
+    <string name="update_subtitle_installed">Используется yt-dlp %1$s</string>
+    <string name="update_installed_version">Установленная версия</string>
+    <string name="update_version_unknown">Неизвестно</string>
+    <string name="update_new_version">Новая версия</string>
+    <string name="update_installing_binary">Установка исполняемого файла</string>
+    <string name="update_installing_body">Загрузка с GitHub и замена движка. Не закрывайте приложение.</string>
+    <string name="update_action_update_now">Обновить сейчас</string>
+    <string name="update_action_installing">Установка...</string>
+    <string name="update_action_done">Готово</string>
+    <string name="update_action_retry">Повторить</string>
+    <string name="update_action_check">Проверить обновления</string>
+    <string name="update_action_checking">Проверка...</string>
+    <string name="update_info_heading">Информация</string>
+    <string name="update_info_component">Компонент</string>
+    <string name="update_info_repository">Репозиторий</string>
+    <string name="update_info_binary_size">Размер файла</string>
+    <string name="update_info_distribution">Дистрибутив</string>
+    <string name="update_info_github_releases">Релизы GitHub</string>
+    <string name="update_release_channel">Канал обновлений</string>
+    <string name="update_view_changelog">Список изменений</string>
+
+    <!-- DownloadOptionDialogs -->
+    <string name="options_sponsorblock_title">Фильтрация SponsorBlock</string>
+    <string name="options_sponsorblock_ok">ОК</string>
+    <string name="options_sponsorblock_cancel">Отмена</string>
+    <string name="options_chapters_title">Разделы</string>
+    <string name="options_chapters_in_videos">Разделы в видео</string>
+    <string name="options_chapters_split">Разделить по разделам</string>
+    <string name="options_chapters_split_body">Разделение сохраняет каждый раздел в отдельный файл вместо одного общего.</string>
+    <string name="options_chapters_dismiss">Закрыть</string>
+    <string name="options_subtitles_title">Субтитры</string>
+    <string name="options_subtitles_embed">Встроить субтитры</string>
+    <string name="options_subtitles_save">Сохранить субтитры</string>
+    <string name="options_subtitles_save_auto">Сохранять автосубтитры</string>
+    <string name="options_subtitles_languages_label">Языки субтитров</string>
+    <string name="options_subtitles_dismiss">Закрыть</string>
+    <string name="options_subtitles_languages_title">Языки субтитров</string>
+    <string name="options_subtitles_languages_hint">Селектор языков yt-dlp, например en.*,.*-orig для английского и оригинальной дорожки. Используйте all для всех доступных языков.</string>
+    <string name="options_filename_title">Шаблон имени файла</string>
+    <string name="options_filename_hint">Шаблон вывода yt-dlp. Используйте %(title)s, %(uploader)s, %(id)s и %(ext)s.</string>
+    <string name="options_text_input_save">Сохранить</string>
+    <string name="options_text_input_cancel">Отмена</string>
+
+    <!-- StorageCleanupScreen -->
+    <string name="cleanup_back">Назад</string>
+    <string name="cleanup_title">Временные файлы</string>
+    <string name="cleanup_header_description">Рабочие файлы приложения. Ваши загрузки не входят сюда и никогда отсюда не удаляются.</string>
+    <string name="cleanup_action_clear_everything">Очистить всё</string>
+    <string name="cleanup_category_link_data_label">Кэш данных о ссылках</string>
+    <string name="cleanup_category_link_data_description">Данные плеера yt-dlp для ускорения повторного чтения ссылок. Можно безопасно очистить.</string>
+    <string name="cleanup_category_partial_downloads_label">Незавершённые загрузки</string>
+    <string name="cleanup_category_partial_downloads_description">Фрагменты отменённых или прерванных загрузок до сохранения файла.</string>
+    <string name="cleanup_category_conversions_label">Незавершённые конвертации</string>
+    <string name="cleanup_category_conversions_description">Рабочие файлы конвертера аудио, которые не были перенесены в папку музыки.</string>
+    <string name="cleanup_category_engine_label">Файлы движка yt-dlp</string>
+    <string name="cleanup_category_engine_description">Загрузчик и среда его выполнения. Очистка освобождает больше всего места, но при следующей загрузке потребуется их распаковка.</string>
+    <string name="cleanup_category_other_cache_label">Прочий кэш</string>
+    <string name="cleanup_category_other_cache_description">Обложки и другие файлы, кэшированные при просмотре ссылок.</string>
+    <string name="cleanup_confirm_category_title">Очистить эти файлы?</string>
+    <string name="cleanup_confirm_category_safe">Будет освобождено %1$s. Сохранённые файлы не будут затронуты.</string>
+    <string name="cleanup_confirm_category_unsafe">Будет освобождено %1$s; следующая загрузка займёт больше времени из-за повторной распаковки.</string>
+    <string name="cleanup_confirm_clear">Очистить</string>
+    <string name="cleanup_confirm_cancel">Отмена</string>
+    <string name="cleanup_confirm_all_title">Очистить всё?</string>
+    <string name="cleanup_confirm_all_body">Будет освобождено %1$s. Загрузки и сохранённые сеансы входа сохранятся, но следующая загрузка займёт больше времени из-за повторной распаковки движка.</string>
+    <string name="cleanup_confirm_all_confirm">Очистить всё</string>
+    <string name="cleanup_confirm_all_cancel">Отмена</string>
+
+    <!-- HistoryScreen -->
+    <string name="history_title">Загрузки</string>
+    <string name="history_layout_grid">Крупные обложки</string>
+    <string name="history_layout_list">Показать списком</string>
+    <string name="history_search_action">Поиск загрузок</string>
+    <string name="history_sort_action">Сортировка</string>
+    <string name="history_menu_action">Ещё</string>
+    <string name="history_menu_clear">Очистить историю</string>
+    <string name="history_search_placeholder">Поиск загрузок</string>
+    <string name="history_search_clear">Очистить поиск</string>
+    <string name="history_empty_initial">Пока ничего не загружено</string>
+    <string name="history_empty_filtered">Ничего не найдено</string>
+    <string name="history_clear_dialog_title">Очистить историю</string>
+    <string name="history_clear_dialog_body">Список будет очищен. Загруженные файлы останутся на месте.</string>
+    <string name="history_clear_dialog_confirm">Очистить</string>
+    <string name="history_clear_dialog_cancel">Отмена</string>
+    <string name="history_delete_dialog_title">Удалить файл</string>
+    <string name="history_delete_dialog_body">Файл %1$s будет удалён с вашего устройства.</string>
+    <string name="history_toast_file_deleted">Файл удалён</string>
+    <string name="history_toast_file_delete_failed">Не удалось удалить файл</string>
+    <string name="history_delete_dialog_confirm">Удалить</string>
+    <string name="history_delete_dialog_cancel">Отмена</string>
+    <string name="history_card_options">Параметры</string>
+    <string name="history_card_properties">Свойства</string>
+    <string name="history_card_remove">Удалить из списка</string>
+    <string name="history_card_delete">Удалить файл</string>
+    <string name="history_tag_deleted">Удалено</string>
+    <string name="history_row_options">Параметры</string>
+    <string name="history_row_properties">Свойства</string>
+    <string name="history_row_remove">Удалить из списка</string>
+    <string name="history_row_delete">Удалить файл</string>
+    <string name="history_toast_file_gone">Этот файл больше не найден на устройстве</string>
+
+    <!-- DownloadPropertiesSheet -->
+    <string name="properties_title">Свойства</string>
+    <string name="properties_status">Статус</string>
+    <string name="properties_status_present">На этом устройстве</string>
+    <string name="properties_status_deleted">Удалено с устройства</string>
+    <string name="properties_kind">Тип</string>
+    <string name="properties_kind_video">Видео</string>
+    <string name="properties_kind_audio">Аудио</string>
+    <string name="properties_quality">Качество</string>
+    <string name="properties_resolution">Разрешение</string>
+    <string name="properties_length">Длительность</string>
+    <string name="properties_codec">Кодек</string>
+    <string name="properties_bitrate">Битрейт</string>
+    <string name="properties_bitrate_value">%1$d кбит/с</string>
+    <string name="properties_size">Размер</string>
+    <string name="properties_container">Контейнер</string>
+    <string name="properties_type">Формат</string>
+    <string name="properties_embedded">Встроено</string>
+    <string name="properties_file">Файл</string>
+    <string name="properties_saved_to">Сохранено в</string>
+    <string name="properties_downloaded">Загружено</string>
+    <string name="properties_source">Источник</string>
+    <string name="properties_link_copied_opened">Ссылка скопирована и открыта</string>
+    <string name="properties_link_copied">Ссылка скопирована</string>
+
+    <!-- CookiesScreen -->
+    <string name="cookies_back">Назад</string>
+    <string name="cookies_title">Файлы cookie</string>
+    <string name="cookies_menu">Ещё</string>
+    <string name="cookies_menu_import">Импортировать из буфера</string>
+    <string name="cookies_menu_export">Экспортировать в буфер</string>
+    <string name="cookies_menu_delete_all">Удалить все</string>
+    <string name="cookies_imported_title">Импортированные cookie</string>
+    <string name="cookies_toast_imported">Cookie импортированы</string>
+    <string name="cookies_toast_no_data">В буфере обмена нет данных cookie</string>
+    <string name="cookies_toast_nothing_to_export">Нечего экспортировать</string>
+    <string name="cookies_toast_exported">Скопировано в буфер обмена</string>
+    <string name="cookies_toast_entry_copied">Скопировано в буфер обмена</string>
+    <string name="cookies_use_title">Использовать cookie</string>
+    <string name="cookies_use_description">Передавать сохранённые данные входа загрузчику</string>
+    <string name="cookies_new">Новые cookie</string>
+    <string name="cookies_empty_title">Нет сохранённых cookie</string>
+    <string name="cookies_empty_body">Добавьте их для загрузки материалов с возрастным ограничением, приватных или доступных только спонсорам.</string>
+    <string name="cookies_delete_title">Удалить cookie</string>
+    <string name="cookies_delete_body">Удалить сохранённые данные входа для %1$s?</string>
+    <string name="cookies_delete_confirm">Удалить</string>
+    <string name="cookies_delete_cancel">Отмена</string>
+    <string name="cookies_delete_all_title">Удалить все cookie</string>
+    <string name="cookies_delete_all_body">Все сохранённые сеансы входа будут удалены. Это действие нельзя отменить.</string>
+    <string name="cookies_delete_all_confirm">Удалить все</string>
+    <string name="cookies_delete_all_cancel">Отмена</string>
+    <string name="cookies_row_fallback_name">Cookie</string>
+    <string name="cookies_sheet_title">Файлы cookie</string>
+    <string name="cookies_sheet_copy">Копировать cookie</string>
+    <string name="cookies_sheet_delete">Удалить cookie</string>
+    <string name="cookies_field_title">Название</string>
+    <string name="cookies_field_url">URL</string>
+    <string name="cookies_sheet_save">Сохранить</string>
+    <string name="cookies_sheet_get">Получить cookie</string>
+    <string name="cookies_sheet_update">Обновить</string>
+
+    <!-- Batch option sheets -->
+    <string name="batch_quality_best">Наилучшее качество</string>
+    <string name="batch_type_sheet_title">Предпочтительный тип загрузки</string>
+    <string name="batch_type_sheet_subtitle">В каком виде сохранять эти ссылки</string>
+    <string name="batch_type_audio">Аудио</string>
+    <string name="batch_type_video">Видео</string>
+    <string name="batch_format_title">Формат</string>
+    <string name="batch_format_subtitle">Выберите формат</string>
+    <string name="batch_container_title">Контейнер</string>
+    <string name="batch_container_subtitle">Формат файла для сохранения ссылок</string>
+    <string name="batch_save_dir_title">Место сохранения</string>
+    <string name="batch_open_folder">Открыть эту папку</string>
+    <string name="batch_change_folder">Сменить папку</string>
+
+    <!-- Batch action bar -->
+    <string name="batch_bar_thumbnail">Обложка</string>
+    <string name="batch_bar_chapters">Разделы</string>
+    <string name="batch_bar_subtitles">Субтитры</string>
+    <string name="batch_bar_sponsorblock">SponsorBlock</string>
+    <string name="batch_bar_filename_template">Шаблон имени файла</string>
+    <string name="batch_bar_download_type">Предпочтительный тип загрузки</string>
+    <string name="batch_bar_quality">Качество: %1$s</string>
+    <string name="batch_bar_save_location">Место сохранения</string>
+    <string name="batch_bar_container">Контейнер</string>
+
+    <!-- Batch download sheet -->
+    <string name="batch_header_title">Загрузка</string>
+    <string name="batch_header_subtitle">Настроить загрузку</string>
+    <string name="batch_download_action">Скачать</string>
+    <string name="batch_stop_selecting">Завершить выбор</string>
+    <string name="batch_start_selecting">Выбрать ссылки</string>
+    <string name="batch_list_options">Параметры списка</string>
+    <string name="batch_menu_select_links">Выбрать ссылки</string>
+    <string name="batch_menu_select_all">Выбрать все</string>
+    <string name="batch_menu_invert">Инвертировать выбор</string>
+    <string name="batch_menu_remove_selected">Удалить выбранные</string>
+    <string name="batch_menu_done">Готово</string>
+    <plurals name="batch_selected">
+        <item quantity="one">%d выбран</item>
+        <item quantity="few">%d выбрано</item>
+        <item quantity="many">%d выбрано</item>
+        <item quantity="other">%d выбрано</item>
+    </plurals>
+    <plurals name="batch_links">
+        <item quantity="one">%d ссылка</item>
+        <item quantity="few">%d ссылки</item>
+        <item quantity="many">%d ссылок</item>
+        <item quantity="other">%d ссылок</item>
+    </plurals>
+    <string name="batch_card_download_type">Тип загрузки для этой ссылки</string>
+    <string name="batch_card_remove">Удалить</string>
+
+    <!-- Opening a finished file -->
+    <string name="media_open_unknown_location">Расположение этого файла неизвестно</string>
+    <string name="media_open_chooser">Открыть с помощью</string>
+    <string name="media_open_no_app">На этом устройстве нет подходящего приложения</string>
+
+    <!-- Download notifications -->
+    <string name="notification_cancelled_text">Загрузка отменена</string>
+    <string name="notification_channel_progress_description">Прогресс загрузки, отображает значок в строке состояния</string>
+    <string name="notification_channel_complete_description">Оповещения о завершении загрузки</string>
+    <string name="notification_action_pause">Пауза</string>
+    <string name="notification_action_resume">Продолжить</string>
+    <string name="notification_action_cancel">Отмена</string>
+    <string name="notification_action_sign_in">Войти</string>
+    <string name="notification_wifi_title">Ожидание Wi-Fi</string>
+    <string name="notification_wifi_text">Загрузки настроены только по Wi-Fi. Они начнутся при подключении к Wi-Fi.</string>
+
+    <!-- Sign-in web view -->
+    <string name="cookie_webview_close">Закрыть</string>
+    <string name="cookie_webview_desktop_site">Версия для ПК</string>
+    <string name="cookie_webview_no_cookies">Файлы cookie не были получены</string>
+    <string name="cookie_webview_done">"  ОК"</string>
+
+    <!-- FormatSelectionSheet -->
+    <string name="format_selection_sort">Сортировка форматов</string>
+    <string name="format_selection_change">Сменить формат</string>
+    <string name="format_selection_title">Формат</string>
+    <string name="format_selection_subtitle">Выберите формат</string>
+    <string name="format_selection_confirm">ОК</string>
+    <string name="format_selection_loading">Чтение остальных форматов</string>
+    <string name="format_sort_quality">Качество</string>
+    <string name="format_sort_file_size">Размер файла</string>
+    <string name="format_sort_container">Контейнер</string>
+
+    <!-- AudioLanguageSheet -->
+    <string name="audio_language_title">Язык аудио</string>
+    <string name="audio_language_subtitle">Выберите звуковую дорожку</string>
+
+    <!-- AppearanceScreen -->
+    <string name="appearance_back">Назад</string>
+    <string name="appearance_title">Внешний вид</string>
+
+    <!-- Language picker -->
+    <string name="language_title">Язык приложения</string>
+    <string name="language_system">Системный по умолчанию</string>
+    <string name="language_system_description">Как на устройстве</string>
+    <string name="language_current">Текущий: %1$s</string>
+    <string name="language_selected">Выбран: %1$s</string>
+    <string name="language_cancel">Отмена</string>
+    <string name="language_confirm">Подтвердить</string>
+    <string name="language_changed_title">Язык изменён</string>
+    <string name="language_changed_body">Язык Hazel изменён. Всё, что ещё не переведено, останется на английском.</string>
+    <string name="language_changed_ok">ОК</string>
+    <string name="appearance_dark_theme">Тёмная тема</string>
+    <string name="appearance_accent_color">Цветовой акцент</string>
+
+    <!-- AccentPickerDialog -->
+    <string name="accent_picker_title">Цветовой акцент</string>
+    <string name="accent_picker_close">Закрыть</string>
+
+    <!-- FetchSettingsScreen -->
+    <string name="fetch_settings_back">Назад</string>
+    <string name="fetch_settings_title">Чтение ссылок</string>
+    <string name="fetch_settings_timeout_description">Сколько ожидать медленный источник перед прекращением и повторной попыткой.</string>
+    <plurals name="fetch_settings_timing">
+        <item quantity="one">тайм-аут %1$d с, %2$d попытка</item>
+        <item quantity="few">тайм-аут %1$d с, %2$d попытки</item>
+        <item quantity="many">тайм-аут %1$d с, %2$d попыток</item>
+        <item quantity="other">тайм-аут %1$d с, %2$d попыток</item>
+    </plurals>
+    <string name="fetch_settings_reading_links">Чтение ссылок</string>
+    <string name="fetch_settings_reading_links_description">Какой модуль определяет содержимое ссылки. Для загрузки всегда используется yt-dlp независимо от выбранного варианта.</string>
+    <string name="fetch_settings_force_ipv4_description">Включайте только при зависании ссылок в вашей сети. Обходит некорректный маршрут IPv6 и замедляет работу во всех остальных сетях.</string>
+    <string name="fetch_settings_force_ipv4">Принудительно IPv4</string>
+    <string name="fetch_mode_fast_label">Быстрый</string>
+    <string name="fetch_mode_fast_description">Быстро завершает попытку. Быстрее всего в стабильной сети, но чаще требует повторной попытки.</string>
+    <string name="fetch_mode_balanced_label">Сбалансированный</string>
+    <string name="fetch_mode_balanced_description">Баланс между скоростью и стабильностью при неидеальном соединении.</string>
+    <string name="fetch_mode_thorough_label">Тщательный</string>
+    <string name="fetch_mode_thorough_description">Дольше ожидает и делает больше попыток. Самый медленный, но справляется со слабым сигналом.</string>
+    <string name="listing_source_ytdlp_description">Тот же движок, что выполняет загрузку. Работает со всеми поддерживаемыми сайтами и обновляется сам, адаптируясь к изменениям сайтов.</string>
+    <string name="listing_source_newpipe_label">Предпочитать встроенный модуль</string>
+    <string name="listing_source_newpipe_description">Получает плейлисты и каналы за один запрос без запуска движка, что быстрее на поддерживаемых сайтах. Для остального и при ошибках переключается на yt-dlp.</string>
+
+    <!-- ToolsScreen -->
+    <string name="tools_back">Назад</string>
+    <string name="tools_title">Инструменты</string>
+    <string name="tools_empty">Здесь пока ничего нет.</string>
+
+    <!-- DirectShareScreen -->
+    <string name="direct_share_back">Назад</string>
+    <string name="direct_share_save_as">Сохранить как</string>
+    <string name="direct_share_video">Видео</string>
+    <string name="direct_share_audio_only">Только аудио</string>
+    <string name="direct_share_title">Hazel Мгновенно</string>
+    <string name="direct_share_intro">Отправка ссылки в Hazel Мгновенно сразу запускает загрузку без диалоговых окон и вопросов. Вот используемые параметры.</string>
+    <string name="direct_share_video_description">Изображение и звук, объединённые в один файл.</string>
+    <string name="direct_share_audio_description">Только аудио наилучшего качества из доступных в источнике.</string>
+    <string name="direct_share_quality_title">Ограничение качества</string>
+    <string name="direct_share_quality_description">Верхний предел, а не точный размер. Не все источники имеют одинаковое разрешение: выбирается максимальное в пределах лимита, либо минимальное из доступных, если ни одно не подошло.</string>
+    <string name="direct_share_output_title">Выходной файл</string>
+    <string name="direct_share_output_description">Файл, который сохраняется на устройстве. По умолчанию сохраняется исходный формат источника — это быстрее всего, так как перекодирование не требуется.</string>
+    <string name="direct_share_filename_template">Шаблон имени файла</string>
+    <string name="direct_share_audio_language">Язык аудио</string>
+    <string name="direct_share_audio_language_default">Как в источнике</string>
+    <string name="direct_share_extras_title">Дополнительно</string>
+    <string name="direct_share_extras_description">Применяются, если они есть у источника. Недоступные элементы просто пропускаются, не вызывая ошибки загрузки.</string>
+    <string name="direct_share_cover_art">Обложка</string>
+    <string name="direct_share_cover_art_description">Записывает обложку в файл, если формат контейнера это поддерживает.</string>
+    <string name="direct_share_chapters">Разделы</string>
+    <string name="direct_share_subtitles">Субтитры</string>
+    <string name="direct_share_sponsorblock">SponsorBlock</string>
+    <string name="direct_share_sponsorblock_off">Выкл.</string>
+    <plurals name="direct_share_sponsorblock_cut">
+        <item quantity="one">вырезана %1$d категория</item>
+        <item quantity="few">вырезано %1$d категории</item>
+        <item quantity="many">вырезано %1$d категорий</item>
+        <item quantity="other">вырезано %1$d категорий</item>
+    </plurals>
+    <string name="direct_share_signins_title">Вход в аккаунт</string>
+    <string name="direct_share_signins_description">Мгновенная отправка использует сохранённые cookie для соответствующего сайта так же, как и загрузка из меню. Запросы при этом не показываются, поэтому загрузка с авторизацией работает, только если вход уже выполнен и включён.</string>
+    <string name="direct_share_cookies">Файлы cookie</string>
+    <string name="direct_share_cookies_on">Вкл., используются для каждой мгновенной загрузки</string>
+    <string name="direct_share_cookies_off">Выкл.</string>
+    <string name="direct_share_change">Изменить %1$s</string>
+
+    <!-- StorageLocationsScreen -->
+    <string name="storage_locations_back">Назад</string>
+    <string name="storage_locations_downloads">Загрузки</string>
+    <string name="storage_locations_title">Загрузки</string>
+    <string name="storage_locations_subtitle">Где сохраняются загрузки и действующие ограничения</string>
+    <string name="storage_locations_limits">Ограничения</string>
+    <string name="storage_locations_wifi_only_description">Загрузки приостанавливаются, чтобы не расходовать мобильные данные</string>
+    <string name="storage_locations_speed_limit_description">Максимально допустимая скорость загрузки</string>
+    <string name="storage_locations_internal_note">Все файлы хранятся во внутренней памяти вашего устройства. Вы можете получить к ним доступ в любое время через любой файловый менеджер.</string>
+    <string name="storage_locations_wifi_only">Только по Wi-Fi</string>
+    <string name="storage_locations_speed_limit">Ограничение скорости</string>
+
+</resources>


### PR DESCRIPTION
## Summary
Add complete translations for three new languages: **Russian** (ru), **Japanese** (ja), and **Indonesian** (in).

## Changes
### Translation Files
- values-ru/strings.xml: Russian (470 keys, CLDR plural categories: one, few, many, other)
- values-ja/strings.xml: Japanese (470 keys, CLDR plural category: other)
- values-in/strings.xml: Indonesian (470 keys, CLDR plural category: other)

### Wiring
- All three languages were already registered in AppLocale.LANGUAGES (the language picker bottomsheet)
- All three locales were already registered in locales_config.xml (Android 13+ per-app language settings)

## Validation
- check.py translations: PASS for all 9 language files
- check.py resources: PASS (no duplicate keys, no orphan keys, no dangling references)
- gradlew test: BUILD SUCCESSFUL, all unit tests pass
- Key parity: all 470 translatable keys present in each file, no extras, no non-translatable keys included
- Format specifiers: all %1, %d, etc. match the English source exactly
- Plural categories: match CLDR rules for each language