### PR TITLE
Drop the foojay toolchain resolver so F-Droid can build

### DIFF
--- a/fastlane/com.hazel.android.yml
+++ b/fastlane/com.hazel.android.yml
@@ -11,7 +11,9 @@
 #   4. Build it the way the server will:  fdroid build -v -l com.hazel.android
 #   5. Open the merge request
 #
-# The versionName and commit in every Builds entry still point at a tag that has to exist.
+# Every versionName and commit below names v1.0.5, which does not exist yet. v1.0.4 cannot
+# be submitted: it predates the removal of the foojay toolchain resolver, and F-Droid's
+# scanner refuses to build a tree containing it.
 
 # Download is the one that matters, since it is where somebody looking for a downloader
 # actually browses. Multimedia and Internet are the broader shelves the app also belongs on.
@@ -46,61 +48,60 @@ Builds:
   # when none of the architecture builds fit; anything matching a real architecture is
   # offered that smaller file instead.
   #
-  # Set versionName and commit to the tag actually cut before submitting.
-  - versionName: 1.0.4
-    versionCode: 100
-    commit: v1.0.4
+  # There is deliberately no build: running ./gradlew here. F-Droid deletes
+  # gradle-wrapper.jar before building, because a binary blob in the source tree is exactly
+  # what they will not run, and supplies its own Gradle instead. The gradle: field is what
+  # asks for that, and gradleprops is how -P arguments reach it. A recipe that calls
+  # ./gradlew itself fails with "No such file or directory" after compiling nothing.
+  - versionName: 1.0.5
+    versionCode: 200
+    commit: v1.0.5
     subdir: app
     gradle:
       - yes
-    output: app/build/outputs/apk/release/Hazel-v1.0.4-universal-stable.apk
-    build:
-      - sed -i -e '/sdk-location/d' ../local.properties || true
-      - ./gradlew :app:assembleRelease -PVERSION_NAME=1.0.4
+    gradleprops:
+      - VERSION_NAME=1.0.5
+    output: app/build/outputs/apk/release/Hazel-v1.0.5-universal-stable.apk
 
-  - versionName: 1.0.4
-    versionCode: 101
-    commit: v1.0.4
+  - versionName: 1.0.5
+    versionCode: 201
+    commit: v1.0.5
     subdir: app
     gradle:
       - yes
-    output: app/build/outputs/apk/release/Hazel-v1.0.4-armeabi-v7a-stable.apk
-    build:
-      - sed -i -e '/sdk-location/d' ../local.properties || true
-      - ./gradlew :app:assembleRelease -PVERSION_NAME=1.0.4
+    gradleprops:
+      - VERSION_NAME=1.0.5
+    output: app/build/outputs/apk/release/Hazel-v1.0.5-armeabi-v7a-stable.apk
 
-  - versionName: 1.0.4
-    versionCode: 102
-    commit: v1.0.4
+  - versionName: 1.0.5
+    versionCode: 202
+    commit: v1.0.5
     subdir: app
     gradle:
       - yes
-    output: app/build/outputs/apk/release/Hazel-v1.0.4-x86-stable.apk
-    build:
-      - sed -i -e '/sdk-location/d' ../local.properties || true
-      - ./gradlew :app:assembleRelease -PVERSION_NAME=1.0.4
+    gradleprops:
+      - VERSION_NAME=1.0.5
+    output: app/build/outputs/apk/release/Hazel-v1.0.5-x86-stable.apk
 
-  - versionName: 1.0.4
-    versionCode: 103
-    commit: v1.0.4
+  - versionName: 1.0.5
+    versionCode: 203
+    commit: v1.0.5
     subdir: app
     gradle:
       - yes
-    output: app/build/outputs/apk/release/Hazel-v1.0.4-x86_64-stable.apk
-    build:
-      - sed -i -e '/sdk-location/d' ../local.properties || true
-      - ./gradlew :app:assembleRelease -PVERSION_NAME=1.0.4
+    gradleprops:
+      - VERSION_NAME=1.0.5
+    output: app/build/outputs/apk/release/Hazel-v1.0.5-x86_64-stable.apk
 
-  - versionName: 1.0.4
-    versionCode: 104
-    commit: v1.0.4
+  - versionName: 1.0.5
+    versionCode: 204
+    commit: v1.0.5
     subdir: app
     gradle:
       - yes
-    output: app/build/outputs/apk/release/Hazel-v1.0.4-arm64-v8a-stable.apk
-    build:
-      - sed -i -e '/sdk-location/d' ../local.properties || true
-      - ./gradlew :app:assembleRelease -PVERSION_NAME=1.0.4
+    gradleprops:
+      - VERSION_NAME=1.0.5
+    output: app/build/outputs/apk/release/Hazel-v1.0.5-arm64-v8a-stable.apk
 
 # Reproducible builds. F-Droid builds from source, compares the result against the APK you
 # published, and where they match it ships YOUR signed file, so an update from GitHub and an
@@ -113,5 +114,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^v[0-9.]+$
-CurrentVersion: 1.0.4
-CurrentVersionCode: 104
+CurrentVersion: 1.0.5
+CurrentVersionCode: 204


### PR DESCRIPTION
## The finding

Ran Hazel through F-Droid's own tooling (`fdroidserver` 2.4.5, on WSL). The build scanner refuses the whole thing:

```
ERROR: Found usual suspect 'org.gradle.toolchains.foojay-resolver' at settings.gradle.kts
ERROR: Can't build due to 1 error while scanning
```

`foojay-resolver-convention` resolves a Java toolchain by downloading a JDK from the Foojay API partway through the build. F-Droid rejects that on sight, and reasonably: a build that fetches its own compiler from a third party is not one anyone else can reproduce.

**Nothing in this project requests a toolchain.** No `jvmToolchain(...)`, no `JavaLanguageVersion`. Java level is set through `sourceCompatibility` and `jvmTarget`, which the plugin has no part in. It came from the Android Studio template and has never done anything here.

Removed. `:app:compileReleaseKotlin` still configures and builds; after this change the scanner passes and the build proceeds to compiling.

## Also in here

The recipe draft ran `./gradlew` itself from a `build:` command. That cannot work on F-Droid: it **deletes `gradle-wrapper.jar`** before building (seen in the log: `Removing gradle-wrapper.jar at gradle/wrapper/gradle-wrapper.jar`), and the command runs from `app/` where `gradlew` does not exist. It now uses `gradle:` so fdroidserver runs `assembleRelease` with its own Gradle, and `gradleprops` to pass `VERSION_NAME`.

The recipe's `Changelog` also moves from `/blob/main/` to `/blob/HEAD/`, which is what `fdroid lint` asks for. Lint is now clean, exit 0.

## What this means for submission

The recipe targets **v1.0.5**, which does not exist yet. `v1.0.4` cannot be submitted to F-Droid: it predates this fix, so their scanner would reject it. The tag has to be cut after this merges.

`v1.0.4` on GitHub is unaffected and stays as it is. It is a working release, just not one F-Droid can build.

## Verified along the way

- `fdroid lint com.hazel.android` clean
- Categories checked against the real 108-entry `config/categories.yml`; `Download` is a valid category and the best fit
- fdroidserver strips the signing config itself, so the `HAZEL_SIGNING_DIR` unsigned fallback never comes up on their builders
- Gradle 9.5.0 verifies against its official checksum, though fdroidserver 2.4.5 ships no hash for any 9.x and needs one added upstream
