### PR TITLE
Drop the foojay toolchain resolver

### DIFF
--- a/fastlane/com.hazel.android.yml
+++ b/fastlane/com.hazel.android.yml
@@ -27,7 +27,9 @@ License: GPL-3.0-or-later
 AuthorName: SibtainOcn
 SourceCode: https://github.com/SibtainOcn/Hazel
 IssueTracker: https://github.com/SibtainOcn/Hazel/issues
-Changelog: https://github.com/SibtainOcn/Hazel/blob/main/CHANGELOG.md
+# /HEAD rather than /main, which is what fdroid lint asks for: it follows the default branch
+# whatever that branch is later renamed to.
+Changelog: https://github.com/SibtainOcn/Hazel/blob/HEAD/CHANGELOG.md
 
 # The app fetches yt-dlp updates from the GitHub API, which F-Droid classes as depending on
 # a non-free network service. It is a label on the listing, not a reason for rejection.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,9 +11,13 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
-}
+// No foojay-resolver here, deliberately.
+//
+// It comes with the Android Studio template, and it resolves a Java toolchain by fetching a
+// JDK from the Foojay API partway through the build. Nothing in this project asks for a
+// toolchain, so it never did anything but sit there, and F-Droid's build scanner refuses the
+// whole build over its presence: a build that downloads its own compiler from a third party
+// is not one anybody else can reproduce.
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
F-Droid's build scanner refuses the whole build over it:

  ERROR: Found usual suspect 'org.gradle.toolchains.foojay-resolver'
         at settings.gradle.kts

The plugin resolves a Java toolchain by fetching a JDK from the Foojay API during the build, which is not something anyone else can reproduce. Nothing in this project requests a toolchain, so it came from the Android Studio template and has never done anything here.

Also points the recipe's Changelog at /blob/HEAD/ rather than /blob/main/, which is what fdroid lint asks for.