### PR TITLE
Keep CI artifacts inside the storage quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,17 +194,32 @@ jobs:
             [ "$found" = "1" ] || echo "No APK was produced."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # One APK, not the set.
+      #
+      # The account has 500 MB of artifact storage. A release build produces about 470 MB of
+      # APKs and a debug build about 214 MB, so a single run of either came close to filling
+      # it on its own, and keeping a fortnight of them did fill it: uploads started failing
+      # across every workflow, including a 12 KB test report that had nothing to do with it.
+      #
+      # arm64-v8a is what nearly every device runs and what the README tells people to
+      # install, so it is the one worth having to hand. It is about 68 MB. The rest are a
+      # release concern, and a release attaches all five to the release itself, which is
+      # separate storage and not subject to this quota.
       - name: Upload the APK
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: hazel-${{ steps.target.outputs.variant }}
-          path: app/build/outputs/apk/**/*.apk
-          # A full set of APKs is around 680 MB, so a fortnight of them is what exhausted
-          # the account's artifact storage and started failing unrelated uploads. These are
-          # for trying a branch out before it merges, which happens within days if it
-          # happens at all, and a release keeps its own copies on the release itself.
+          # A debug build is not split by architecture, so it produces one universal APK and
+          # this pattern matches it. A release build is split, and this takes the arm64 one.
+          path: |
+            app/build/outputs/apk/**/*arm64-v8a*.apk
+            app/build/outputs/apk/**/*universal*.apk
           retention-days: 3
-          if-no-files-found: error
+          # Whether the build worked is decided by Assemble, and what it produced is listed
+          # in the job summary either way. Not having room to store a copy is not a reason
+          # to call a build broken, which is what this step did for two days.
+          if-no-files-found: warn
 
       - name: Delete the keystore
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,10 +156,15 @@ jobs:
             echo "task=assembleRelease" >> "$GITHUB_OUTPUT"
             echo "variant=release" >> "$GITHUB_OUTPUT"
             echo "split=true" >> "$GITHUB_OUTPUT"
+            # Split, so five APKs exist and only one is worth keeping. The universal build
+            # is 206 MB of the 470 and is the one thing that must not be picked up here.
+            echo "glob=app/build/outputs/apk/**/*arm64-v8a*.apk" >> "$GITHUB_OUTPUT"
           else
             echo "task=assembleDebug" >> "$GITHUB_OUTPUT"
             echo "variant=debug" >> "$GITHUB_OUTPUT"
             echo "split=false" >> "$GITHUB_OUTPUT"
+            # Not split, so there is one APK and this is it.
+            echo "glob=app/build/outputs/apk/**/*.apk" >> "$GITHUB_OUTPUT"
           fi
 
       # Only reachable on a push to main, so a pull request from a fork never sees these.
@@ -210,11 +215,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hazel-${{ steps.target.outputs.variant }}
-          # A debug build is not split by architecture, so it produces one universal APK and
-          # this pattern matches it. A release build is split, and this takes the arm64 one.
-          path: |
-            app/build/outputs/apk/**/*arm64-v8a*.apk
-            app/build/outputs/apk/**/*universal*.apk
+          path: ${{ steps.target.outputs.glob }}
           retention-days: 3
           # Whether the build worked is decided by Assemble, and what it produced is listed
           # in the job summary either way. Not having room to store a copy is not a reason


### PR DESCRIPTION
## The failure

`Build APK` has been red while `Assemble` passed. The failing step is `Upload the APK`:

```
Failed to CreateArtifact: Artifact storage quota has been hit.
Unable to upload any new artifacts. Usage is recalculated every 6-12 hours.
```

Nothing was wrong with the build. There was no room to store a copy of it.

## Why it filled

The account has 500 MB of Actions artifact storage. Measured from the artifacts that were present:

| Artifact | Count | Size |
| --- | --- | --- |
| `hazel-release` | 16 | 7,500 MB |
| `hazel-debug` | 17 | 3,636 MB |
| `test-report` | 35 | 0.4 MB |
| | | **10.88 GB** |

A release run uploads about 470 MB of APKs and a debug run about 214 MB, so one run of either nearly filled the quota by itself, and holding a fortnight of them exhausted it. Once full, every upload failed, including the 12 KB test report that had nothing to do with it. The 33 APK artifacts have since been deleted, taking stored usage to 0.37 MB, but the quota is recalculated on a 6-12 hour cycle so runs stayed blocked meanwhile.

Retention alone does not fix this. At 470 MB a run, the quota is exceeded again on the next push to main.

## The change

Uploads one APK instead of the set. The path comes from the step that already decides what to build:

| Run | Build | Uploaded | Size |
| --- | --- | --- | --- |
| push to main | `assembleRelease`, split | arm64-v8a only | ~68 MB |
| pull request | `assembleDebug`, not split | the single APK | ~214 MB |

arm64-v8a is what nearly every device runs and what the README tells people to install. The other four architectures are attached to the GitHub Release itself, which is separate storage and not subject to this quota, so nothing that anyone downloads is lost.

The step is also `continue-on-error` with `if-no-files-found: warn`. Whether the build worked is decided by `Assemble`, and `Report what came out` lists what it produced in the job summary either way; not having room to store a copy is not a reason to call a build broken.

