### PR TITLE
Release 1.0.8 without the dependency metadata block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-09-03
+
+### Store
+- Download audio and video from YouTube, Instagram, TikTok, X, Reddit, SoundCloud and a
+  thousand other sites.
+- Queue a playlist or a whole channel, or share a link from any app and start at once.
+- Choose the audio language, cut sponsor segments, embed chapters and subtitles.
+- Background downloads you can pause, resume and cancel, with a Wi-Fi only mode.
+- No accounts and no analytics, and an incognito mode that records nothing.
+
+### Fixed
+- The published APKs no longer carry Gradle's dependency-metadata block inside the APK
+  signing block. AGP adds it by default, F-Droid's scanner rejects any APK that has it, and
+  it describes the machine that built the APK rather than the app.
+
 ## [1.0.7] - 2026-09-03
 
 ### Store

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,9 +152,9 @@ android {
         // The release's own code, with the architecture digits left at zero. This is what
         // the universal APK keeps and what a build with the splits turned off reports;
         // every per-architecture output replaces it further down.
-        versionCode = 400
+        versionCode = 500
 
-        versionName = "1.0.7"
+        versionName = "1.0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -197,6 +197,14 @@ android {
             isUniversalApk = true
         }
     }
+    // F-Droid's scanner rejects APKs that carry the Gradle dependency-metadata block
+    // inside the APK Signing Block. AGP injects it by default; turning it off keeps the
+    // binary APKs clean and reproducible.
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     packaging {
         jniLibs {
             useLegacyPackaging = true

--- a/fastlane/metadata/android/en-US/changelogs/500.txt
+++ b/fastlane/metadata/android/en-US/changelogs/500.txt
@@ -1,0 +1,5 @@
+* Download audio and video from YouTube, Instagram, TikTok, X, Reddit, SoundCloud and a thousand other sites.
+* Queue a playlist or a whole channel, or share a link from any app and start at once.
+* Choose the audio language, cut sponsor segments, embed chapters and subtitles.
+* Background downloads you can pause, resume and cancel, with a Wi-Fi only mode.
+* No accounts and no analytics, and an incognito mode that records nothing.

--- a/fastlane/metadata/android/en-US/changelogs/501.txt
+++ b/fastlane/metadata/android/en-US/changelogs/501.txt
@@ -1,0 +1,5 @@
+* Download audio and video from YouTube, Instagram, TikTok, X, Reddit, SoundCloud and a thousand other sites.
+* Queue a playlist or a whole channel, or share a link from any app and start at once.
+* Choose the audio language, cut sponsor segments, embed chapters and subtitles.
+* Background downloads you can pause, resume and cancel, with a Wi-Fi only mode.
+* No accounts and no analytics, and an incognito mode that records nothing.

--- a/fastlane/metadata/android/en-US/changelogs/502.txt
+++ b/fastlane/metadata/android/en-US/changelogs/502.txt
@@ -1,0 +1,5 @@
+* Download audio and video from YouTube, Instagram, TikTok, X, Reddit, SoundCloud and a thousand other sites.
+* Queue a playlist or a whole channel, or share a link from any app and start at once.
+* Choose the audio language, cut sponsor segments, embed chapters and subtitles.
+* Background downloads you can pause, resume and cancel, with a Wi-Fi only mode.
+* No accounts and no analytics, and an incognito mode that records nothing.

--- a/fastlane/metadata/android/en-US/changelogs/503.txt
+++ b/fastlane/metadata/android/en-US/changelogs/503.txt
@@ -1,0 +1,5 @@
+* Download audio and video from YouTube, Instagram, TikTok, X, Reddit, SoundCloud and a thousand other sites.
+* Queue a playlist or a whole channel, or share a link from any app and start at once.
+* Choose the audio language, cut sponsor segments, embed chapters and subtitles.
+* Background downloads you can pause, resume and cancel, with a Wi-Fi only mode.
+* No accounts and no analytics, and an incognito mode that records nothing.

--- a/fastlane/metadata/android/en-US/changelogs/504.txt
+++ b/fastlane/metadata/android/en-US/changelogs/504.txt
@@ -1,0 +1,5 @@
+* Download audio and video from YouTube, Instagram, TikTok, X, Reddit, SoundCloud and a thousand other sites.
+* Queue a playlist or a whole channel, or share a link from any app and start at once.
+* Choose the audio language, cut sponsor segments, embed chapters and subtitles.
+* Background downloads you can pause, resume and cancel, with a Wi-Fi only mode.
+* No accounts and no analytics, and an incognito mode that records nothing.


### PR DESCRIPTION
Release 1.0.8. The only functional change is that the APKs stop carrying Gradle's dependency-metadata block.

## Why

`fdroid scanner` fails the `check apk` job on every 1.0.7 APK:

```
Problem: found extra signing block 'Dependency metadata'
CRITICAL: Found 1 problems in tmp/binaries/com.hazel.android_400.binary.apk
```

AGP writes that block into the APK signing block by default. It describes the machine that built the APK rather than the app, and it is one more thing that has to match for a rebuild to reproduce.

## Changes

- `dependenciesInfo { includeInApk = false; includeInBundle = false }` in `app/build.gradle.kts`.
- Version bumped to 1.0.8, base version code 500, so the published codes are 500 to 504.
- Store changelogs regenerated for 500 to 504 via `:app:generateFastlaneChangelogs`.
- CHANGELOG.md entry for 1.0.8.

The block is in the bytes already published as 1.0.7, so re-tagging that release would not clear it. A new tag is the only way the F-Droid job sees clean APKs.

## Follow-up outside this repo

The `com.hazel.android.yml` metadata entry needs its five build blocks moved to 1.0.8 / 500-504, and each `binary:` key needs the trailing space `fdroid rewritemeta` insists on. Both are prepared locally and go up with the fdroiddata merge request once `v1.0.8` is released.
